### PR TITLE
feat: implement auth login endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,6 +67,9 @@ docker-compose.override.yml
 certs/
 secrets/
 
+# Claude Code
+.claude/
+
 # IDE — JetBrains
 *.iml
 *.ipr

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,13 +1,20 @@
 repos:
-  - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.7
-    hooks:
-      - id: ruff
-        args: [--fix, --exit-non-zero-on-fix]
-      - id: ruff-format
-
   - repo: local
     hooks:
+      - id: ruff-lint
+        name: ruff
+        entry: bash -c 'cd api && uv run ruff check --fix --exit-non-zero-on-fix .'
+        language: system
+        pass_filenames: false
+        always_run: true
+
+      - id: ruff-format
+        name: ruff format
+        entry: bash -c 'cd api && uv run ruff format .'
+        language: system
+        pass_filenames: false
+        always_run: true
+
       - id: pyright
         name: pyright
         entry: bash -c 'cd api && uv run pyright'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,6 +8,13 @@ repos:
 
   - repo: local
     hooks:
+      - id: pyright
+        name: pyright
+        entry: bash -c 'cd api && uv run pyright'
+        language: system
+        pass_filenames: false
+        always_run: true
+
       - id: pytest
         name: pytest
         entry: bash -c 'cd api && uv run pytest --cov=src --cov-report=term-missing -v'

--- a/api/src/com/qode/qrew/v1/service/core/security.py
+++ b/api/src/com/qode/qrew/v1/service/core/security.py
@@ -4,6 +4,7 @@ import string
 from datetime import UTC, datetime, timedelta
 
 import httpx
+import jwt
 import structlog
 from passlib.context import CryptContext
 
@@ -70,3 +71,27 @@ def phone_number_otp_expiry() -> datetime:
     return datetime.now(UTC) + timedelta(
         minutes=settings.phone_number_otp_expire_minutes
     )
+
+
+def create_access_token(subject: str) -> str:
+    """Return a signed JWT access token for the given subject."""
+    now = datetime.now(UTC)
+    payload = {
+        "sub": subject,
+        "type": "access",
+        "iat": now,
+        "exp": now + timedelta(minutes=settings.access_token_expire_minutes),
+    }
+    return jwt.encode(payload, settings.secret_key, algorithm="HS256")
+
+
+def create_refresh_token(subject: str) -> str:
+    """Return a signed JWT refresh token for the given subject."""
+    now = datetime.now(UTC)
+    payload = {
+        "sub": subject,
+        "type": "refresh",
+        "iat": now,
+        "exp": now + timedelta(days=settings.refresh_token_expire_days),
+    }
+    return jwt.encode(payload, settings.secret_key, algorithm="HS256")

--- a/api/src/com/qode/qrew/v1/service/repositories/user.py
+++ b/api/src/com/qode/qrew/v1/service/repositories/user.py
@@ -22,6 +22,13 @@ class UserRepository:
         )
         return result.scalar() is not None
 
