### PR TITLE
feat: implement logout and refresh token revocation

### DIFF
--- a/api/alembic/versions/3abe87e2c49f_2026_05_08_add_kyc_fields_and_passkey_credentials.py
+++ b/api/alembic/versions/3abe87e2c49f_2026_05_08_add_kyc_fields_and_passkey_credentials.py
@@ -1,4 +1,4 @@
-"""add kyc fields and passkey credentials table
+"""2026_05_08_add_kyc_fields_and_passkey_credentials
 
 Revision ID: 3abe87e2c49f
 Revises: 393549af2f17

--- a/api/alembic/versions/a1b2c3d4e5f6_2026_05_17_add_last_used_at_name_and_cascade_to_passkey_credentials.py
+++ b/api/alembic/versions/a1b2c3d4e5f6_2026_05_17_add_last_used_at_name_and_cascade_to_passkey_credentials.py
@@ -1,4 +1,4 @@
-"""add last_used_at, name, and cascade to passkey_credentials
+"""2026_05_17_add_last_used_at_name_and_cascade_to_passkey_credentials
 
 Revision ID: a1b2c3d4e5f6
 Revises: 3abe87e2c49f

--- a/api/alembic/versions/b2c3d4e5f6a7_2026_05_17_add_is_admin_to_users.py
+++ b/api/alembic/versions/b2c3d4e5f6a7_2026_05_17_add_is_admin_to_users.py
@@ -1,4 +1,4 @@
-"""add is_admin to users
+"""2026_05_17_add_is_admin_to_users
 
 Revision ID: b2c3d4e5f6a7
 Revises: a1b2c3d4e5f6

--- a/api/src/com/qode/qrew/v1/service/core/security.py
+++ b/api/src/com/qode/qrew/v1/service/core/security.py
@@ -1,6 +1,7 @@
 import hashlib
 import secrets
 import string
+import uuid
 from datetime import UTC, datetime, timedelta
 
 import httpx
@@ -105,7 +106,13 @@ def create_refresh_token(subject: str) -> str:
     payload = {
         "sub": subject,
         "type": "refresh",
+        "jti": str(uuid.uuid4()),
         "iat": now,
         "exp": now + timedelta(days=settings.refresh_token_expire_days),
     }
     return jwt.encode(payload, settings.secret_key, algorithm="HS256")
+
+
+def decode_refresh_token(token: str) -> dict[str, object]:
+    """Decode and validate a refresh token; raises jwt errors on failure."""
+    return jwt.decode(token, settings.secret_key, algorithms=["HS256"])  # type: ignore[no-any-return]

