### PR TITLE
feat: implement resend verification endpoints

### DIFF
--- a/api/src/com/qode/qrew/v1/service/routers/auth.py
+++ b/api/src/com/qode/qrew/v1/service/routers/auth.py
@@ -16,6 +16,9 @@ from com.qode.qrew.v1.service.schemas.auth import (
     RefreshResponse,
     RegisterRequest,
     RegisterResponse,
+    ResendEmailVerificationRequest,
+    ResendPhoneOtpRequest,
+    ResendResponse,
     VerifyEmailRequest,
     VerifyPhoneRequest,
     VerifyResponse,
@@ -29,6 +32,11 @@ from com.qode.qrew.v1.service.services.refresh import RefreshError, RefreshServi
 from com.qode.qrew.v1.service.services.registration import (
     RegistrationError,
     RegistrationService,
+)
+from com.qode.qrew.v1.service.services.resend import (
+    ResendEmailVerificationService,
+    ResendError,
+    ResendPhoneOtpService,
 )
 from com.qode.qrew.v1.service.services.verification import (
     EmailVerificationService,
@@ -86,8 +94,29 @@ def get_refresh_service(
     return RefreshService(UserRepository(db))
 
 
+def get_resend_email_verification_service(
+    db: AsyncSession = Depends(get_db),
+    notifier: NotificationDispatcher = Depends(_get_notification_service),
+) -> ResendEmailVerificationService:
+    """Build and return the resend email verification service."""
+    return ResendEmailVerificationService(UserRepository(db), notifier)
+
+
+def get_resend_phone_otp_service(
+    db: AsyncSession = Depends(get_db),
+    notifier: NotificationDispatcher = Depends(_get_notification_service),
+) -> ResendPhoneOtpService:
+    """Build and return the resend phone OTP service."""
+    return ResendPhoneOtpService(UserRepository(db), notifier)
+
+
 _DomainError = (
-    RegistrationError | VerificationError | CaptchaError | LoginError | RefreshError
+    RegistrationError
+    | VerificationError
+    | CaptchaError
+    | LoginError
+    | RefreshError
+    | ResendError
 )
 
 
@@ -199,3 +228,45 @@ async def refresh(
         return await service.refresh(body)
     except RefreshError as exc:
         raise _domain_error(exc, status.HTTP_401_UNAUTHORIZED) from exc
+
+
+@router.post(
+    "/resend-email-verification",
+    response_model=ResendResponse,
+    status_code=status.HTTP_200_OK,
+    summary="Resend the email verification link",
+)
+@limiter.limit("3/hour")  # type: ignore[misc]
+async def resend_email_verification(
+    request: Request,
+    body: ResendEmailVerificationRequest,
+    service: ResendEmailVerificationService = Depends(
+        get_resend_email_verification_service
+    ),
+) -> ResendResponse:
+    """Send a fresh email verification link to an unverified account."""
+    try:
+        await service.resend(body.email)
+        return ResendResponse(message="Verification link sent. Check your inbox.")
+    except ResendError as exc:
+        raise _domain_error(exc, status.HTTP_400_BAD_REQUEST) from exc
+
+
+@router.post(
+    "/resend-phone-otp",
+    response_model=ResendResponse,
+    status_code=status.HTTP_200_OK,
+    summary="Resend the phone verification OTP",
+)
+@limiter.limit("3/hour")  # type: ignore[misc]
+async def resend_phone_otp(
+    request: Request,
+    body: ResendPhoneOtpRequest,
+    service: ResendPhoneOtpService = Depends(get_resend_phone_otp_service),
+) -> ResendResponse:
+    """Send a fresh OTP to an unverified phone number."""
+    try:
+        await service.resend(body.phone_number)
+        return ResendResponse(message="Verification OTP sent. Check your SMS.")
+    except ResendError as exc:
+        raise _domain_error(exc, status.HTTP_400_BAD_REQUEST) from exc

--- a/api/src/com/qode/qrew/v1/service/schemas/auth.py
+++ b/api/src/com/qode/qrew/v1/service/schemas/auth.py
@@ -105,3 +105,27 @@ class RefreshRequest(BaseModel):
 class RefreshResponse(BaseModel):
     access_token: str
     token_type: str = "bearer"  # noqa: S105
+
+
+class ResendEmailVerificationRequest(BaseModel):
+    email: EmailStr
+
+
+class ResendPhoneOtpRequest(BaseModel):
+    phone_number: str = Field(..., min_length=7, max_length=20)
+
+    @field_validator("phone_number")
+    @classmethod
+    def validate_phone_number(cls, v: str) -> str:
+        """Reject phone numbers that are not valid for their region."""
+        try:
+            parsed = phonenumbers.parse(v, None)
+        except phonenumbers.NumberParseException as exc:
+            raise ValueError("Invalid phone number") from exc
+        if not phonenumbers.is_valid_number(parsed):
+            raise ValueError("Phone number is not valid for its region")
+        return v
+
+
+class ResendResponse(BaseModel):
+    message: str

--- a/api/src/com/qode/qrew/v1/service/services/resend.py
+++ b/api/src/com/qode/qrew/v1/service/services/resend.py
@@ -1,0 +1,81 @@
+import structlog
+
+from com.qode.qrew.v1.service.core.errors import DomainError
+from com.qode.qrew.v1.service.core.security import (
+    email_verification_token_expiry,
+    generate_otp,
+    generate_token,
+    phone_number_otp_expiry,
+)
+from com.qode.qrew.v1.service.repositories.user import UserRepository
+from com.qode.qrew.v1.service.services.notification import NotificationService
+
+logger = structlog.get_logger(__name__)
+
+
+class ResendError(DomainError):
+    """Raised when a verification resend cannot be completed."""
+
+
+class ResendEmailVerificationService:
+    def __init__(self, repo: UserRepository, notifier: NotificationService) -> None:
+        self._repo = repo
+        self._notifier = notifier
+
+    async def resend(self, email: str) -> None:
+        """Generate a fresh email verification token and dispatch the link."""
+        user = await self._repo.get_by_email(email)
+
+        if user is None:
+            await logger.awarning("resend_email_failed", reason="user_not_found")
+            raise ResendError("No account found with that email address", field="email")
+        if user.email_verified:
+            await logger.awarning(
+                "resend_email_failed",
+                reason="already_verified",
+                user_id=str(user.id),
+            )
+            raise ResendError("This email address is already verified", field="email")
+
+        token = generate_token()
+        user.email_verification_token = token
+        user.email_verification_token_expires_at = email_verification_token_expiry()
+        await self._repo.save(user)
+
+        await self._notifier.send_email_verification_link(
+            user.email, user.full_name, token
+        )
+        await logger.ainfo("email_verification_resent", user_id=str(user.id))
+
+
+class ResendPhoneOtpService:
+    def __init__(self, repo: UserRepository, notifier: NotificationService) -> None:
+        self._repo = repo
+        self._notifier = notifier
+
+    async def resend(self, phone_number: str) -> None:
+        """Generate a fresh OTP and dispatch it via SMS."""
+        user = await self._repo.get_by_phone_number(phone_number)
+
+        if user is None:
+            await logger.awarning("resend_otp_failed", reason="user_not_found")
+            raise ResendError(
+                "No account found with that phone number", field="phone_number"
+            )
+        if user.phone_number_verified:
+            await logger.awarning(
+                "resend_otp_failed",
+                reason="already_verified",
+                user_id=str(user.id),
+            )
+            raise ResendError(
+                "This phone number is already verified", field="phone_number"
+            )
+
+        otp = generate_otp()
+        user.phone_number_otp = otp
+        user.phone_number_otp_expires_at = phone_number_otp_expiry()
+        await self._repo.save(user)
+
+        await self._notifier.send_sms_otp(user.phone_number, otp)
+        await logger.ainfo("phone_otp_resent", user_id=str(user.id))

--- a/api/tests/v1/auth/resend_verification_test.py
+++ b/api/tests/v1/auth/resend_verification_test.py
@@ -1,0 +1,177 @@
+"""Tests for POST /v1/auth/resend-email-verification and /v1/auth/resend-phone-otp."""
+
+from collections.abc import Iterator
+from unittest.mock import AsyncMock
+
+import pytest
+from httpx import AsyncClient
+
+from com.qode.qrew.v1.service.main import app
+from com.qode.qrew.v1.service.routers.auth import (
+    get_resend_email_verification_service,
+    get_resend_phone_otp_service,
+)
+from com.qode.qrew.v1.service.services.resend import ResendError
+
+_EMAIL_ENDPOINT = "/v1/auth/resend-email-verification"
+_PHONE_ENDPOINT = "/v1/auth/resend-phone-otp"
+
+_VALID_EMAIL_PAYLOAD: dict[str, object] = {"email": "alice@example.com"}
+_VALID_PHONE_PAYLOAD: dict[str, object] = {"phone_number": "+34612345678"}
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def mock_email_service() -> AsyncMock:
+    service = AsyncMock()
+    service.resend = AsyncMock()
+    return service
+
+
+@pytest.fixture
+def mock_phone_service() -> AsyncMock:
+    service = AsyncMock()
+    service.resend = AsyncMock()
+    return service
+
+
+@pytest.fixture(autouse=True)
+def override_services(
+    mock_email_service: AsyncMock, mock_phone_service: AsyncMock
+) -> Iterator[None]:
+    app.dependency_overrides[get_resend_email_verification_service] = lambda: (
+        mock_email_service
+    )
+    app.dependency_overrides[get_resend_phone_otp_service] = lambda: mock_phone_service
+    yield
+    app.dependency_overrides.clear()
+
+
+# ── resend-email-verification ─────────────────────────────────────────────────
+
+
+async def test_resend_email_returns_200(
+    client: AsyncClient, mock_email_service: AsyncMock
+) -> None:
+    mock_email_service.resend.return_value = None
+
+    response = await client.post(_EMAIL_ENDPOINT, json=_VALID_EMAIL_PAYLOAD)
+
+    assert response.status_code == 200
+    assert "message" in response.json()
+
+
+async def test_resend_email_calls_service_with_email(
+    client: AsyncClient, mock_email_service: AsyncMock
+) -> None:
+    mock_email_service.resend.return_value = None
+
+    await client.post(_EMAIL_ENDPOINT, json=_VALID_EMAIL_PAYLOAD)
+
+    mock_email_service.resend.assert_awaited_once_with("alice@example.com")
+
+
+async def test_resend_email_rejects_missing_email(client: AsyncClient) -> None:
+    response = await client.post(_EMAIL_ENDPOINT, json={})
+    assert response.status_code == 422
+
+
+async def test_resend_email_rejects_invalid_email_format(client: AsyncClient) -> None:
+    response = await client.post(_EMAIL_ENDPOINT, json={"email": "not-an-email"})
+    assert response.status_code == 422
+
+
+async def test_resend_email_returns_400_when_user_not_found(
+    client: AsyncClient, mock_email_service: AsyncMock
+) -> None:
+    mock_email_service.resend.side_effect = ResendError(
+        "No account found with that email address", field="email"
+    )
+    response = await client.post(_EMAIL_ENDPOINT, json=_VALID_EMAIL_PAYLOAD)
+    assert response.status_code == 400
+
+
+async def test_resend_email_returns_400_when_already_verified(
+    client: AsyncClient, mock_email_service: AsyncMock
+) -> None:
+    mock_email_service.resend.side_effect = ResendError(
+        "This email address is already verified", field="email"
+    )
+    response = await client.post(_EMAIL_ENDPOINT, json=_VALID_EMAIL_PAYLOAD)
+    assert response.status_code == 400
+
+
+async def test_resend_email_error_includes_field(
+    client: AsyncClient, mock_email_service: AsyncMock
+) -> None:
+    mock_email_service.resend.side_effect = ResendError(
+        "This email address is already verified", field="email"
+    )
+    response = await client.post(_EMAIL_ENDPOINT, json=_VALID_EMAIL_PAYLOAD)
+    assert response.json()["detail"]["field"] == "email"
+
+
+# ── resend-phone-otp ──────────────────────────────────────────────────────────
+
+
+async def test_resend_phone_returns_200(
+    client: AsyncClient, mock_phone_service: AsyncMock
+) -> None:
+    mock_phone_service.resend.return_value = None
+
+    response = await client.post(_PHONE_ENDPOINT, json=_VALID_PHONE_PAYLOAD)
+
+    assert response.status_code == 200
+    assert "message" in response.json()
+
+
+async def test_resend_phone_calls_service_with_phone_number(
+    client: AsyncClient, mock_phone_service: AsyncMock
+) -> None:
+    mock_phone_service.resend.return_value = None
+
+    await client.post(_PHONE_ENDPOINT, json=_VALID_PHONE_PAYLOAD)
+
+    mock_phone_service.resend.assert_awaited_once_with("+34612345678")
+
+
+async def test_resend_phone_rejects_missing_phone(client: AsyncClient) -> None:
+    response = await client.post(_PHONE_ENDPOINT, json={})
+    assert response.status_code == 422
+
+
+async def test_resend_phone_rejects_invalid_phone_format(client: AsyncClient) -> None:
+    response = await client.post(_PHONE_ENDPOINT, json={"phone_number": "not-a-phone"})
+    assert response.status_code == 422
+
+
+async def test_resend_phone_returns_400_when_user_not_found(
+    client: AsyncClient, mock_phone_service: AsyncMock
+) -> None:
+    mock_phone_service.resend.side_effect = ResendError(
+        "No account found with that phone number", field="phone_number"
+    )
+    response = await client.post(_PHONE_ENDPOINT, json=_VALID_PHONE_PAYLOAD)
+    assert response.status_code == 400
+
+
+async def test_resend_phone_returns_400_when_already_verified(
+    client: AsyncClient, mock_phone_service: AsyncMock
+) -> None:
+    mock_phone_service.resend.side_effect = ResendError(
+        "This phone number is already verified", field="phone_number"
+    )
+    response = await client.post(_PHONE_ENDPOINT, json=_VALID_PHONE_PAYLOAD)
+    assert response.status_code == 400
+
+
+async def test_resend_phone_error_includes_field(
+    client: AsyncClient, mock_phone_service: AsyncMock
+) -> None:
+    mock_phone_service.resend.side_effect = ResendError(
+        "This phone number is already verified", field="phone_number"
+    )
+    response = await client.post(_PHONE_ENDPOINT, json=_VALID_PHONE_PAYLOAD)
+    assert response.json()["detail"]["field"] == "phone_number"

--- a/uv.lock
+++ b/uv.lock
@@ -64,7 +64,7 @@ wheels = [
 
 [[package]]
 name = "api"
-version = "1.0.0"
+version = "1.1.0"
 source = { editable = "api" }
 dependencies = [
     { name = "aiosmtplib" },


### PR DESCRIPTION
## Summary

Adds `POST /auth/resend-email-verification` and `POST /auth/resend-phone-otp` so users whose verification token or OTP expired can request fresh ones rather than being permanently locked out.

Without these endpoints a user who registered but didn't verify within the TTL window (24h email, 10min OTP) could neither log in (email not verified) nor re-verify (token expired) — a permanent dead end.

Both endpoints validate the user exists and is not already verified, generate a fresh token/OTP with a new expiry, persist it, and dispatch the notification via the existing `NotificationDispatcher`. They are rate-limited to `3/hour` to prevent notification spam.

## Verification

- `tests/v1/auth/resend_verification_test.py`

## Issue Reference

Closes [QRW-35](https://github.com/cristiangilsanz/qrew/issues/35)

## Checklist
- [x] I confirm that this PR follows the project's established coding standards.