+    async def get_by_email(self, email: str) -> User | None:
+        """Return the user matching the given email address."""
+        result = await self._session.execute(
+            select(User).where(User.email == email).limit(1)
+        )
+        return result.scalar_one_or_none()
+
     async def get_by_email_verification_token(self, token: str) -> User | None:
         """Return the user matching the given email verification token."""
         result = await self._session.execute(

--- a/api/src/com/qode/qrew/v1/service/routers/auth.py
+++ b/api/src/com/qode/qrew/v1/service/routers/auth.py
@@ -91,7 +91,7 @@ def _domain_error(
     "/register",
     response_model=RegisterResponse,
     status_code=status.HTTP_201_CREATED,
-    summary="Create a new user account",
+    summary="Register a new user account",
 )
 @limiter.limit("5/hour")  # type: ignore[misc]
 async def register(
@@ -155,7 +155,7 @@ async def verify_phone(
     "/login",
     response_model=LoginResponse,
     status_code=status.HTTP_200_OK,
-    summary="Authenticate and receive access and refresh tokens",
+    summary="Log in a registered user",
 )
 @limiter.limit("10/minute")  # type: ignore[misc]
 async def login(
@@ -163,7 +163,7 @@ async def login(
     body: LoginRequest,
     service: LoginService = Depends(get_login_service),
 ) -> LoginResponse:
-    """Authenticate with email and password."""
+    """Log in as a registered user."""
     try:
         return await service.login(body)
     except LoginError as exc:

--- a/api/src/com/qode/qrew/v1/service/routers/auth.py
+++ b/api/src/com/qode/qrew/v1/service/routers/auth.py
@@ -10,12 +10,15 @@ from com.qode.qrew.v1.service.core.database import get_db
 from com.qode.qrew.v1.service.core.limiter import limiter
 from com.qode.qrew.v1.service.repositories.user import UserRepository
 from com.qode.qrew.v1.service.schemas.auth import (
+    LoginRequest,
+    LoginResponse,
     RegisterRequest,
     RegisterResponse,
     VerifyEmailRequest,
     VerifyPhoneRequest,
     VerifyResponse,
 )
+from com.qode.qrew.v1.service.services.login import LoginError, LoginService
 from com.qode.qrew.v1.service.services.notification import (
     NotificationDispatcher,
     build_notification_dispatcher,
@@ -66,8 +69,15 @@ def get_phone_verification_service(
     return PhoneVerificationService(UserRepository(db))
 
 
+def get_login_service(
+    db: AsyncSession = Depends(get_db),
+) -> LoginService:
+    """Build and return the login service."""
+    return LoginService(UserRepository(db))
+
+
 def _domain_error(
-    exc: RegistrationError | VerificationError | CaptchaError,
+    exc: RegistrationError | VerificationError | CaptchaError | LoginError,
     http_status: int,
 ) -> HTTPException:
     """Convert a domain error to an HTTP exception."""
@@ -139,3 +149,22 @@ async def verify_phone(
         return VerifyResponse(message="Phone number verified successfully.")
     except VerificationError as exc:
         raise _domain_error(exc, status.HTTP_400_BAD_REQUEST) from exc
+
+
+@router.post(
+    "/login",
+    response_model=LoginResponse,
+    status_code=status.HTTP_200_OK,
+    summary="Authenticate and receive access and refresh tokens",
+)
+@limiter.limit("10/minute")  # type: ignore[misc]
+async def login(
+    request: Request,
+    body: LoginRequest,
+    service: LoginService = Depends(get_login_service),
+) -> LoginResponse:
+    """Authenticate with email and password."""
+    try:
+        return await service.login(body)
+    except LoginError as exc:
+        raise _domain_error(exc, status.HTTP_401_UNAUTHORIZED) from exc

--- a/api/src/com/qode/qrew/v1/service/routers/auth.py
+++ b/api/src/com/qode/qrew/v1/service/routers/auth.py
@@ -155,7 +155,7 @@ async def verify_phone(
     "/login",
     response_model=LoginResponse,
     status_code=status.HTTP_200_OK,
-    summary="Log in a registered user",
+    summary="Log in as a registered user",
 )
 @limiter.limit("10/minute")  # type: ignore[misc]
 async def login(

--- a/api/src/com/qode/qrew/v1/service/routers/auth.py
+++ b/api/src/com/qode/qrew/v1/service/routers/auth.py
@@ -135,7 +135,7 @@ async def verify_email(
     "/verify-phone",
     response_model=VerifyResponse,
     status_code=status.HTTP_200_OK,
-    summary="Confirm a phone number using the token from the SMS",
+    summary="Confirm a phone number using the OTP from the SMS",
 )
 @limiter.limit("5/hour")  # type: ignore[misc]
 async def verify_phone(

--- a/api/src/com/qode/qrew/v1/service/schemas/auth.py
+++ b/api/src/com/qode/qrew/v1/service/schemas/auth.py
@@ -83,5 +83,16 @@ class VerifyPhoneRequest(BaseModel):
         return v
 
 
+class LoginRequest(BaseModel):
+    email: EmailStr
+    password: str = Field(..., min_length=1)
+
+
+class LoginResponse(BaseModel):
+    access_token: str
+    refresh_token: str
+    token_type: str = "bearer"  # noqa: S105
+
+
 class VerifyResponse(BaseModel):
     message: str

--- a/api/src/com/qode/qrew/v1/service/services/login.py
+++ b/api/src/com/qode/qrew/v1/service/services/login.py
@@ -24,7 +24,7 @@ class LoginService:
         self._repo = repo
 
     async def login(self, request: LoginRequest) -> LoginResponse:
-        """Authenticate a user and return JWT tokens."""
+        """Authenticate a user."""
         user = await self._repo.get_by_email(request.email)
 
         if user is None:

--- a/api/src/com/qode/qrew/v1/service/services/login.py
+++ b/api/src/com/qode/qrew/v1/service/services/login.py
@@ -1,0 +1,69 @@
+import structlog
+
+from com.qode.qrew.v1.service.core.errors import DomainError
+from com.qode.qrew.v1.service.core.security import (
+    create_access_token,
+    create_refresh_token,
+    hash_password,
+    verify_password,
+)
+from com.qode.qrew.v1.service.repositories.user import UserRepository
+from com.qode.qrew.v1.service.schemas.auth import LoginRequest, LoginResponse
+
+logger = structlog.get_logger(__name__)
+
+# Pre-computed hash so that the bcrypt cost is paid even when the user
+# does not exist, preventing timing-based email enumeration.
+_DUMMY_HASH = hash_password("dummy-timing-pad")
+
+
+class LoginError(DomainError):
+    """A business-rule violation raised when a login attempt cannot be completed."""
+
+
+class LoginService:
+    def __init__(self, repo: UserRepository) -> None:
+        self._repo = repo
+
+    async def login(self, request: LoginRequest) -> LoginResponse:
+        """Authenticate a user and return JWT tokens."""
+        user = await self._repo.get_by_email(request.email)
+
+        if user is None:
+            verify_password(request.password, _DUMMY_HASH)
+            await logger.awarning("login_failed", reason="invalid_credentials")
+            raise LoginError("Invalid email or password")
+
+        if not verify_password(request.password, user.hashed_password):
+            await logger.awarning(
+                "login_failed",
+                reason="invalid_credentials",
+                user_id=str(user.id),
+            )
+            raise LoginError("Invalid email or password")
+
+        if not user.email_verified:
+            await logger.awarning(
+                "login_failed",
+                reason="email_not_verified",
+                user_id=str(user.id),
+            )
+            raise LoginError("Please verify your email before logging in")
+
+        if not user.is_active:
+            await logger.awarning(
+                "login_failed",
+                reason="account_deactivated",
+                user_id=str(user.id),
+            )
+            raise LoginError("Account has been deactivated")
+
+        access_token = create_access_token(str(user.id))
+        refresh_token = create_refresh_token(str(user.id))
+
+        await logger.ainfo("user_logged_in", user_id=str(user.id))
+
+        return LoginResponse(
+            access_token=access_token,
+            refresh_token=refresh_token,
+        )

--- a/api/src/com/qode/qrew/v1/service/services/login.py
+++ b/api/src/com/qode/qrew/v1/service/services/login.py
@@ -12,8 +12,6 @@ from com.qode.qrew.v1.service.schemas.auth import LoginRequest, LoginResponse
 
 logger = structlog.get_logger(__name__)
 
-# Pre-computed hash so that the bcrypt cost is paid even when the user
-# does not exist, preventing timing-based email enumeration.
 _DUMMY_HASH = hash_password("dummy-timing-pad")
 
 

--- a/api/src/com/qode/qrew/v1/service/settings.py
+++ b/api/src/com/qode/qrew/v1/service/settings.py
@@ -25,6 +25,7 @@ class Settings(BaseSettings):
     # Auth
     secret_key: str = "sekret"  # noqa: S105
     access_token_expire_minutes: int = 30
+    refresh_token_expire_days: int = 7
     email_verification_token_expire_hours: int = 24
     phone_number_otp_expire_minutes: int = 10
 

--- a/api/tests/v1/auth/login_test.py
+++ b/api/tests/v1/auth/login_test.py
@@ -1,0 +1,142 @@
+"""Tests for POST /v1/auth/login."""
+
+from collections.abc import Iterator
+from unittest.mock import AsyncMock
+
+import pytest
+from httpx import AsyncClient
+
+from com.qode.qrew.v1.service.main import app
+from com.qode.qrew.v1.service.routers.auth import get_login_service
+from com.qode.qrew.v1.service.schemas.auth import LoginResponse
+from com.qode.qrew.v1.service.services.login import LoginError
+
+_VALID_PAYLOAD: dict[str, object] = {
+    "email": "alice@example.com",
+    "password": "Str0ng!P@ssw0rd#2024",
+}
+
+_ENDPOINT = "/v1/auth/login"
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def mock_service() -> AsyncMock:
+    service = AsyncMock()
+    service.login = AsyncMock()
+    return service
+
+
+@pytest.fixture(autouse=True)
+def override_service(mock_service: AsyncMock) -> Iterator[None]:
+    app.dependency_overrides[get_login_service] = lambda: mock_service
+    yield
+    app.dependency_overrides.clear()
+
+
+# ── Happy path ────────────────────────────────────────────────────────────────
+
+
+async def test_login_returns_200_with_tokens(
+    client: AsyncClient, mock_service: AsyncMock
+) -> None:
+    mock_service.login.return_value = LoginResponse(
+        access_token="a.b.c",
+        refresh_token="d.e.f",
+    )
+
+    response = await client.post(_ENDPOINT, json=_VALID_PAYLOAD)
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["access_token"] == "a.b.c"
+    assert body["refresh_token"] == "d.e.f"
+    assert body["token_type"] == "bearer"
+
+
+async def test_login_calls_service_with_correct_args(
+    client: AsyncClient, mock_service: AsyncMock
+) -> None:
+    mock_service.login.return_value = LoginResponse(
+        access_token="a.b.c",
+        refresh_token="d.e.f",
+    )
+
+    await client.post(_ENDPOINT, json=_VALID_PAYLOAD)
+
+    mock_service.login.assert_awaited_once()
+    call_args = mock_service.login.call_args
+    request_body = call_args[0][0]
+    assert request_body.email == "alice@example.com"
+    assert request_body.password == "Str0ng!P@ssw0rd#2024"
+
+
+# ── Input validation (422) ────────────────────────────────────────────────────
+
+
+async def test_rejects_missing_email(client: AsyncClient) -> None:
+    payload = {k: v for k, v in _VALID_PAYLOAD.items() if k != "email"}
+    response = await client.post(_ENDPOINT, json=payload)
+    assert response.status_code == 422
+
+
+async def test_rejects_missing_password(client: AsyncClient) -> None:
+    payload = {k: v for k, v in _VALID_PAYLOAD.items() if k != "password"}
+    response = await client.post(_ENDPOINT, json=payload)
+    assert response.status_code == 422
+
+
+async def test_rejects_invalid_email_format(client: AsyncClient) -> None:
+    response = await client.post(
+        _ENDPOINT, json={**_VALID_PAYLOAD, "email": "not-an-email"}
+    )
+    assert response.status_code == 422
+
+
+async def test_rejects_empty_password(client: AsyncClient) -> None:
+    response = await client.post(_ENDPOINT, json={**_VALID_PAYLOAD, "password": ""})
+    assert response.status_code == 422
+
+
+async def test_rejects_empty_body(client: AsyncClient) -> None:
+    response = await client.post(_ENDPOINT, json={})
+    assert response.status_code == 422
+
+
+# ── Authentication failures (401) ────────────────────────────────────────────
+
+
+async def test_returns_401_on_invalid_credentials(
+    client: AsyncClient, mock_service: AsyncMock
+) -> None:
+    mock_service.login.side_effect = LoginError("Invalid email or password")
+    response = await client.post(_ENDPOINT, json=_VALID_PAYLOAD)
+    assert response.status_code == 401
+
+
+async def test_returns_401_on_unverified_email(
+    client: AsyncClient, mock_service: AsyncMock
+) -> None:
+    mock_service.login.side_effect = LoginError(
+        "Please verify your email before logging in"
+    )
+    response = await client.post(_ENDPOINT, json=_VALID_PAYLOAD)
+    assert response.status_code == 401
+
+
+async def test_returns_401_on_deactivated_account(
+    client: AsyncClient, mock_service: AsyncMock
+) -> None:
+    mock_service.login.side_effect = LoginError("Account has been deactivated")
+    response = await client.post(_ENDPOINT, json=_VALID_PAYLOAD)
+    assert response.status_code == 401
+
+
+async def test_credential_error_has_no_field(
+    client: AsyncClient, mock_service: AsyncMock
+) -> None:
+    mock_service.login.side_effect = LoginError("Invalid email or password")
+    response = await client.post(_ENDPOINT, json=_VALID_PAYLOAD)
+    assert response.json()["detail"]["field"] is None

--- a/justfile
+++ b/justfile
@@ -12,6 +12,12 @@ setup:
     docker compose up postgres redis -d
     uv venv --python 3.12
     cd api && uv sync --all-groups
+    just db-upgrade
+
+# Resume dev environment
+resume:
+    docker compose start postgres redis
+    just db-upgrade
 
 # Tear down dev environment
 shutdown:
@@ -24,6 +30,7 @@ install:
 # Run dev environment
 dev:
     -fuser -k 8000/tcp
+    just db-upgrade
     cd api && uv run dev
 
 # Verify linter


### PR DESCRIPTION
## Summary

Implements the user login flow for the API.

This adds the `POST /v1/auth/login` endpoint that authenticates an existing user by email and password, returning JWT access and refresh tokens.

The access token expires after 30 minutes and the refresh token after 7 days, both signed with HS256.

Login is only allowed after email verification (registration complete). Inactive accounts are also rejected. 

To prevent email enumeration, all credential failures return a generic "Invalid email or password" message with no `field` hint, and a dummy bcrypt hash is verified when the email doesn't exist to keep response times constant.

The endpoint is rate limited to 10 requests/minute per IP.

## Verification

- `login_test.py`

## Issue Reference

Closes [QRW-31](https://github.com/cristiangilsanz/qrew/issues/31)

## Checklist
- [x] I confirm that this PR follows the project's established coding standards.