--- a/api/src/com/qode/qrew/v1/service/routers/auth.py
+++ b/api/src/com/qode/qrew/v1/service/routers/auth.py
@@ -29,6 +29,8 @@ from com.qode.qrew.v1.service.schemas.auth import (
     KycUploadResponse,
     LoginRequest,
     LoginResponse,
+    LogoutRequest,
+    LogoutResponse,
     PasskeyAuthenticationBeginRequest,
     PasskeyAuthenticationCompleteRequest,
     PasskeyRegistrationCompleteRequest,
@@ -50,6 +52,7 @@ from com.qode.qrew.v1.service.services.complete_setup import (
 )
 from com.qode.qrew.v1.service.services.kyc import KycError, KycService
 from com.qode.qrew.v1.service.services.login import LoginError, LoginService
+from com.qode.qrew.v1.service.services.logout import LogoutError, LogoutService
 from com.qode.qrew.v1.service.services.notification import (
     NotificationDispatcher,
     build_notification_dispatcher,
@@ -116,9 +119,17 @@ def get_login_service(
 
 def get_refresh_service(
     db: AsyncSession = Depends(get_db),
+    redis: Annotated[aioredis.Redis, Depends(get_redis)] = ...,  # type: ignore[type-arg, assignment]
 ) -> RefreshService:
     """Build and return the refresh service."""
-    return RefreshService(UserRepository(db))
+    return RefreshService(UserRepository(db), redis)
+
+
+def get_logout_service(
+    redis: Annotated[aioredis.Redis, Depends(get_redis)] = ...,  # type: ignore[type-arg, assignment]
+) -> LogoutService:
+    """Build and return the logout service."""
+    return LogoutService(redis)
 
 
 def get_resend_email_verification_service(
@@ -166,6 +177,7 @@ _DomainError = (
     | CaptchaError
     | LoginError
     | RefreshError
+    | LogoutError
     | ResendError
     | KycError
     | PasskeyError
@@ -289,6 +301,26 @@ async def refresh(
     try:
         return await service.refresh(body)
     except RefreshError as exc:
+        raise _domain_error(exc, status.HTTP_401_UNAUTHORIZED) from exc
+
+
+@router.post(
+    "/logout",
+    response_model=LogoutResponse,
+    status_code=status.HTTP_200_OK,
+    summary="Log out and invalidate the refresh token",
+)
+@limiter.limit("20/minute")  # type: ignore[misc]
+async def logout(
+    request: Request,
+    body: LogoutRequest,
+    service: LogoutService = Depends(get_logout_service),
+) -> LogoutResponse:
+    """Blacklist the refresh token's JTI so it cannot be reused."""
+    try:
+        await service.logout(body.refresh_token)
+        return LogoutResponse(message="Logged out successfully.")
+    except LogoutError as exc:
         raise _domain_error(exc, status.HTTP_401_UNAUTHORIZED) from exc
 
 

--- a/api/src/com/qode/qrew/v1/service/schemas/auth.py
+++ b/api/src/com/qode/qrew/v1/service/schemas/auth.py
@@ -115,6 +115,14 @@ class RefreshResponse(BaseModel):
     token_type: str = "bearer"  # noqa: S105
 
 
+class LogoutRequest(BaseModel):
+    refresh_token: str = Field(..., min_length=1)
+
+
+class LogoutResponse(BaseModel):
+    message: str
+
+
 class ResendEmailVerificationRequest(BaseModel):
     email: EmailStr
 

--- a/api/src/com/qode/qrew/v1/service/services/logout.py
+++ b/api/src/com/qode/qrew/v1/service/services/logout.py
@@ -1,0 +1,49 @@
+from datetime import UTC, datetime
+
+import redis.asyncio as aioredis
+import structlog
+from jwt import ExpiredSignatureError, InvalidTokenError
+
+from com.qode.qrew.v1.service.core.errors import DomainError
+from com.qode.qrew.v1.service.core.security import decode_refresh_token
+
+logger = structlog.get_logger(__name__)
+
+JTI_BLACKLIST_PREFIX = "blacklist:jti:"
+
+
+class LogoutError(DomainError):
+    """A business-rule violation raised when logout cannot be completed."""
+
+
+class LogoutService:
+    def __init__(self, redis: aioredis.Redis) -> None:  # type: ignore[type-arg]
+        self._redis = redis
+
+    async def logout(self, refresh_token: str) -> None:
+        """Blacklist the refresh token's JTI so it cannot be used again."""
+        try:
+            payload = decode_refresh_token(refresh_token)
+        except ExpiredSignatureError:
+            return
+        except InvalidTokenError as exc:
+            raise LogoutError("Invalid refresh token") from exc
+
+        if payload.get("type") != "refresh":
+            raise LogoutError("Invalid token type")
+
+        jti = payload.get("jti")
+        if not isinstance(jti, str):
+            raise LogoutError("Invalid refresh token")
+
+        exp = payload.get("exp")
+        ttl = (
+            int(exp) - int(datetime.now(UTC).timestamp())
+            if isinstance(exp, (int, float))
+            else 0
+        )
+
+        if ttl > 0:
+            await self._redis.setex(JTI_BLACKLIST_PREFIX + jti, ttl, "1")
+
+        await logger.ainfo("token_revoked", jti=jti)

--- a/api/src/com/qode/qrew/v1/service/services/refresh.py
+++ b/api/src/com/qode/qrew/v1/service/services/refresh.py
@@ -1,6 +1,7 @@
 import uuid
 
 import jwt
+import redis.asyncio as aioredis
 import structlog
 from jwt import ExpiredSignatureError, InvalidTokenError
 
@@ -8,6 +9,7 @@ from com.qode.qrew.v1.service.core.errors import DomainError
 from com.qode.qrew.v1.service.core.security import create_access_token
 from com.qode.qrew.v1.service.repositories.user import UserRepository
 from com.qode.qrew.v1.service.schemas.auth import RefreshRequest, RefreshResponse
+from com.qode.qrew.v1.service.services.logout import JTI_BLACKLIST_PREFIX
 from com.qode.qrew.v1.service.settings import settings
 
 logger = structlog.get_logger(__name__)
@@ -18,8 +20,9 @@ class RefreshError(DomainError):
 
 
 class RefreshService:
-    def __init__(self, repo: UserRepository) -> None:
+    def __init__(self, repo: UserRepository, redis: aioredis.Redis) -> None:  # type: ignore[type-arg]
         self._repo = repo
+        self._redis = redis
 
     async def refresh(self, request: RefreshRequest) -> RefreshResponse:
         """Issue a new access token from a valid refresh token."""
@@ -39,6 +42,12 @@ class RefreshService:
         if payload.get("type") != "refresh":
             await logger.awarning("refresh_failed", reason="wrong_token_type")
             raise RefreshError("Invalid token type")
+
+        jti = payload.get("jti")
+        key = JTI_BLACKLIST_PREFIX + jti if isinstance(jti, str) else None
+        if key and await self._redis.exists(key):
+            await logger.awarning("refresh_failed", reason="token_revoked")
+            raise RefreshError("Refresh token has been revoked")
 
         subject = payload.get("sub")
         if not isinstance(subject, str):

--- a/api/tests/v1/auth/integration/auth_flow_test.py
+++ b/api/tests/v1/auth/integration/auth_flow_test.py
@@ -9,6 +9,7 @@ from httpx import AsyncClient
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from com.qode.qrew.v1.service.core.security import create_refresh_token
 from com.qode.qrew.v1.service.models.passkey import PasskeyCredential
 from com.qode.qrew.v1.service.models.user import KycStatus, User
 
@@ -428,3 +429,38 @@ async def test_passkey_authenticate_complete_without_begin_is_rejected(
         )
     assert response.status_code == 400
     assert "expired" in response.json()["detail"]["message"].lower()
+
+
+# ── Logout ────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.integration
+async def test_logout_invalidates_refresh_token(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Logout → subsequent refresh is rejected with 401."""
+    await _register(client)
+    user = await _fetch_user(db_session)
+    await _verify_email(client, str(user.email_verification_token))
+
+    refresh_token = create_refresh_token(str(user.id))
+
+    r = await client.post("/v1/auth/logout", json={"refresh_token": refresh_token})
+    assert r.status_code == 200
+    assert "logged out" in r.json()["message"].lower()
+
+    r = await client.post("/v1/auth/refresh", json={"refresh_token": refresh_token})
+    assert r.status_code == 401
+    assert "revoked" in r.json()["detail"]["message"].lower()
+
+
+@pytest.mark.integration
+async def test_logout_with_invalid_token_returns_401(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    r = await client.post(
+        "/v1/auth/logout", json={"refresh_token": "not.a.valid.token"}
+    )
+    assert r.status_code == 401

--- a/api/tests/v1/auth/unit/logout_test.py
+++ b/api/tests/v1/auth/unit/logout_test.py
@@ -1,0 +1,89 @@
+"""Tests for POST /v1/auth/logout."""
+
+from collections.abc import Iterator
+from unittest.mock import AsyncMock
+
+import pytest
+from httpx import AsyncClient
+
+from com.qode.qrew.v1.service.main import app
+from com.qode.qrew.v1.service.routers.auth import get_logout_service
+from com.qode.qrew.v1.service.services.logout import LogoutError
+
+_ENDPOINT = "/v1/auth/logout"
+_VALID_PAYLOAD: dict[str, object] = {"refresh_token": "a.valid.refresh.token"}
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def mock_service() -> AsyncMock:
+    service = AsyncMock()
+    service.logout = AsyncMock(return_value=None)
+    return service
+
+
+@pytest.fixture(autouse=True)
+def override_dependencies(mock_service: AsyncMock) -> Iterator[None]:
+    app.dependency_overrides[get_logout_service] = lambda: mock_service
+    yield
+    app.dependency_overrides.clear()
+
+
+# ── Happy path ────────────────────────────────────────────────────────────────
+
+
+async def test_logout_returns_200(client: AsyncClient, mock_service: AsyncMock) -> None:
+    response = await client.post(_ENDPOINT, json=_VALID_PAYLOAD)
+
+    assert response.status_code == 200
+    assert "logged out" in response.json()["message"].lower()
+
+
+async def test_logout_calls_service_with_token(
+    client: AsyncClient, mock_service: AsyncMock
+) -> None:
+    await client.post(_ENDPOINT, json=_VALID_PAYLOAD)
+
+    mock_service.logout.assert_awaited_once_with("a.valid.refresh.token")
+
+
+async def test_expired_token_still_returns_200(
+    client: AsyncClient, mock_service: AsyncMock
+) -> None:
+    """Expired tokens are silently accepted — no error, no blacklist entry."""
+    response = await client.post(_ENDPOINT, json=_VALID_PAYLOAD)
+    assert response.status_code == 200
+
+
+# ── Error cases (401) ─────────────────────────────────────────────────────────
+
+
+async def test_returns_401_on_invalid_token(
+    client: AsyncClient, mock_service: AsyncMock
+) -> None:
+    mock_service.logout.side_effect = LogoutError("Invalid refresh token")
+    response = await client.post(_ENDPOINT, json=_VALID_PAYLOAD)
+    assert response.status_code == 401
+
+
+async def test_returns_401_on_wrong_token_type(
+    client: AsyncClient, mock_service: AsyncMock
+) -> None:
+    mock_service.logout.side_effect = LogoutError("Invalid token type")
+    response = await client.post(_ENDPOINT, json=_VALID_PAYLOAD)
+    assert response.status_code == 401
+
+
+# ── Input validation (422) ────────────────────────────────────────────────────
+
+
+async def test_rejects_missing_refresh_token(client: AsyncClient) -> None:
+    response = await client.post(_ENDPOINT, json={})
+    assert response.status_code == 422
+
+
+async def test_rejects_empty_refresh_token(client: AsyncClient) -> None:
+    response = await client.post(_ENDPOINT, json={"refresh_token": ""})
+    assert response.status_code == 422

--- a/api/tests/v1/auth/unit/refresh_test.py
+++ b/api/tests/v1/auth/unit/refresh_test.py
@@ -115,3 +115,11 @@ async def test_error_has_no_field(client: AsyncClient, mock_service: AsyncMock) 
     mock_service.refresh.side_effect = RefreshError("Invalid refresh token")
     response = await client.post(_ENDPOINT, json=_VALID_PAYLOAD)
     assert response.json()["detail"]["field"] is None
+
+
+async def test_returns_401_on_revoked_token(
+    client: AsyncClient, mock_service: AsyncMock
+) -> None:
+    mock_service.refresh.side_effect = RefreshError("Refresh token has been revoked")
+    response = await client.post(_ENDPOINT, json=_VALID_PAYLOAD)
+    assert response.status_code == 401


### PR DESCRIPTION
## Summary

Adds `POST /v1/auth/logout` to perform server-side session termination. Previously, a stolen refresh token remained valid until expiry. This endpoint immediately invalidates the token using a Redis JTI blacklist.

## Verification

- `tests/v1/auth/unit/logout_test.py` 
- `tests/v1/auth/unit/refresh_test.py`
- `tests/v1/auth/integration/auth_flow_test.py`

## Issue Reference

Closes [QRW-50](https://github.com/cristiangilsanz/qrew/issues/50)

## Checklist
- [x] I confirm that this PR follows the project's established coding standards.