### PR TITLE
fix: repair github actions project not found error by hardcoding user

### DIFF
--- a/.github/workflows/issue-labeler.yml
+++ b/.github/workflows/issue-labeler.yml
@@ -69,24 +69,18 @@ jobs:
         with:
           github-token: ${{ secrets.ISSUE_LABELER }}
           script: |
-            const { owner } = context.repo;
+            const owner = 'cristiangilsanz';
             const issueNodeId = context.payload.issue.node_id;
             const projectNumber = parseInt(process.env.PROJECT_NUMBER);
 
-            const orgResult = await github.graphql(`
-              query($owner: String!, $number: Int!) {
-                organization(login: $owner) { projectV2(number: $number) { id } }
-              }`, { owner, number: projectNumber }
-            ).catch(() => null);
-
-            const userResult = orgResult?.organization?.projectV2?.id ? null : await github.graphql(`
+            const result = await github.graphql(`
               query($owner: String!, $number: Int!) {
                 user(login: $owner) { projectV2(number: $number) { id } }
               }`, { owner, number: projectNumber }
-            ).catch(() => null);
+            ).catch(e => { core.setFailed(`GraphQL error: ${e.message}`); return null; });
 
-            const projectId = orgResult?.organization?.projectV2?.id ?? userResult?.user?.projectV2?.id;
-            if (!projectId) { core.setFailed(`Project #${projectNumber} not found.`); return; }
+            const projectId = result?.user?.projectV2?.id;
+            if (!projectId) { core.setFailed(`Project #${projectNumber} not found for user ${owner}.`); return; }
 
             await github.graphql(`
               mutation($projectId: ID!, $contentId: ID!) {
@@ -101,25 +95,19 @@ jobs:
         with:
           github-token: ${{ secrets.ISSUE_LABELER }}
           script: |
-            const { owner } = context.repo;
+            const owner = 'cristiangilsanz';
             const issueNodeId = context.payload.issue.node_id;
             const projectNumber = parseInt(process.env.PROJECT_NUMBER);
             const today = new Date().toISOString().split('T')[0];
 
-            const orgResult = await github.graphql(`
-              query($owner: String!, $number: Int!) {
-                organization(login: $owner) { projectV2(number: $number) { id fields(first: 20) { nodes { ... on ProjectV2Field { id name } } } } }
-              }`, { owner, number: projectNumber }
-            ).catch(() => null);
-
-            const userResult = orgResult?.organization?.projectV2 ? null : await github.graphql(`
+            const result = await github.graphql(`
               query($owner: String!, $number: Int!) {
                 user(login: $owner) { projectV2(number: $number) { id fields(first: 20) { nodes { ... on ProjectV2Field { id name } } } } }
               }`, { owner, number: projectNumber }
-            ).catch(() => null);
+            ).catch(e => { core.setFailed(`GraphQL error: ${e.message}`); return null; });
 
-            const project = orgResult?.organization?.projectV2 ?? userResult?.user?.projectV2;
-            if (!project) { core.setFailed(`Project #${projectNumber} not found.`); return; }
+            const project = result?.user?.projectV2;
+            if (!project) { core.setFailed(`Project #${projectNumber} not found for user ${owner}.`); return; }
 
             const startField = project.fields.nodes.find(f => f.name === 'Start date');
             if (!startField) { core.setFailed('Start date field not found.'); return; }

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -87,7 +87,8 @@ jobs:
         with:
           github-token: ${{ secrets.ISSUE_LABELER }}
           script: |
-            const { owner, repo } = context.repo;
+            const owner = 'cristiangilsanz';
+            const { repo } = context.repo;
             const body = context.payload.pull_request.body || '';
             const projectNumber = parseInt(process.env.PROJECT_NUMBER);
             const today = new Date().toISOString().split('T')[0];
@@ -98,20 +99,14 @@ jobs:
             const { data: issue } = await github.rest.issues.get({ owner, repo, issue_number: parseInt(issueMatch[1]) }).catch(() => ({ data: null }));
             if (!issue) return;
 
-            const orgResult = await github.graphql(`
-              query($owner: String!, $number: Int!) {
-                organization(login: $owner) { projectV2(number: $number) { id fields(first: 20) { nodes { ... on ProjectV2Field { id name } } } items(first: 100) { nodes { id content { ... on Issue { id } } } } } }
-              }`, { owner, number: projectNumber }
-            ).catch(() => null);
-
-            const userResult = orgResult?.organization?.projectV2 ? null : await github.graphql(`
+            const result = await github.graphql(`
               query($owner: String!, $number: Int!) {
                 user(login: $owner) { projectV2(number: $number) { id fields(first: 20) { nodes { ... on ProjectV2Field { id name } } } items(first: 100) { nodes { id content { ... on Issue { id } } } } } }
               }`, { owner, number: projectNumber }
-            ).catch(() => null);
+            ).catch(e => { core.setFailed(`GraphQL error: ${e.message}`); return null; });
 
-            const project = orgResult?.organization?.projectV2 ?? userResult?.user?.projectV2;
-            if (!project) { core.setFailed(`Project #${projectNumber} not found.`); return; }
+            const project = result?.user?.projectV2;
+            if (!project) { core.setFailed(`Project #${projectNumber} not found for user ${owner}.`); return; }
 
             const endField = project.fields.nodes.find(f => f.name === 'End date');
             if (!endField) { core.setFailed('End date field not found.'); return; }
@@ -124,4 +119,3 @@ jobs:
                 updateProjectV2ItemFieldValue(input: { projectId: $projectId, itemId: $itemId, fieldId: $fieldId, value: { date: $value } }) { projectV2Item { id } }
               }`, { projectId: project.id, itemId: projectItem.id, fieldId: endField.id, value: today }
             );
-


### PR DESCRIPTION
## Summary
<!---Provide a concise overview of the problem addressed and the technical solution implemented.-->
This PR fixes the `Project #1 not found` error in `issue-labeler.yml` and `pr-labeler.yml`.

The dual `organization`/`user` GraphQL fallback was unreliable for personal account projects — the org query silently returns `null` via `.catch(() => null)`, causing the fallback condition to misfire. 

Fixed by hardcoding `owner = 'cristiangilsanz'` and replacing the dual-query pattern with a single direct `user(login:)` query across `Set Project`, `Set Issue Start Date`, and `Set Issue End Date` steps.

## Issue Reference

Closes [QRW-15](https://github.com/cristiangilsanz/qrew/issues/15)

## Checklist
- [x] I confirm that this PR follows the project's established coding standards.
