### PR TITLE
feat: implement append-only audit event log with Merkle hash chain

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -217,3 +217,4 @@ ehthumbs_vista.db
 Thumbs.db
 Thumbs.db:encryptable
 
+notes

--- a/api/alembic/versions/c1d2e3f4a5b6_2026_05_20_add_audit_events_table.py
+++ b/api/alembic/versions/c1d2e3f4a5b6_2026_05_20_add_audit_events_table.py
@@ -1,0 +1,78 @@
+"""2026_05_20_add_audit_events_table
+
+Revision ID: c1d2e3f4a5b6
+Revises: b2c3d4e5f6a7
+Create Date: 2026-05-20 00:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision: str = "c1d2e3f4a5b6"
+down_revision: str | None = "b2c3d4e5f6a7"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "audit_events",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("actor_id", sa.UUID(), nullable=True),
+        sa.Column("action", sa.String(length=64), nullable=False),
+        sa.Column("entity_type", sa.String(length=64), nullable=True),
+        sa.Column("entity_id", sa.String(length=255), nullable=True),
+        sa.Column("ip_address", sa.String(length=45), nullable=True),
+        sa.Column("device_fingerprint_hash", sa.String(length=255), nullable=True),
+        sa.Column("user_agent", sa.Text(), nullable=True),
+        sa.Column("payload", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column("prev_hash", sa.LargeBinary(length=32), nullable=True),
+        sa.Column("hash", sa.LargeBinary(length=32), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        op.f("ix_audit_events_action"), "audit_events", ["action"], unique=False
+    )
+    op.create_index(
+        op.f("ix_audit_events_actor_id"), "audit_events", ["actor_id"], unique=False
+    )
+    op.create_index(
+        op.f("ix_audit_events_created_at"),
+        "audit_events",
+        ["created_at"],
+        unique=False,
+    )
+
+    # Enforce append-only at the database level
+    op.execute("""
+        CREATE FUNCTION prevent_audit_modification()
+        RETURNS trigger LANGUAGE plpgsql AS $$
+        BEGIN
+            RAISE EXCEPTION 'audit_events is append-only: UPDATE and DELETE are forbidden';
+        END;
+        $$
+    """)
+    op.execute("""
+        CREATE TRIGGER audit_events_no_modify
+        BEFORE UPDATE OR DELETE ON audit_events
+        FOR EACH ROW EXECUTE FUNCTION prevent_audit_modification()
+    """)
+
+
+def downgrade() -> None:
+    op.execute("DROP TRIGGER IF EXISTS audit_events_no_modify ON audit_events")
+    op.execute("DROP FUNCTION IF EXISTS prevent_audit_modification")
+    op.drop_index(op.f("ix_audit_events_created_at"), table_name="audit_events")
+    op.drop_index(op.f("ix_audit_events_actor_id"), table_name="audit_events")
+    op.drop_index(op.f("ix_audit_events_action"), table_name="audit_events")
+    op.drop_table("audit_events")

--- a/api/http/index.html
+++ b/api/http/index.html
@@ -1,0 +1,760 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<title>Qrew — API Tester</title>
+<style>
+*{box-sizing:border-box;margin:0;padding:0}
+body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;background:#0f172a;color:#e2e8f0;min-height:100vh}
+
+/* ── header ── */
+.header{background:#020617;border-bottom:1px solid #1e293b;padding:12px 24px;display:flex;align-items:center;gap:12px;position:sticky;top:0;z-index:20;flex-wrap:wrap}
+.header h1{font-size:13px;font-weight:700;letter-spacing:1px;color:#f8fafc;flex-shrink:0}
+.header input{background:#0f172a;border:1px solid #334155;color:#94a3b8;padding:5px 10px;border-radius:5px;font-size:12px;font-family:monospace;width:220px}
+.tokens{display:flex;gap:6px;flex-wrap:wrap;margin-left:auto}
+.tok{font-size:10px;font-family:monospace;padding:3px 9px;border-radius:20px;background:#1e293b;color:#475569;display:flex;align-items:center;gap:4px;cursor:default;user-select:none}
+.tok.on{background:#0c2340;color:#38bdf8;cursor:pointer}
+.tok.on:hover{background:#0f2d52}
+.tok.copied{background:#14532d!important;color:#4ade80!important}
+.tok b{color:#64748b;font-size:10px;text-transform:uppercase}
+.tok.on b{color:#7dd3fc}
+.dot{width:5px;height:5px;border-radius:50%;background:#1e293b;flex-shrink:0;border:1px solid #334155}
+.tok.on .dot{background:#4ade80;border-color:#16a34a}
+.btn-clean{background:#450a0a;color:#fca5a5;font-size:11px;padding:5px 11px;border-radius:5px;border:1px solid #7f1d1d;cursor:pointer;font-weight:600;transition:background .15s;flex-shrink:0}
+.btn-clean:hover{background:#7f1d1d}
+.btn-clean:disabled{opacity:.4;cursor:not-allowed}
+
+/* ── layout ── */
+.layout{display:grid;grid-template-columns:1fr 1fr 1fr;grid-template-rows:auto;gap:1px;background:#1e293b;min-height:calc(100vh - 53px)}
+.col{background:#0f172a;display:flex;flex-direction:column}
+
+/* ── column header ── */
+.col-head{padding:14px 16px 10px;border-bottom:1px solid #1e293b;position:sticky;top:53px;background:#0f172a;z-index:10}
+.col-label{font-size:9px;font-weight:700;text-transform:uppercase;letter-spacing:1.5px;color:#475569;margin-bottom:2px}
+.col-title{font-size:13px;font-weight:700;color:#f1f5f9}
+.col-desc{font-size:11px;color:#475569;margin-top:2px}
+
+/* ── cards ── */
+.cards{padding:10px 10px 24px;display:flex;flex-direction:column;gap:8px;flex:1}
+
+/* ── card ── */
+.card{background:#1e293b;border-radius:8px;border:1px solid #334155;overflow:hidden;transition:border-color .2s}
+.card.done{border-color:#166534}
+.card.fail{border-color:#991b1b}
+.card-head{display:flex;align-items:center;gap:10px;padding:10px 12px}
+.num{width:22px;height:22px;border-radius:50%;background:#0f172a;color:#475569;font-size:10px;font-weight:700;display:flex;align-items:center;justify-content:center;flex-shrink:0}
+.card.done .num{background:#14532d;color:#4ade80}
+.card.fail .num{background:#450a0a;color:#f87171}
+.card-info{flex:1;min-width:0}
+.card-title{font-size:12px;font-weight:600;color:#e2e8f0;display:flex;align-items:center;gap:6px;flex-wrap:wrap}
+.method{font-size:9px;font-weight:700;padding:1px 6px;border-radius:3px;font-family:monospace;flex-shrink:0}
+.POST{background:#1d3a8a;color:#93c5fd}
+.GET{background:#14532d;color:#86efac}
+.path{font-family:monospace;font-size:11px;color:#94a3b8;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+.card-desc{font-size:10px;color:#475569;margin-top:2px;line-height:1.4}
+
+/* ── card body ── */
+.card-body{padding:0 12px 12px;display:flex;flex-direction:column;gap:6px}
+.field label{display:block;font-size:9px;font-weight:600;text-transform:uppercase;letter-spacing:.5px;color:#64748b;margin-bottom:2px}
+.field input,.field select{width:100%;padding:6px 9px;border:1px solid #334155;border-radius:5px;font-size:11px;font-family:monospace;background:#0f172a;color:#cbd5e1;transition:border-color .2s,background .2s}
+.field input:focus,.field select:focus{outline:none;border-color:#6366f1;background:#0f172a}
+.field input.flashed{border-color:#22c55e!important;background:#052e16!important}
+.field select option{background:#0f172a}
+.row2{display:grid;grid-template-columns:1fr 1fr;gap:6px}
+.auto-tag{font-size:8px;background:#2e1065;color:#a78bfa;padding:1px 5px;border-radius:3px;font-style:normal;flex-shrink:0}
+.dev-tag{font-size:8px;background:#431407;color:#fb923c;padding:1px 5px;border-radius:3px;font-style:normal;flex-shrink:0}
+
+/* ── buttons ── */
+.btn{padding:7px 16px;border:none;border-radius:5px;font-size:12px;font-weight:600;cursor:pointer;transition:background .15s;align-self:flex-start}
+.btn-primary{background:#4f46e5;color:#fff}
+.btn-primary:hover{background:#4338ca}
+.btn-primary:disabled{background:#312e81;color:#6366f1;cursor:not-allowed}
+.btn-danger{background:#7f1d1d;color:#fca5a5}
+.btn-danger:hover{background:#991b1b}
+
+/* ── info ── */
+.info{font-size:10px;color:#64748b;background:#0f172a;border:1px solid #1e293b;border-radius:5px;padding:7px 9px;line-height:1.5}
+.info code{font-family:monospace;background:#1e293b;padding:1px 4px;border-radius:2px;font-size:9px;color:#94a3b8}
+
+/* ── response ── */
+.res{border-radius:5px;overflow:hidden;display:none;margin-top:2px}
+.res.show{display:block}
+.res-bar{display:flex;align-items:center;gap:8px;padding:5px 10px;background:#020617;font-size:10px;font-family:monospace}
+.res-status{font-weight:700;font-size:12px}
+.res-status.ok{color:#4ade80}
+.res-status.er{color:#f87171}
+.res-path{color:#334155;flex:1;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+.res-ms{color:#1e293b}
+.res-body{background:#020617;color:#cbd5e1;padding:10px;font-family:monospace;font-size:11px;line-height:1.6;white-space:pre-wrap;word-break:break-all;max-height:200px;overflow-y:auto}
+.jk{color:#a78bfa}.js{color:#34d399}.jn{color:#fbbf24}.jb{color:#60a5fa}.jx{color:#475569}
+
+/* ── divider ── */
+.divider{height:1px;background:#1e293b;margin:4px 0}
+
+/* ── toast ── */
+.toast{position:fixed;bottom:20px;left:50%;transform:translateX(-50%) translateY(70px);background:#0f172a;border:1px solid #334155;color:#e2e8f0;padding:9px 18px;border-radius:7px;font-size:12px;font-weight:500;transition:transform .25s ease;z-index:200;pointer-events:none;white-space:nowrap}
+.toast.show{transform:translateX(-50%) translateY(0)}
+.toast.err{border-color:#7f1d1d;color:#fca5a5}
+</style>
+</head>
+<body>
+
+<div class="header">
+  <h1>QREW API</h1>
+  <input id="base" value="http://localhost:8000/v1" />
+  <button class="btn-clean" id="btn-clean" onclick="cleanDb()">⟳ Reset</button>
+  <div class="tokens">
+    <div class="tok" id="tk-setup" onclick="copyTok('setup')" title="Click to copy"><div class="dot"></div><b>setup</b><span id="tv-setup">—</span></div>
+    <div class="tok" id="tk-access" onclick="copyTok('access')" title="Click to copy"><div class="dot"></div><b>access</b><span id="tv-access">—</span></div>
+    <div class="tok" id="tk-refresh" onclick="copyTok('refresh')" title="Click to copy"><div class="dot"></div><b>refresh</b><span id="tv-refresh">—</span></div>
+  </div>
+</div>
+
+<div class="toast" id="toast"></div>
+
+<div class="layout">
+
+  <!-- ══════════════════════════ AUTH ══════════════════════════ -->
+  <div class="col">
+    <div class="col-head">
+      <div class="col-label">Router</div>
+      <div class="col-title">/auth</div>
+    </div>
+    <div class="cards">
+
+      <!-- Register -->
+      <div class="card" id="s-register">
+        <div class="card-head">
+          <div class="num">1</div>
+          <div class="card-info">
+            <div class="card-title"><span class="method POST">POST</span><span class="path">/auth/register</span></div>
+            <div class="card-desc">Create account</div>
+          </div>
+        </div>
+        <div class="card-body">
+          <div class="row2">
+            <div class="field"><label>Full name</label><input id="r-name" value="Ana García" /></div>
+            <div class="field"><label>Email</label><input id="r-email" value="ana@qrew.dev" /></div>
+          </div>
+          <div class="row2">
+            <div class="field"><label>Phone</label><input id="r-phone" value="+34600000001" /></div>
+            <div class="field"><label>Password</label><input id="r-password" type="password" value="Qrew2026!" /></div>
+          </div>
+          <button class="btn btn-primary" onclick="register()">Send</button>
+          <div class="res" id="res-register"></div>
+        </div>
+      </div>
+
+      <!-- Verify email -->
+      <div class="card" id="s-verify-email">
+        <div class="card-head">
+          <div class="num">2</div>
+          <div class="card-info">
+            <div class="card-title"><span class="method POST">POST</span><span class="path">/auth/verify-email</span></div>
+            <div class="card-desc">Confirm email</div>
+          </div>
+        </div>
+        <div class="card-body">
+          <div class="field">
+            <label>Token <em class="auto-tag">auto</em></label>
+            <input id="ve-token" placeholder="auto-filled" />
+          </div>
+          <button class="btn btn-primary" onclick="verifyEmail()">Send</button>
+          <div class="res" id="res-verify-email"></div>
+        </div>
+      </div>
+
+      <!-- Login setup -->
+      <div class="card" id="s-login-setup">
+        <div class="card-head">
+          <div class="num">3</div>
+          <div class="card-info">
+            <div class="card-title"><span class="method POST">POST</span><span class="path">/auth/login</span></div>
+            <div class="card-desc">Login</div>
+          </div>
+        </div>
+        <div class="card-body">
+          <div class="row2">
+            <div class="field"><label>Email</label><input id="ls-email" value="ana@qrew.dev" /></div>
+            <div class="field"><label>Password</label><input id="ls-password" type="password" value="Qrew2026!" /></div>
+          </div>
+          <button class="btn btn-primary" onclick="loginSetup()">Send</button>
+          <div class="res" id="res-login-setup"></div>
+        </div>
+      </div>
+
+      <!-- Verify phone -->
+      <div class="card" id="s-verify-phone">
+        <div class="card-head">
+          <div class="num">4</div>
+          <div class="card-info">
+            <div class="card-title"><span class="method POST">POST</span><span class="path">/auth/verify-phone</span></div>
+            <div class="card-desc">Confirm phone</div>
+          </div>
+        </div>
+        <div class="card-body">
+          <div class="field">
+            <label>OTP <em class="auto-tag">auto</em></label>
+            <input id="vp-otp" placeholder="auto-filled" />
+          </div>
+          <button class="btn btn-primary" onclick="verifyPhone()">Send</button>
+          <div class="res" id="res-verify-phone"></div>
+        </div>
+      </div>
+
+      <!-- KYC -->
+      <div class="card" id="s-kyc">
+        <div class="card-head">
+          <div class="num">5</div>
+          <div class="card-info">
+            <div class="card-title"><span class="method POST">POST</span><span class="path">/auth/kyc/upload</span></div>
+            <div class="card-desc">Upload ID document</div>
+          </div>
+        </div>
+        <div class="card-body">
+          <button class="btn btn-primary" onclick="kycUpload()">Send</button>
+          <div class="res" id="res-kyc"></div>
+        </div>
+      </div>
+
+      <!-- Passkey register -->
+      <div class="card" id="s-passkey">
+        <div class="card-head">
+          <div class="num">6</div>
+          <div class="card-info">
+            <div class="card-title"><span class="method POST">POST</span><span class="path">/auth/passkey/register</span></div>
+            <div class="card-desc">Register a passkey</div>
+          </div>
+        </div>
+        <div class="card-body">
+          <button class="btn btn-primary" onclick="passkeyRegister()">Send</button>
+          <div class="res" id="res-passkey"></div>
+        </div>
+      </div>
+
+      <!-- Complete setup -->
+      <div class="card" id="s-complete-setup">
+        <div class="card-head">
+          <div class="num">7</div>
+          <div class="card-info">
+            <div class="card-title"><span class="method POST">POST</span><span class="path">/auth/complete-setup</span></div>
+            <div class="card-desc">Exchange setup token</div>
+          </div>
+        </div>
+        <div class="card-body">
+          <button class="btn btn-primary" onclick="completeSetup()">Send</button>
+          <div class="res" id="res-complete-setup"></div>
+        </div>
+      </div>
+
+      <div class="divider"></div>
+
+      <!-- Login full -->
+      <div class="card" id="s-login-full">
+        <div class="card-head">
+          <div class="num">→</div>
+          <div class="card-info">
+            <div class="card-title"><span class="method POST">POST</span><span class="path">/auth/login</span></div>
+            <div class="card-desc">Login after setup</div>
+          </div>
+        </div>
+        <div class="card-body">
+          <div class="row2">
+            <div class="field"><label>Email</label><input id="lf-email" value="ana@qrew.dev" /></div>
+            <div class="field"><label>Password</label><input id="lf-password" type="password" value="Qrew2026!" /></div>
+          </div>
+          <button class="btn btn-primary" onclick="loginFull()">Send</button>
+          <div class="res" id="res-login-full"></div>
+        </div>
+      </div>
+
+      <!-- Refresh -->
+      <div class="card" id="s-refresh">
+        <div class="card-head">
+          <div class="num">→</div>
+          <div class="card-info">
+            <div class="card-title"><span class="method POST">POST</span><span class="path">/auth/refresh</span></div>
+            <div class="card-desc">Get new access token</div>
+          </div>
+        </div>
+        <div class="card-body">
+          <div class="field">
+            <label>Refresh token <em class="auto-tag">auto</em></label>
+            <input id="ref-token" placeholder="auto-filled" />
+          </div>
+          <button class="btn btn-primary" onclick="refresh()">Send</button>
+          <div class="res" id="res-refresh"></div>
+        </div>
+      </div>
+
+      <!-- Logout -->
+      <div class="card" id="s-logout">
+        <div class="card-head">
+          <div class="num">→</div>
+          <div class="card-info">
+            <div class="card-title"><span class="method POST">POST</span><span class="path">/auth/logout</span></div>
+            <div class="card-desc">Revoke refresh token</div>
+          </div>
+        </div>
+        <div class="card-body">
+          <div class="field">
+            <label>Refresh token <em class="auto-tag">auto</em></label>
+            <input id="lo-token" placeholder="auto-filled" />
+          </div>
+          <button class="btn btn-danger" onclick="logout()">Send</button>
+          <div class="res" id="res-logout"></div>
+        </div>
+      </div>
+
+      <!-- Passkey auth -->
+      <div class="card" id="s-passkey-auth">
+        <div class="card-head">
+          <div class="num">→</div>
+          <div class="card-info">
+            <div class="card-title"><span class="method POST">POST</span><span class="path">/auth/passkey/authenticate</span></div>
+            <div class="card-desc">Passkey login</div>
+          </div>
+        </div>
+        <div class="card-body">
+          <div class="field"><label>Email</label><input id="pa-email" value="ana@qrew.dev" /></div>
+          <button class="btn btn-primary" onclick="passkeyAuth()">Send</button>
+          <div class="res" id="res-passkey-auth"></div>
+        </div>
+      </div>
+
+    </div>
+  </div>
+
+  <!-- ══════════════════════════ ADMIN ══════════════════════════ -->
+  <div class="col">
+    <div class="col-head">
+      <div class="col-label">Router</div>
+      <div class="col-title">/admin</div>
+    </div>
+    <div class="cards">
+
+      <!-- KYC review -->
+      <div class="card" id="s-kyc-review">
+        <div class="card-head">
+          <div class="num">→</div>
+          <div class="card-info">
+            <div class="card-title"><span class="method POST">POST</span><span class="path">/admin/kyc/{id}/review</span></div>
+            <div class="card-desc">Approve or reject a pending KYC submission</div>
+          </div>
+        </div>
+        <div class="card-body">
+          <div class="field">
+            <label>User ID <em class="auto-tag">auto</em></label>
+            <input id="kr-uid" placeholder="auto-filled" />
+          </div>
+          <div class="row2">
+            <div class="field">
+              <label>Action</label>
+              <select id="kr-action">
+                <option value="approve">approve</option>
+                <option value="reject">reject</option>
+              </select>
+            </div>
+            <div class="field"><label>Reason (reject only)</label><input id="kr-reason" placeholder="optional" /></div>
+          </div>
+          <button class="btn btn-primary" onclick="kycReview()">Send</button>
+          <div class="res" id="res-kyc-review"></div>
+        </div>
+      </div>
+
+      <!-- Audit verify -->
+      <div class="card" id="s-audit">
+        <div class="card-head">
+          <div class="num">→</div>
+          <div class="card-info">
+            <div class="card-title"><span class="method GET">GET</span><span class="path">/admin/audit/verify</span></div>
+            <div class="card-desc">Verify Merkle hash chain integrity</div>
+          </div>
+        </div>
+        <div class="card-body">
+          <div class="info">Uses the current access token automatically.</div>
+          <button class="btn btn-primary" onclick="auditVerify()">Send</button>
+          <div class="res" id="res-audit"></div>
+        </div>
+      </div>
+
+    </div>
+  </div>
+
+  <!-- ══════════════════════════ HEALTH / DEV ══════════════════════════ -->
+  <div class="col">
+    <div class="col-head">
+      <div class="col-label">Router</div>
+      <div class="col-title">/health · /dev</div>
+    </div>
+    <div class="cards">
+
+      <!-- Health -->
+      <div class="card" id="s-health">
+        <div class="card-head">
+          <div class="num">→</div>
+          <div class="card-info">
+            <div class="card-title"><span class="method GET">GET</span><span class="path">/health</span></div>
+            <div class="card-desc">Check the API is running</div>
+          </div>
+        </div>
+        <div class="card-body">
+          <button class="btn btn-primary" onclick="health()">Send</button>
+          <div class="res" id="res-health"></div>
+        </div>
+      </div>
+
+      <div class="divider"></div>
+
+      <!-- Dev: lookup user -->
+      <div class="card" id="s-dev-user">
+        <div class="card-head">
+          <div class="num">→</div>
+          <div class="card-info">
+            <div class="card-title"><span class="method GET">GET</span><span class="path">/dev/user</span><em class="dev-tag">dev</em></div>
+            <div class="card-desc">Inspect user</div>
+          </div>
+        </div>
+        <div class="card-body">
+          <div class="field"><label>Email</label><input id="du-email" value="ana@qrew.dev" /></div>
+          <button class="btn btn-primary" onclick="devUser()">Send</button>
+          <div class="res" id="res-dev-user"></div>
+        </div>
+      </div>
+
+      <!-- Dev: reset -->
+      <div class="card" id="s-dev-reset">
+        <div class="card-head">
+          <div class="num">→</div>
+          <div class="card-info">
+            <div class="card-title"><span class="method POST">POST</span><span class="path">/dev/reset</span><em class="dev-tag">dev</em></div>
+            <div class="card-desc">Truncate all tables from genesis</div>
+          </div>
+        </div>
+        <div class="card-body">
+          <button class="btn btn-danger" onclick="cleanDb()">Send</button>
+          <div class="res" id="res-dev-reset"></div>
+        </div>
+      </div>
+
+      <!-- Dev: make admin -->
+      <div class="card" id="s-dev-admin">
+        <div class="card-head">
+          <div class="num">→</div>
+          <div class="card-info">
+            <div class="card-title"><span class="method POST">POST</span><span class="path">/dev/make-admin</span><em class="dev-tag">dev</em></div>
+            <div class="card-desc">Grant admin role</div>
+          </div>
+        </div>
+        <div class="card-body">
+          <div class="field"><label>Email</label><input id="da-email" value="admin@qrew.dev" /></div>
+          <button class="btn btn-primary" onclick="devMakeAdmin()">Send</button>
+          <div class="res" id="res-dev-admin"></div>
+        </div>
+      </div>
+
+    </div>
+  </div>
+
+</div><!-- /layout -->
+
+<script>
+// ── token state ───────────────────────────────────────────────────
+const T = { setup:'', access:'', refresh:'' };
+
+function setTok(key, v) {
+  T[key] = v || '';
+  const pill = document.getElementById('tk-' + key);
+  const span = document.getElementById('tv-' + key);
+  if (!pill || !span) return;
+  span.textContent = v ? v.slice(0,20)+'…' : '—';
+  span.title = v || '';
+  pill.classList.toggle('on', !!v);
+}
+
+function copyTok(key) {
+  if (!T[key]) return;
+  navigator.clipboard.writeText(T[key]).then(() => {
+    const pill = document.getElementById('tk-' + key);
+    pill.classList.add('copied');
+    setTimeout(() => pill.classList.remove('copied'), 900);
+    toast('Copied ' + key.toUpperCase() + ' token');
+  });
+}
+
+function absorb(json) {
+  if (!json) return;
+  if (json.refresh_token) { setTok('refresh', json.refresh_token); autoFillRefresh(json.refresh_token); }
+  if (json.access_token)  { setTok(json.setup_required ? 'setup' : 'access', json.access_token); }
+}
+
+function autoFillRefresh(val) {
+  ['ref-token','lo-token'].forEach(id => {
+    const el = document.getElementById(id);
+    if (el && !el.value) { el.value = val; flash(id); }
+  });
+}
+
+// ── field helpers ─────────────────────────────────────────────────
+function fill(id, val) {
+  if (!val) return;
+  const el = document.getElementById(id);
+  if (!el) return;
+  el.value = val;
+  flash(id);
+}
+
+function flash(id) {
+  const el = document.getElementById(id);
+  if (!el) return;
+  el.classList.add('flashed');
+  setTimeout(() => el.classList.remove('flashed'), 1600);
+}
+
+// ── toast ─────────────────────────────────────────────────────────
+let _tt = 0;
+function toast(msg, isErr) {
+  const el = document.getElementById('toast');
+  el.textContent = msg;
+  el.className = 'toast' + (isErr ? ' err' : '');
+  void el.offsetWidth;
+  el.classList.add('show');
+  clearTimeout(_tt);
+  _tt = setTimeout(() => el.classList.remove('show'), 2800);
+}
+
+// ── dev helpers ───────────────────────────────────────────────────
+async function fetchDevUser(email) {
+  try {
+    const r = await fetch(base() + '/dev/user?email=' + encodeURIComponent(email));
+    if (!r.ok) return null;
+    return await r.json();
+  } catch { return null; }
+}
+
+async function cleanDb() {
+  const btn = document.getElementById('btn-clean');
+  btn.disabled = true; btn.textContent = '…';
+  try {
+    const r = await fetch(base() + '/dev/reset', { method: 'POST' });
+    if (r.ok || r.status === 204) {
+      ['setup','access','refresh'].forEach(k => setTok(k, ''));
+      document.querySelectorAll('.card').forEach(el => el.classList.remove('done','fail'));
+      document.querySelectorAll('.res').forEach(el => { el.className='res'; el.innerHTML=''; });
+      ['ve-token','vp-otp','kr-uid','ma-email','ref-token','lo-token'].forEach(id => {
+        const el=document.getElementById(id); if(el) el.value='';
+      });
+      toast('Reset successful');
+    } else { toast('Reset failed (' + r.status + ')', true); }
+  } catch(e) { toast('Reset failed: ' + e.message, true); }
+  finally { btn.disabled=false; btn.textContent='⟳ Reset'; }
+}
+
+// ── http ──────────────────────────────────────────────────────────
+function base() { return document.getElementById('base').value.replace(/\/$/,''); }
+function authFor(type) {
+  return type==='setup'  ? (T.setup||T.access)
+       : type==='access' ? T.access
+       : '';
+}
+
+async function req(method, path, body, authType, isForm, resId, stepId) {
+  const resEl  = document.getElementById('res-' + resId);
+  const stepEl = document.getElementById('s-' + stepId);
+  resEl.className = 'res show';
+  resEl.innerHTML = '<div class="res-bar"><span class="res-status" style="color:#475569">…</span><span class="res-path">' + method + ' ' + path + '</span></div>';
+
+  const headers = {};
+  const t = authFor(authType);
+  if (t) headers['Authorization'] = 'Bearer ' + t;
+  let b;
+  if (isForm) { b = body; }
+  else if (body) { headers['Content-Type'] = 'application/json'; b = JSON.stringify(body); }
+
+  const t0 = Date.now();
+  try {
+    const r   = await fetch(base() + path, { method, headers, body: b });
+    const ms  = Date.now() - t0;
+    let json; try { json = await r.json(); } catch { json = null; }
+
+    const ok = r.status < 400;
+    if (stepEl) { stepEl.classList.toggle('done',ok); stepEl.classList.toggle('fail',!ok); }
+
+    resEl.innerHTML =
+      '<div class="res-bar">' +
+        '<span class="res-status ' + (ok?'ok':'er') + '">' + r.status + '</span>' +
+        '<span class="res-path">' + method + ' ' + path + '</span>' +
+        '<span class="res-ms">' + ms + 'ms</span>' +
+      '</div>' +
+      '<div class="res-body">' + (json ? fmt(json) : '(empty)') + '</div>';
+
+    absorb(json);
+    return { ok, status: r.status, json };
+  } catch(e) {
+    resEl.innerHTML = '<div class="res-bar"><span class="res-status er">ERR</span><span class="res-path">' + e.message + '</span></div>';
+    if (stepEl) stepEl.classList.add('fail');
+    return { ok: false };
+  }
+}
+
+function fmt(j) {
+  return JSON.stringify(j, null, 2)
+    .replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;')
+    .replace(/"([^"]+)":/g, '<span class="jk">"$1"</span>:')
+    .replace(/: "([^"]*)"/g, ': <span class="js">"$1"</span>')
+    .replace(/: (\d+\.?\d*)/g, ': <span class="jn">$1</span>')
+    .replace(/: (true|false)/g, ': <span class="jb">$1</span>')
+    .replace(/: null/g, ': <span class="jx">null</span>');
+}
+
+function v(id) { return (document.getElementById(id)||{}).value||''; }
+
+// ── auth handlers ─────────────────────────────────────────────────
+async function register() {
+  const email = v('r-email');
+  const r = await req('POST','/auth/register',{
+    full_name:v('r-name'), email, phone_number:v('r-phone'),
+    password:v('r-password'), captcha_token:'1x00000000000000000000AA', terms_accepted:true
+  },null,false,'register','register');
+  if (r.ok) {
+    const user = await fetchDevUser(email);
+    if (user) {
+      fill('ve-token', user.email_verification_token);
+      fill('vp-otp', user.phone_number_otp);
+      fill('kr-uid', user.id);
+      toast('Email token + OTP + user ID auto-filled');
+    }
+  }
+  return r;
+}
+
+function verifyEmail() {
+  return req('POST','/auth/verify-email',{ token:v('ve-token') },null,false,'verify-email','verify-email');
+}
+
+function loginSetup() {
+  return req('POST','/auth/login',{ email:v('ls-email'), password:v('ls-password') },null,false,'login-setup','login-setup');
+}
+
+function verifyPhone() {
+  return req('POST','/auth/verify-phone',{ phone_number:v('r-phone')||'+34600000001', otp:v('vp-otp') },'setup',false,'verify-phone','verify-phone');
+}
+
+function kycUpload() {
+  const form = new FormData();
+  form.append('document', new Blob(['FAKE_KYC_DOCUMENT\nName: Ana García\nID: 12345678A'],{type:'text/plain'}), 'id.txt');
+  return req('POST','/auth/kyc/upload',form,'setup',true,'kyc','kyc');
+}
+
+async function passkeyRegister() {
+  const toBytes = s => Uint8Array.from(atob(s.replace(/-/g,'+').replace(/_/g,'/')), c=>c.charCodeAt(0));
+  const toB64   = b => btoa(String.fromCharCode(...new Uint8Array(b))).replace(/\+/g,'-').replace(/\//g,'_').replace(/=+$/,'');
+  const resEl   = document.getElementById('res-passkey');
+  resEl.className = 'res show';
+  resEl.innerHTML = '<div class="res-bar"><span class="res-status" style="color:#475569">Waiting for authenticator…</span></div>';
+  try {
+    const br = await fetch(base()+'/auth/passkey/register/begin',{method:'POST',headers:{Authorization:'Bearer '+(T.setup||T.access)}});
+    const opts = await br.json();
+    if (!br.ok) {
+      resEl.innerHTML='<div class="res-bar"><span class="res-status er">'+br.status+'</span><span class="res-path">begin failed</span></div><div class="res-body">'+fmt(opts)+'</div>';
+      return;
+    }
+    opts.challenge = toBytes(opts.challenge);
+    opts.user.id   = toBytes(opts.user.id);
+    if (opts.excludeCredentials) opts.excludeCredentials = opts.excludeCredentials.map(c=>({...c,id:toBytes(c.id)}));
+    const cred = await navigator.credentials.create({ publicKey: opts });
+    await req('POST','/auth/passkey/register/complete',{
+      id:cred.id, raw_id:toB64(cred.rawId),
+      response:{ client_data_json:toB64(cred.response.clientDataJSON), attestation_object:toB64(cred.response.attestationObject) }
+    },'setup',false,'passkey','passkey');
+  } catch(e) {
+    resEl.innerHTML='<div class="res-bar"><span class="res-status er">ERR</span><span class="res-path">'+e.message+'</span></div>';
+    document.getElementById('s-passkey').classList.add('fail');
+  }
+}
+
+function completeSetup() {
+  return req('POST','/auth/complete-setup',null,'setup',false,'complete-setup','complete-setup');
+}
+
+function loginFull() {
+  return req('POST','/auth/login',{ email:v('lf-email'), password:v('lf-password') },null,false,'login-full','login-full');
+}
+
+function refresh() {
+  return req('POST','/auth/refresh',{ refresh_token:v('ref-token')||T.refresh },null,false,'refresh','refresh');
+}
+
+function logout() {
+  return req('POST','/auth/logout',{ refresh_token:v('lo-token')||T.refresh },null,false,'logout','logout');
+}
+
+async function passkeyAuth() {
+  const toBytes = s => Uint8Array.from(atob(s.replace(/-/g,'+').replace(/_/g,'/')), c=>c.charCodeAt(0));
+  const toB64   = b => btoa(String.fromCharCode(...new Uint8Array(b))).replace(/\+/g,'-').replace(/\//g,'_').replace(/=+$/,'');
+  const resEl   = document.getElementById('res-passkey-auth');
+  resEl.className = 'res show';
+  resEl.innerHTML = '<div class="res-bar"><span class="res-status" style="color:#475569">Waiting for authenticator…</span></div>';
+  try {
+    const br = await fetch(base()+'/auth/passkey/authenticate/begin',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({email:v('pa-email')})});
+    const opts = await br.json();
+    if (!br.ok) { resEl.innerHTML='<div class="res-bar"><span class="res-status er">'+br.status+'</span></div><div class="res-body">'+fmt(opts)+'</div>'; return; }
+    opts.challenge = toBytes(opts.challenge);
+    if (opts.allowCredentials) opts.allowCredentials = opts.allowCredentials.map(c=>({...c,id:toBytes(c.id)}));
+    const cred = await navigator.credentials.get({ publicKey: opts });
+    await req('POST','/auth/passkey/authenticate/complete',{
+      id:cred.id, raw_id:toB64(cred.rawId),
+      response:{
+        client_data_json:toB64(cred.response.clientDataJSON),
+        authenticator_data:toB64(cred.response.authenticatorData),
+        signature:toB64(cred.response.signature),
+        user_handle:cred.response.userHandle?toB64(cred.response.userHandle):null
+      }
+    },null,false,'passkey-auth','passkey-auth');
+  } catch(e) {
+    resEl.innerHTML='<div class="res-bar"><span class="res-status er">ERR</span><span class="res-path">'+e.message+'</span></div>';
+  }
+}
+
+// ── admin handlers ────────────────────────────────────────────────
+
+function kycReview() {
+  const body = { action:v('kr-action') };
+  const reason = v('kr-reason'); if (reason) body.reason = reason;
+  return req('POST','/admin/kyc/'+v('kr-uid')+'/review',body,'access',false,'kyc-review','kyc-review');
+}
+
+function auditVerify() {
+  return req('GET','/admin/audit/verify',null,'access',false,'audit','audit');
+}
+
+// ── health / dev handlers ─────────────────────────────────────────
+function health() {
+  return fetch(base()+'/health')
+    .then(r=>r.json().then(j=>{
+      const el=document.getElementById('res-health');
+      el.className='res show';
+      el.innerHTML='<div class="res-bar"><span class="res-status ok">'+r.status+'</span><span class="res-path">GET /health</span></div><div class="res-body">'+fmt(j)+'</div>';
+      document.getElementById('s-health').classList.add('done');
+    }));
+}
+
+function devUser() {
+  const email = v('du-email');
+  return fetch(base()+'/dev/user?email='+encodeURIComponent(email))
+    .then(async r=>{
+      const json=await r.json();
+      const el=document.getElementById('res-dev-user');
+      el.className='res show';
+      const ok=r.status<400;
+      el.innerHTML='<div class="res-bar"><span class="res-status '+(ok?'ok':'er')+'">'+r.status+'</span><span class="res-path">GET /dev/user</span></div><div class="res-body">'+fmt(json)+'</div>';
+      document.getElementById('s-dev-user').classList.toggle('done',ok);
+    });
+}
+
+function devMakeAdmin() {
+  return req('POST','/dev/make-admin?email='+encodeURIComponent(v('da-email')),null,null,false,'dev-admin','dev-admin');
+}
+</script>
+</body>
+</html>

--- a/api/src/com/qode/qrew/v1/service/lifespan.py
+++ b/api/src/com/qode/qrew/v1/service/lifespan.py
@@ -4,11 +4,14 @@ from contextlib import asynccontextmanager
 import structlog
 from fastapi import FastAPI
 
+from com.qode.qrew.v1.service.services.audit import AuditService
+
 logger = structlog.get_logger(__name__)
 
 
 @asynccontextmanager
 async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     await logger.ainfo("startup")
+    await AuditService().ensure_genesis()
     yield
     await logger.ainfo("shutdown")

--- a/api/src/com/qode/qrew/v1/service/models/audit.py
+++ b/api/src/com/qode/qrew/v1/service/models/audit.py
@@ -1,0 +1,50 @@
+import enum
+import uuid
+from datetime import datetime
+
+from sqlalchemy import DateTime, LargeBinary, String, Text, func
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from com.qode.qrew.v1.service.core.database import Base
+
+
+class AuditAction(enum.StrEnum):
+    REGISTER = "register"
+    LOGIN = "login"
+    LOGIN_FAILED = "login_failed"
+    LOGOUT = "logout"
+    VERIFY_EMAIL = "verify_email"
+    VERIFY_PHONE = "verify_phone"
+    KYC_UPLOADED = "kyc_uploaded"
+    KYC_REVIEWED = "kyc_reviewed"
+    PASSKEY_REGISTERED = "passkey_registered"
+    PASSKEY_AUTHENTICATED = "passkey_authenticated"
+    TOKEN_REFRESHED = "token_refreshed"  # noqa: S105
+    SETUP_COMPLETED = "setup_completed"
+    GENESIS = "genesis"
+
+
+class AuditEvent(Base):
+    __tablename__ = "audit_events"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    actor_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), nullable=True, index=True
+    )
+    action: Mapped[str] = mapped_column(String(64), index=True)
+    entity_type: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    entity_id: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    ip_address: Mapped[str | None] = mapped_column(String(45), nullable=True)
+    device_fingerprint_hash: Mapped[str | None] = mapped_column(
+        String(255), nullable=True
+    )
+    user_agent: Mapped[str | None] = mapped_column(Text, nullable=True)
+    payload: Mapped[dict[str, object]] = mapped_column(JSONB, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), index=True
+    )
+    prev_hash: Mapped[bytes | None] = mapped_column(LargeBinary(32), nullable=True)
+    hash: Mapped[bytes] = mapped_column(LargeBinary(32), nullable=False)

--- a/api/src/com/qode/qrew/v1/service/repositories/audit.py
+++ b/api/src/com/qode/qrew/v1/service/repositories/audit.py
@@ -1,0 +1,98 @@
+import hashlib
+import json
+import uuid
+from datetime import datetime
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from com.qode.qrew.v1.service.models.audit import AuditAction, AuditEvent
+
+
+def _canonical_json(data: dict[str, object]) -> bytes:
+    return json.dumps(data, sort_keys=True, default=str, separators=(",", ":")).encode()
+
+
+def compute_hash(prev_hash: bytes | None, event_data: dict[str, object]) -> bytes:
+    """SHA-256(prev_hash_bytes || canonical_json(event_data))."""
+    return hashlib.sha256((prev_hash or b"") + _canonical_json(event_data)).digest()
+
+
+def event_to_hashable(event: AuditEvent) -> dict[str, object]:
+    """Return the fields that are included in the hash (excludes prev_hash and hash)."""
+    return {
+        "id": str(event.id),
+        "actor_id": str(event.actor_id) if event.actor_id else None,
+        "action": event.action,
+        "entity_type": event.entity_type,
+        "entity_id": event.entity_id,
+        "ip_address": event.ip_address,
+        "device_fingerprint_hash": event.device_fingerprint_hash,
+        "user_agent": event.user_agent,
+        "payload": event.payload,
+        "created_at": event.created_at.isoformat(),
+    }
+
+
+def build_event(
+    action: str,
+    actor_id: uuid.UUID | None,
+    entity_type: str | None,
+    entity_id: str | None,
+    ip_address: str | None,
+    device_fingerprint_hash: str | None,
+    user_agent: str | None,
+    payload: dict[str, object],
+    created_at: datetime,
+    prev_hash: bytes | None,
+) -> AuditEvent:
+    event = AuditEvent(
+        id=uuid.uuid4(),
+        actor_id=actor_id,
+        action=action,
+        entity_type=entity_type,
+        entity_id=entity_id,
+        ip_address=ip_address,
+        device_fingerprint_hash=device_fingerprint_hash,
+        user_agent=user_agent,
+        payload=payload,
+        created_at=created_at,
+        prev_hash=prev_hash,
+        hash=b"",
+    )
+    event.hash = compute_hash(prev_hash, event_to_hashable(event))
+    return event
+
+
+class AuditRepository:
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+
+    async def get_last_hash(self) -> bytes | None:
+        result = await self._session.execute(
+            select(AuditEvent.hash)
+            .order_by(AuditEvent.created_at.desc(), AuditEvent.id.desc())
+            .limit(1)
+        )
+        return result.scalar_one_or_none()
+
+    async def insert(self, event: AuditEvent) -> AuditEvent:
+        self._session.add(event)
+        await self._session.flush()
+        return event
+
+    async def has_genesis(self) -> bool:
+        result = await self._session.execute(
+            select(AuditEvent.id)
+            .where(AuditEvent.action == AuditAction.GENESIS)
+            .limit(1)
+        )
+        return result.scalar_one_or_none() is not None
+
+    async def get_all_ordered(self) -> list[AuditEvent]:
+        result = await self._session.execute(
+            select(AuditEvent).order_by(
+                AuditEvent.created_at.asc(), AuditEvent.id.asc()
+            )
+        )
+        return list(result.scalars().all())

--- a/api/src/com/qode/qrew/v1/service/routers/__init__.py
+++ b/api/src/com/qode/qrew/v1/service/routers/__init__.py
@@ -3,8 +3,14 @@ from fastapi import APIRouter
 from com.qode.qrew.v1.service.routers.admin import router as admin_router
 from com.qode.qrew.v1.service.routers.auth import router as auth_router
 from com.qode.qrew.v1.service.routers.health import router as health_router
+from com.qode.qrew.v1.service.settings import settings
 
 router = APIRouter(prefix="/v1")
 router.include_router(health_router)
 router.include_router(auth_router)
 router.include_router(admin_router)
+
+if settings.debug:
+    from com.qode.qrew.v1.service.routers.dev import router as dev_router
+
+    router.include_router(dev_router)

--- a/api/src/com/qode/qrew/v1/service/routers/admin.py
+++ b/api/src/com/qode/qrew/v1/service/routers/admin.py
@@ -9,9 +9,11 @@ from com.qode.qrew.v1.service.core.limiter import limiter
 from com.qode.qrew.v1.service.models.user import User
 from com.qode.qrew.v1.service.repositories.user import UserRepository
 from com.qode.qrew.v1.service.schemas.admin import (
+    AuditVerifyResponse,
     KycReviewRequest,
     KycReviewResponse,
 )
+from com.qode.qrew.v1.service.services.audit import AuditService
 from com.qode.qrew.v1.service.services.kyc_review import (
     KycReviewError,
     KycReviewService,
@@ -33,7 +35,27 @@ def get_kyc_review_service(
     notifier: NotificationDispatcher = Depends(_get_notification_service),
 ) -> KycReviewService:
     """Build and return the KYC review service."""
-    return KycReviewService(UserRepository(db), notifier)
+    return KycReviewService(UserRepository(db), notifier, AuditService())
+
+
+@router.get(
+    "/audit/verify",
+    response_model=AuditVerifyResponse,
+    status_code=status.HTTP_200_OK,
+    summary="Verify the integrity of the audit event Merkle hash chain",
+)
+@limiter.limit("10/minute")  # type: ignore[misc]
+async def audit_verify(
+    request: Request,
+    _admin: User = Depends(get_admin_user),
+) -> AuditVerifyResponse:
+    """Walk the audit chain from genesis and detect any tampered rows."""
+    result = await AuditService().verify_chain()
+    return AuditVerifyResponse(
+        valid=result.valid,
+        event_count=result.event_count,
+        tampered_ids=result.tampered_ids,
+    )
 
 
 @router.post(

--- a/api/src/com/qode/qrew/v1/service/routers/auth.py
+++ b/api/src/com/qode/qrew/v1/service/routers/auth.py
@@ -46,6 +46,7 @@ from com.qode.qrew.v1.service.schemas.auth import (
     VerifyPhoneRequest,
     VerifyResponse,
 )
+from com.qode.qrew.v1.service.services.audit import AuditService
 from com.qode.qrew.v1.service.services.complete_setup import (
     CompleteSetupService,
     SetupError,
@@ -93,28 +94,30 @@ def get_registration_service(
     captcha: CaptchaService = Depends(_get_captcha_service),
 ) -> RegistrationService:
     """Build and return the registration service."""
-    return RegistrationService(UserRepository(db), notifier, captcha)
+    return RegistrationService(UserRepository(db), notifier, captcha, AuditService())
 
 
 def get_email_verification_service(
     db: AsyncSession = Depends(get_db),
 ) -> EmailVerificationService:
     """Build and return the email verification service."""
-    return EmailVerificationService(UserRepository(db))
+    return EmailVerificationService(UserRepository(db), AuditService())
 
 
 def get_phone_verification_service(
     db: AsyncSession = Depends(get_db),
 ) -> PhoneVerificationService:
     """Build and return the phone verification service."""
-    return PhoneVerificationService(UserRepository(db))
+    return PhoneVerificationService(UserRepository(db), AuditService())
 
 
 def get_login_service(
     db: AsyncSession = Depends(get_db),
 ) -> LoginService:
     """Build and return the login service."""
-    return LoginService(UserRepository(db), PasskeyCredentialRepository(db))
+    return LoginService(
+        UserRepository(db), PasskeyCredentialRepository(db), AuditService()
+    )
 
 
 def get_refresh_service(
@@ -122,14 +125,14 @@ def get_refresh_service(
     redis: Annotated[aioredis.Redis, Depends(get_redis)] = ...,  # type: ignore[type-arg, assignment]
 ) -> RefreshService:
     """Build and return the refresh service."""
-    return RefreshService(UserRepository(db), redis)
+    return RefreshService(UserRepository(db), redis, AuditService())
 
 
 def get_logout_service(
     redis: Annotated[aioredis.Redis, Depends(get_redis)] = ...,  # type: ignore[type-arg, assignment]
 ) -> LogoutService:
     """Build and return the logout service."""
-    return LogoutService(redis)
+    return LogoutService(redis, AuditService())
 
 
 def get_resend_email_verification_service(
@@ -153,7 +156,7 @@ def get_kyc_service(
     notifier: NotificationDispatcher = Depends(_get_notification_service),
 ) -> KycService:
     """Build and return the KYC service."""
-    return KycService(UserRepository(db), notifier)
+    return KycService(UserRepository(db), notifier, AuditService())
 
 
 def get_passkey_service(
@@ -161,14 +164,18 @@ def get_passkey_service(
     redis: Annotated[aioredis.Redis, Depends(get_redis)] = ...,  # type: ignore[type-arg, assignment]
 ) -> PasskeyService:
     """Build and return the passkey service."""
-    return PasskeyService(PasskeyCredentialRepository(db), redis, UserRepository(db))
+    return PasskeyService(
+        PasskeyCredentialRepository(db), redis, UserRepository(db), AuditService()
+    )
 
 
 def get_complete_setup_service(
     db: AsyncSession = Depends(get_db),
 ) -> CompleteSetupService:
     """Build and return the complete-setup service."""
-    return CompleteSetupService(UserRepository(db), PasskeyCredentialRepository(db))
+    return CompleteSetupService(
+        UserRepository(db), PasskeyCredentialRepository(db), AuditService()
+    )
 
 
 _DomainError = (

--- a/api/src/com/qode/qrew/v1/service/routers/dev.py
+++ b/api/src/com/qode/qrew/v1/service/routers/dev.py
@@ -1,0 +1,74 @@
+from typing import Annotated
+
+import redis.asyncio as aioredis
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+from sqlalchemy import select, text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from com.qode.qrew.v1.service.core.database import get_db
+from com.qode.qrew.v1.service.core.redis import get_redis
+from com.qode.qrew.v1.service.models.user import User
+from com.qode.qrew.v1.service.services.audit import AuditService
+
+router = APIRouter(prefix="/dev", tags=["dev"])
+
+
+class DevUserResponse(BaseModel):
+    id: str
+    email: str
+    email_verified: bool
+    phone_verified: bool
+    is_admin: bool
+    kyc_status: str
+    email_verification_token: str | None
+    phone_number_otp: str | None
+
+
+@router.get("/user", response_model=DevUserResponse)
+async def dev_get_user(
+    email: str,
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> DevUserResponse:
+    result = await db.execute(select(User).where(User.email == email))
+    user = result.scalar_one_or_none()
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
+    return DevUserResponse(
+        id=str(user.id),
+        email=user.email,
+        email_verified=user.email_verified,
+        phone_verified=user.phone_number_verified,
+        is_admin=user.is_admin,
+        kyc_status=str(user.kyc_status),
+        email_verification_token=user.email_verification_token,
+        phone_number_otp=user.phone_number_otp,
+    )
+
+
+@router.post("/reset", status_code=204)
+async def dev_reset_db(
+    db: Annotated[AsyncSession, Depends(get_db)],
+    redis: Annotated[aioredis.Redis, Depends(get_redis)],  # type: ignore[type-arg, assignment]
+) -> None:
+    await db.execute(
+        text(
+            "TRUNCATE audit_events, passkey_credentials, users RESTART IDENTITY CASCADE"
+        )
+    )
+    await db.commit()
+    await redis.flushdb()  # type: ignore[no-untyped-call]
+    await AuditService().ensure_genesis()
+
+
+@router.post("/make-admin", status_code=204)
+async def dev_make_admin(
+    email: str,
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> None:
+    result = await db.execute(select(User).where(User.email == email))
+    user = result.scalar_one_or_none()
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
+    user.is_admin = True
+    await db.commit()

--- a/api/src/com/qode/qrew/v1/service/schemas/admin.py
+++ b/api/src/com/qode/qrew/v1/service/schemas/admin.py
@@ -17,3 +17,9 @@ class KycReviewResponse(BaseModel):
     user_id: str
     kyc_status: str
     message: str
+
+
+class AuditVerifyResponse(BaseModel):
+    valid: bool
+    event_count: int
+    tampered_ids: list[str]

--- a/api/src/com/qode/qrew/v1/service/services/audit.py
+++ b/api/src/com/qode/qrew/v1/service/services/audit.py
@@ -1,0 +1,115 @@
+import uuid
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+import structlog
+from sqlalchemy import text
+
+from com.qode.qrew.v1.service.core.database import AsyncSessionLocal
+from com.qode.qrew.v1.service.models.audit import AuditAction
+from com.qode.qrew.v1.service.repositories.audit import (
+    AuditRepository,
+    build_event,
+    compute_hash,
+    event_to_hashable,
+)
+
+logger = structlog.get_logger(__name__)
+
+_ADVISORY_LOCK = "SELECT pg_advisory_xact_lock(hashtext('audit_events'))"
+
+
+@dataclass
+class ChainVerificationResult:
+    valid: bool
+    event_count: int
+    tampered_ids: list[str]
+
+
+class AuditService:
+    """Append-only audit log with SHA-256 Merkle hash chain.
+
+    Uses its own session (independent of the caller's transaction) so that audit
+    events are always committed, even when the main transaction rolls back.
+    The advisory lock serialises all inserts so the hash chain is never forked.
+    """
+
+    async def record(
+        self,
+        action: str,
+        actor_id: uuid.UUID | None = None,
+        entity_type: str | None = None,
+        entity_id: str | None = None,
+        ip_address: str | None = None,
+        device_fingerprint_hash: str | None = None,
+        user_agent: str | None = None,
+        payload: dict[str, object] | None = None,
+    ) -> None:
+        now = datetime.now(UTC)
+        async with AsyncSessionLocal() as session, session.begin():
+            await session.execute(text(_ADVISORY_LOCK))
+            repo = AuditRepository(session)
+            prev_hash = await repo.get_last_hash()
+            event = build_event(
+                action=action,
+                actor_id=actor_id,
+                entity_type=entity_type,
+                entity_id=entity_id,
+                ip_address=ip_address,
+                device_fingerprint_hash=device_fingerprint_hash,
+                user_agent=user_agent,
+                payload=payload or {},
+                created_at=now,
+                prev_hash=prev_hash,
+            )
+            await repo.insert(event)
+        await logger.ainfo(
+            "audit_recorded",
+            action=action,
+            actor_id=str(actor_id) if actor_id else None,
+        )
+
+    async def ensure_genesis(self) -> None:
+        """Write the genesis record on first boot. Idempotent."""
+        async with AsyncSessionLocal() as session, session.begin():
+            await session.execute(text(_ADVISORY_LOCK))
+            repo = AuditRepository(session)
+            if await repo.has_genesis():
+                return
+            event = build_event(
+                action=AuditAction.GENESIS,
+                actor_id=None,
+                entity_type="system",
+                entity_id=None,
+                ip_address=None,
+                device_fingerprint_hash=None,
+                user_agent=None,
+                payload={"message": "Audit chain genesis"},
+                created_at=datetime.now(UTC),
+                prev_hash=None,
+            )
+            await repo.insert(event)
+        await logger.ainfo("audit_genesis_created")
+
+    async def verify_chain(self) -> ChainVerificationResult:
+        """Recompute every hash from genesis and return tampered IDs."""
+        async with AsyncSessionLocal() as session:
+            repo = AuditRepository(session)
+            events = await repo.get_all_ordered()
+
+        prev_hash: bytes | None = None
+        tampered: list[str] = []
+
+        for event in events:
+            expected = compute_hash(prev_hash, event_to_hashable(event))
+            if event.hash != expected:
+                tampered.append(str(event.id))
+            # always advance using the stored hash so a single tampered row
+            # does not cascade false positives to every subsequent event
+            prev_hash = event.hash
+
+        return ChainVerificationResult(
+            valid=len(tampered) == 0,
+            event_count=len(events),
+            tampered_ids=tampered,
+        )

--- a/api/src/com/qode/qrew/v1/service/services/complete_setup.py
+++ b/api/src/com/qode/qrew/v1/service/services/complete_setup.py
@@ -5,10 +5,12 @@ from com.qode.qrew.v1.service.core.security import (
     create_access_token,
     create_refresh_token,
 )
+from com.qode.qrew.v1.service.models.audit import AuditAction
 from com.qode.qrew.v1.service.models.user import KycStatus, User
 from com.qode.qrew.v1.service.repositories.passkey import PasskeyCredentialRepository
 from com.qode.qrew.v1.service.repositories.user import UserRepository
 from com.qode.qrew.v1.service.schemas.auth import LoginResponse
+from com.qode.qrew.v1.service.services.audit import AuditService
 
 logger = structlog.get_logger(__name__)
 
@@ -19,10 +21,14 @@ class SetupError(DomainError):
 
 class CompleteSetupService:
     def __init__(
-        self, user_repo: UserRepository, passkey_repo: PasskeyCredentialRepository
+        self,
+        user_repo: UserRepository,
+        passkey_repo: PasskeyCredentialRepository,
+        audit: AuditService,
     ) -> None:
         self._user_repo = user_repo
         self._passkey_repo = passkey_repo
+        self._audit = audit
 
     async def complete(self, user: User) -> LoginResponse:
         """Issue full tokens once all onboarding steps are complete."""
@@ -50,5 +56,17 @@ class CompleteSetupService:
         refresh_token = create_refresh_token(str(user.id))
 
         await logger.ainfo("setup_completed", user_id=str(user.id))
+
+        try:
+            await self._audit.record(
+                action=AuditAction.SETUP_COMPLETED,
+                actor_id=user.id,
+                entity_type="user",
+                entity_id=str(user.id),
+            )
+        except Exception:
+            await logger.awarning(
+                "audit_write_failed", action=AuditAction.SETUP_COMPLETED
+            )
 
         return LoginResponse(access_token=access_token, refresh_token=refresh_token)

--- a/api/src/com/qode/qrew/v1/service/services/kyc.py
+++ b/api/src/com/qode/qrew/v1/service/services/kyc.py
@@ -3,8 +3,10 @@ import hashlib
 import structlog
 
 from com.qode.qrew.v1.service.core.errors import DomainError
+from com.qode.qrew.v1.service.models.audit import AuditAction
 from com.qode.qrew.v1.service.models.user import KycStatus, User
 from com.qode.qrew.v1.service.repositories.user import UserRepository
+from com.qode.qrew.v1.service.services.audit import AuditService
 from com.qode.qrew.v1.service.services.notification import NotificationDispatcher
 from com.qode.qrew.v1.service.settings import settings
 
@@ -18,9 +20,15 @@ class KycError(DomainError):
 
 
 class KycService:
-    def __init__(self, repo: UserRepository, notifier: NotificationDispatcher) -> None:
+    def __init__(
+        self,
+        repo: UserRepository,
+        notifier: NotificationDispatcher,
+        audit: AuditService,
+    ) -> None:
         self._repo = repo
         self._notifier = notifier
+        self._audit = audit
 
     async def upload(self, user: User, content: bytes) -> KycStatus:
         """Hash the document, mark KYC as pending (or auto-approve if enabled)."""
@@ -48,5 +56,16 @@ class KycService:
             await logger.ainfo("kyc_auto_approved", user_id=str(user.id))
         else:
             await logger.ainfo("kyc_submitted", user_id=str(user.id))
+
+        try:
+            await self._audit.record(
+                action=AuditAction.KYC_UPLOADED,
+                actor_id=user.id,
+                entity_type="user",
+                entity_id=str(user.id),
+                payload={"kyc_status": user.kyc_status},
+            )
+        except Exception:
+            await logger.awarning("audit_write_failed", action=AuditAction.KYC_UPLOADED)
 
         return user.kyc_status

--- a/api/src/com/qode/qrew/v1/service/services/kyc_review.py
+++ b/api/src/com/qode/qrew/v1/service/services/kyc_review.py
@@ -3,9 +3,11 @@ import uuid
 import structlog
 
 from com.qode.qrew.v1.service.core.errors import DomainError
+from com.qode.qrew.v1.service.models.audit import AuditAction
 from com.qode.qrew.v1.service.models.user import KycStatus, User
 from com.qode.qrew.v1.service.repositories.user import UserRepository
 from com.qode.qrew.v1.service.schemas.admin import KycAction
+from com.qode.qrew.v1.service.services.audit import AuditService
 from com.qode.qrew.v1.service.services.notification import NotificationDispatcher
 
 logger = structlog.get_logger(__name__)
@@ -16,9 +18,15 @@ class KycReviewError(DomainError):
 
 
 class KycReviewService:
-    def __init__(self, repo: UserRepository, notifier: NotificationDispatcher) -> None:
+    def __init__(
+        self,
+        repo: UserRepository,
+        notifier: NotificationDispatcher,
+        audit: AuditService,
+    ) -> None:
         self._repo = repo
         self._notifier = notifier
+        self._audit = audit
 
     async def review(
         self,
@@ -52,4 +60,19 @@ class KycReviewService:
             action=action,
             status=new_status,
         )
+
+        try:
+            await self._audit.record(
+                action=AuditAction.KYC_REVIEWED,
+                entity_type="user",
+                entity_id=str(user.id),
+                payload={
+                    "kyc_action": action,
+                    "kyc_status": new_status,
+                    "reason": reason,
+                },
+            )
+        except Exception:
+            await logger.awarning("audit_write_failed", action=AuditAction.KYC_REVIEWED)
+
         return user

--- a/api/src/com/qode/qrew/v1/service/services/login.py
+++ b/api/src/com/qode/qrew/v1/service/services/login.py
@@ -8,10 +8,12 @@ from com.qode.qrew.v1.service.core.security import (
     hash_password,
     verify_password,
 )
+from com.qode.qrew.v1.service.models.audit import AuditAction
 from com.qode.qrew.v1.service.models.user import KycStatus
 from com.qode.qrew.v1.service.repositories.passkey import PasskeyCredentialRepository
 from com.qode.qrew.v1.service.repositories.user import UserRepository
 from com.qode.qrew.v1.service.schemas.auth import LoginRequest, LoginResponse
+from com.qode.qrew.v1.service.services.audit import AuditService
 
 logger = structlog.get_logger(__name__)
 
@@ -24,10 +26,14 @@ class LoginError(DomainError):
 
 class LoginService:
     def __init__(
-        self, repo: UserRepository, passkey_repo: PasskeyCredentialRepository
+        self,
+        repo: UserRepository,
+        passkey_repo: PasskeyCredentialRepository,
+        audit: AuditService,
     ) -> None:
         self._repo = repo
         self._passkey_repo = passkey_repo
+        self._audit = audit
 
     async def login(self, request: LoginRequest) -> LoginResponse:
         """Authenticate a user, returning a setup or full-access token."""
@@ -36,6 +42,15 @@ class LoginService:
         if user is None:
             verify_password(request.password, _DUMMY_HASH)
             await logger.awarning("login_failed", reason="invalid_credentials")
+            try:
+                await self._audit.record(
+                    action=AuditAction.LOGIN_FAILED,
+                    payload={"reason": "invalid_credentials"},
+                )
+            except Exception:
+                await logger.awarning(
+                    "audit_write_failed", action=AuditAction.LOGIN_FAILED
+                )
             raise LoginError("Invalid email or password")
 
         if not verify_password(request.password, user.hashed_password):
@@ -44,6 +59,18 @@ class LoginService:
                 reason="invalid_credentials",
                 user_id=str(user.id),
             )
+            try:
+                await self._audit.record(
+                    action=AuditAction.LOGIN_FAILED,
+                    actor_id=user.id,
+                    entity_type="user",
+                    entity_id=str(user.id),
+                    payload={"reason": "invalid_credentials"},
+                )
+            except Exception:
+                await logger.awarning(
+                    "audit_write_failed", action=AuditAction.LOGIN_FAILED
+                )
             raise LoginError("Invalid email or password")
 
         if not user.email_verified:
@@ -72,9 +99,29 @@ class LoginService:
             access_token = create_access_token(str(user.id))
             refresh_token = create_refresh_token(str(user.id))
             await logger.ainfo("user_logged_in", user_id=str(user.id))
+            try:
+                await self._audit.record(
+                    action=AuditAction.LOGIN,
+                    actor_id=user.id,
+                    entity_type="user",
+                    entity_id=str(user.id),
+                    payload={"setup_complete": True},
+                )
+            except Exception:
+                await logger.awarning("audit_write_failed", action=AuditAction.LOGIN)
             return LoginResponse(access_token=access_token, refresh_token=refresh_token)
 
         await logger.ainfo("user_logged_in_setup_required", user_id=str(user.id))
+        try:
+            await self._audit.record(
+                action=AuditAction.LOGIN,
+                actor_id=user.id,
+                entity_type="user",
+                entity_id=str(user.id),
+                payload={"setup_complete": False},
+            )
+        except Exception:
+            await logger.awarning("audit_write_failed", action=AuditAction.LOGIN)
         return LoginResponse(
             access_token=create_setup_token(str(user.id)),
             setup_required=True,

--- a/api/src/com/qode/qrew/v1/service/services/logout.py
+++ b/api/src/com/qode/qrew/v1/service/services/logout.py
@@ -1,3 +1,4 @@
+import uuid
 from datetime import UTC, datetime
 
 import redis.asyncio as aioredis
@@ -6,6 +7,8 @@ from jwt import ExpiredSignatureError, InvalidTokenError
 
 from com.qode.qrew.v1.service.core.errors import DomainError
 from com.qode.qrew.v1.service.core.security import decode_refresh_token
+from com.qode.qrew.v1.service.models.audit import AuditAction
+from com.qode.qrew.v1.service.services.audit import AuditService
 
 logger = structlog.get_logger(__name__)
 
@@ -17,8 +20,9 @@ class LogoutError(DomainError):
 
 
 class LogoutService:
-    def __init__(self, redis: aioredis.Redis) -> None:  # type: ignore[type-arg]
+    def __init__(self, redis: aioredis.Redis, audit: AuditService) -> None:  # type: ignore[type-arg]
         self._redis = redis
+        self._audit = audit
 
     async def logout(self, refresh_token: str) -> None:
         """Blacklist the refresh token's JTI so it cannot be used again."""
@@ -47,3 +51,16 @@ class LogoutService:
             await self._redis.setex(JTI_BLACKLIST_PREFIX + jti, ttl, "1")
 
         await logger.ainfo("token_revoked", jti=jti)
+
+        sub = payload.get("sub")
+        try:
+            actor_id = uuid.UUID(sub) if isinstance(sub, str) else None
+            await self._audit.record(
+                action=AuditAction.LOGOUT,
+                actor_id=actor_id,
+                entity_type="user",
+                entity_id=sub if isinstance(sub, str) else None,
+                payload={"jti": jti},
+            )
+        except Exception:
+            await logger.awarning("audit_write_failed", action=AuditAction.LOGOUT)

--- a/api/src/com/qode/qrew/v1/service/services/passkey.py
+++ b/api/src/com/qode/qrew/v1/service/services/passkey.py
@@ -9,9 +9,11 @@ from webauthn.helpers.structs import (
     AuthenticationCredential,
     AuthenticatorAssertionResponse,
     AuthenticatorAttestationResponse,
+    AuthenticatorSelectionCriteria,
     PublicKeyCredentialDescriptor,
     PublicKeyCredentialType,
     RegistrationCredential,
+    UserVerificationRequirement,
 )
 
 from com.qode.qrew.v1.service.core.errors import DomainError
@@ -20,6 +22,7 @@ from com.qode.qrew.v1.service.core.security import (
     create_refresh_token,
     create_setup_token,
 )
+from com.qode.qrew.v1.service.models.audit import AuditAction
 from com.qode.qrew.v1.service.models.passkey import PasskeyCredential
 from com.qode.qrew.v1.service.models.user import KycStatus, User
 from com.qode.qrew.v1.service.repositories.passkey import PasskeyCredentialRepository
@@ -29,6 +32,7 @@ from com.qode.qrew.v1.service.schemas.auth import (
     PasskeyAuthenticationCompleteRequest,
     PasskeyRegistrationCompleteRequest,
 )
+from com.qode.qrew.v1.service.services.audit import AuditService
 from com.qode.qrew.v1.service.settings import settings
 
 logger = structlog.get_logger(__name__)
@@ -56,10 +60,12 @@ class PasskeyService:
         passkey_repo: PasskeyCredentialRepository,
         redis: aioredis.Redis,  # type: ignore[type-arg]
         user_repo: UserRepository,
+        audit: AuditService,
     ) -> None:
         self._passkey_repo = passkey_repo
         self._redis = redis
         self._user_repo = user_repo
+        self._audit = audit
 
     async def begin_registration(self, user: User) -> str:
         """Generate WebAuthn registration options and cache the challenge."""
@@ -69,6 +75,9 @@ class PasskeyService:
             user_id=str(user.id).encode(),
             user_name=user.email,
             user_display_name=user.full_name,
+            authenticator_selection=AuthenticatorSelectionCriteria(
+                user_verification=UserVerificationRequirement.REQUIRED,
+            ),
         )
         await self._redis.set(
             _challenge_key(user.id),
@@ -120,10 +129,14 @@ class PasskeyService:
                 "passkey_registration_failed",
                 reason="verification_failed",
                 user_id=str(user.id),
+                detail=str(exc),
             )
-            raise PasskeyError(
-                "Passkey registration failed. Please try again."
-            ) from exc
+            msg = (
+                f"Passkey registration failed: {exc}"
+                if settings.debug
+                else "Passkey registration failed. Please try again."
+            )
+            raise PasskeyError(msg) from exc
 
         await self._passkey_repo.create(
             PasskeyCredential(
@@ -136,6 +149,17 @@ class PasskeyService:
             )
         )
         await logger.ainfo("passkey_registered", user_id=str(user.id))
+        try:
+            await self._audit.record(
+                action=AuditAction.PASSKEY_REGISTERED,
+                actor_id=user.id,
+                entity_type="user",
+                entity_id=str(user.id),
+            )
+        except Exception:
+            await logger.awarning(
+                "audit_write_failed", action=AuditAction.PASSKEY_REGISTERED
+            )
 
     async def begin_authentication(self, email: str) -> str:
         """Generate WebAuthn assertion options and cache the challenge."""
@@ -157,6 +181,7 @@ class PasskeyService:
         options = webauthn.generate_authentication_options(
             rp_id=settings.rp_id,
             allow_credentials=allowed,
+            user_verification=UserVerificationRequirement.REQUIRED,
         )
         await self._redis.set(
             _auth_challenge_key(user.id),
@@ -233,10 +258,14 @@ class PasskeyService:
                 "passkey_authentication_failed",
                 reason="verification_failed",
                 user_id=str(user.id),
+                detail=str(exc),
             )
-            raise PasskeyError(
-                "Passkey authentication failed. Please try again."
-            ) from exc
+            msg = (
+                f"Passkey authentication failed: {exc}"
+                if settings.debug
+                else "Passkey authentication failed. Please try again."
+            )
+            raise PasskeyError(msg) from exc
 
         stored_credential.sign_count = verification.new_sign_count
         stored_credential.last_used_at = datetime.now(UTC)
@@ -250,9 +279,33 @@ class PasskeyService:
             access_token = create_access_token(str(user.id))
             refresh_token = create_refresh_token(str(user.id))
             await logger.ainfo("passkey_authenticated", user_id=str(user.id))
+            try:
+                await self._audit.record(
+                    action=AuditAction.PASSKEY_AUTHENTICATED,
+                    actor_id=user.id,
+                    entity_type="user",
+                    entity_id=str(user.id),
+                    payload={"setup_complete": True},
+                )
+            except Exception:
+                await logger.awarning(
+                    "audit_write_failed", action=AuditAction.PASSKEY_AUTHENTICATED
+                )
             return LoginResponse(access_token=access_token, refresh_token=refresh_token)
 
         await logger.ainfo("passkey_authenticated_setup_required", user_id=str(user.id))
+        try:
+            await self._audit.record(
+                action=AuditAction.PASSKEY_AUTHENTICATED,
+                actor_id=user.id,
+                entity_type="user",
+                entity_id=str(user.id),
+                payload={"setup_complete": False},
+            )
+        except Exception:
+            await logger.awarning(
+                "audit_write_failed", action=AuditAction.PASSKEY_AUTHENTICATED
+            )
         return LoginResponse(
             access_token=create_setup_token(str(user.id)),
             setup_required=True,

--- a/api/src/com/qode/qrew/v1/service/services/refresh.py
+++ b/api/src/com/qode/qrew/v1/service/services/refresh.py
@@ -7,8 +7,10 @@ from jwt import ExpiredSignatureError, InvalidTokenError
 
 from com.qode.qrew.v1.service.core.errors import DomainError
 from com.qode.qrew.v1.service.core.security import create_access_token
+from com.qode.qrew.v1.service.models.audit import AuditAction
 from com.qode.qrew.v1.service.repositories.user import UserRepository
 from com.qode.qrew.v1.service.schemas.auth import RefreshRequest, RefreshResponse
+from com.qode.qrew.v1.service.services.audit import AuditService
 from com.qode.qrew.v1.service.services.logout import JTI_BLACKLIST_PREFIX
 from com.qode.qrew.v1.service.settings import settings
 
@@ -20,9 +22,15 @@ class RefreshError(DomainError):
 
 
 class RefreshService:
-    def __init__(self, repo: UserRepository, redis: aioredis.Redis) -> None:  # type: ignore[type-arg]
+    def __init__(
+        self,
+        repo: UserRepository,
+        redis: aioredis.Redis,
+        audit: AuditService,  # type: ignore[type-arg]
+    ) -> None:
         self._repo = repo
         self._redis = redis
+        self._audit = audit
 
     async def refresh(self, request: RefreshRequest) -> RefreshResponse:
         """Issue a new access token from a valid refresh token."""
@@ -67,5 +75,17 @@ class RefreshService:
 
         access_token = create_access_token(str(user.id))
         await logger.ainfo("token_refreshed", user_id=str(user.id))
+
+        try:
+            await self._audit.record(
+                action=AuditAction.TOKEN_REFRESHED,
+                actor_id=user.id,
+                entity_type="user",
+                entity_id=str(user.id),
+            )
+        except Exception:
+            await logger.awarning(
+                "audit_write_failed", action=AuditAction.TOKEN_REFRESHED
+            )
 
         return RefreshResponse(access_token=access_token)

--- a/api/src/com/qode/qrew/v1/service/services/registration.py
+++ b/api/src/com/qode/qrew/v1/service/services/registration.py
@@ -13,9 +13,11 @@ from com.qode.qrew.v1.service.core.security import (
     is_password_pwned,
     phone_number_otp_expiry,
 )
+from com.qode.qrew.v1.service.models.audit import AuditAction
 from com.qode.qrew.v1.service.models.user import User
 from com.qode.qrew.v1.service.repositories.user import UserRepository
 from com.qode.qrew.v1.service.schemas.auth import RegisterRequest, RegisterResponse
+from com.qode.qrew.v1.service.services.audit import AuditService
 from com.qode.qrew.v1.service.services.notification import NotificationService
 
 logger = structlog.get_logger(__name__)
@@ -57,10 +59,12 @@ class RegistrationService:
         repo: UserRepository,
         notifier: NotificationService,
         captcha: CaptchaService,
+        audit: AuditService,
     ) -> None:
         self._repo = repo
         self._notifier = notifier
         self._captcha = captcha
+        self._audit = audit
 
     async def register(
         self,
@@ -85,6 +89,18 @@ class RegistrationService:
             user_id=str(created.id),
             registration_ip=ip_address,
         )
+
+        try:
+            await self._audit.record(
+                action=AuditAction.REGISTER,
+                actor_id=created.id,
+                entity_type="user",
+                entity_id=str(created.id),
+                ip_address=ip_address,
+                payload={"email": created.email},
+            )
+        except Exception:
+            await logger.awarning("audit_write_failed", action=AuditAction.REGISTER)
 
         return RegisterResponse(
             id=str(created.id),

--- a/api/src/com/qode/qrew/v1/service/services/verification.py
+++ b/api/src/com/qode/qrew/v1/service/services/verification.py
@@ -3,7 +3,9 @@ from datetime import UTC, datetime
 import structlog
 
 from com.qode.qrew.v1.service.core.errors import DomainError
+from com.qode.qrew.v1.service.models.audit import AuditAction
 from com.qode.qrew.v1.service.repositories.user import UserRepository
+from com.qode.qrew.v1.service.services.audit import AuditService
 
 logger = structlog.get_logger(__name__)
 
@@ -13,8 +15,9 @@ class VerificationError(DomainError):
 
 
 class EmailVerificationService:
-    def __init__(self, repo: UserRepository) -> None:
+    def __init__(self, repo: UserRepository, audit: AuditService) -> None:
         self._repo = repo
+        self._audit = audit
 
     async def verify(self, token: str) -> None:
         """Mark the user's email as verified if the token is valid and unexpired."""
@@ -53,11 +56,21 @@ class EmailVerificationService:
         await self._repo.save(user)
 
         await logger.ainfo("email_verified", user_id=str(user.id))
+        try:
+            await self._audit.record(
+                action=AuditAction.VERIFY_EMAIL,
+                actor_id=user.id,
+                entity_type="user",
+                entity_id=str(user.id),
+            )
+        except Exception:
+            await logger.awarning("audit_write_failed", action=AuditAction.VERIFY_EMAIL)
 
 
 class PhoneVerificationService:
-    def __init__(self, repo: UserRepository) -> None:
+    def __init__(self, repo: UserRepository, audit: AuditService) -> None:
         self._repo = repo
+        self._audit = audit
 
     async def verify(self, phone_number: str, otp: str) -> None:
         """Mark the user's phone as verified if the verification OTP is valid
@@ -97,3 +110,12 @@ class PhoneVerificationService:
         await self._repo.save(user)
 
         await logger.ainfo("phone_number_verified", user_id=str(user.id))
+        try:
+            await self._audit.record(
+                action=AuditAction.VERIFY_PHONE,
+                actor_id=user.id,
+                entity_type="user",
+                entity_id=str(user.id),
+            )
+        except Exception:
+            await logger.awarning("audit_write_failed", action=AuditAction.VERIFY_PHONE)

--- a/api/tests/v1/admin/integration/conftest.py
+++ b/api/tests/v1/admin/integration/conftest.py
@@ -20,7 +20,10 @@ async def clean_db() -> None:
     await engine.dispose()
     async with engine.begin() as conn:
         await conn.execute(
-            text("TRUNCATE passkey_credentials, users RESTART IDENTITY CASCADE")
+            text(
+                "TRUNCATE audit_events, passkey_credentials, users"
+                " RESTART IDENTITY CASCADE"
+            )
         )
 
 

--- a/api/tests/v1/audit/integration/audit_chain_test.py
+++ b/api/tests/v1/audit/integration/audit_chain_test.py
@@ -1,0 +1,138 @@
+"""Integration tests for the append-only audit log and Merkle hash chain.
+
+Requires a running PostgreSQL with the migration applied.
+"""
+
+import uuid
+
+import pytest
+from sqlalchemy import select, text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from com.qode.qrew.v1.service.models.audit import AuditAction, AuditEvent
+from com.qode.qrew.v1.service.services.audit import AuditService
+
+pytestmark = pytest.mark.integration
+
+
+# ── record ────────────────────────────────────────────────────────────────────
+
+
+async def test_record_persists_event(db_session: AsyncSession) -> None:
+    audit = AuditService()
+    await audit.record(action=AuditAction.REGISTER, payload={"test": True})
+
+    result = await db_session.execute(
+        select(AuditEvent).where(AuditEvent.action == AuditAction.REGISTER)
+    )
+    events = list(result.scalars().all())
+    assert len(events) == 1
+    assert events[0].hash != b""
+    assert len(events[0].hash) == 32
+
+
+async def test_genesis_event_has_no_prev_hash(db_session: AsyncSession) -> None:
+    audit = AuditService()
+    await audit.ensure_genesis()
+
+    result = await db_session.execute(
+        select(AuditEvent).where(AuditEvent.action == AuditAction.GENESIS)
+    )
+    genesis = result.scalar_one()
+    assert genesis.prev_hash is None
+
+
+async def test_second_event_prev_hash_equals_genesis_hash(
+    db_session: AsyncSession,
+) -> None:
+    audit = AuditService()
+    await audit.ensure_genesis()
+    await audit.record(action=AuditAction.REGISTER)
+
+    result = await db_session.execute(
+        select(AuditEvent).order_by(AuditEvent.created_at.asc(), AuditEvent.id.asc())
+    )
+    events = list(result.scalars().all())
+    assert len(events) == 2
+    genesis, second = events
+    assert second.prev_hash == genesis.hash
+
+
+async def test_ensure_genesis_is_idempotent(db_session: AsyncSession) -> None:
+    audit = AuditService()
+    await audit.ensure_genesis()
+    await audit.ensure_genesis()
+
+    result = await db_session.execute(
+        select(AuditEvent).where(AuditEvent.action == AuditAction.GENESIS)
+    )
+    assert len(list(result.scalars().all())) == 1
+
+
+# ── verify_chain ──────────────────────────────────────────────────────────────
+
+
+async def test_verify_chain_passes_for_untampered_chain() -> None:
+    audit = AuditService()
+    await audit.ensure_genesis()
+    await audit.record(action=AuditAction.REGISTER)
+    await audit.record(action=AuditAction.VERIFY_EMAIL)
+    await audit.record(action=AuditAction.LOGIN)
+
+    result = await audit.verify_chain()
+    assert result.valid is True
+    assert result.event_count == 4
+    assert result.tampered_ids == []
+
+
+async def test_verify_chain_detects_tampered_payload(db_session: AsyncSession) -> None:
+    audit = AuditService()
+    await audit.ensure_genesis()
+    await audit.record(action=AuditAction.REGISTER, payload={"email": "a@b.com"})
+    await audit.record(action=AuditAction.LOGIN)
+
+    # Mutate the register event's payload directly in DB — bypasses app layer
+    await db_session.execute(
+        text("UPDATE audit_events SET payload = :p::jsonb WHERE action = :action"),
+        {"action": AuditAction.REGISTER, "p": '{"email":"hacked@evil.com"}'},
+    )
+    await db_session.commit()
+
+    result = await audit.verify_chain()
+    assert result.valid is False
+    assert len(result.tampered_ids) == 1
+
+
+async def test_verify_chain_detects_tampered_action(db_session: AsyncSession) -> None:
+    audit = AuditService()
+    await audit.ensure_genesis()
+    actor = uuid.uuid4()
+    await audit.record(action=AuditAction.LOGIN, actor_id=actor)
+
+    await db_session.execute(
+        text("UPDATE audit_events SET action = 'login_failed' WHERE action = 'login'")
+    )
+    await db_session.commit()
+
+    result = await audit.verify_chain()
+    assert result.valid is False
+
+
+async def test_append_only_trigger_blocks_update(db_session: AsyncSession) -> None:
+    """The DB trigger must reject any UPDATE on audit_events."""
+    audit = AuditService()
+    await audit.ensure_genesis()
+
+    with pytest.raises(Exception, match="append-only"):
+        await db_session.execute(
+            text("UPDATE audit_events SET action = 'tampered' WHERE action = 'genesis'")
+        )
+
+
+async def test_append_only_trigger_blocks_delete(db_session: AsyncSession) -> None:
+    """The DB trigger must reject any DELETE on audit_events."""
+    audit = AuditService()
+    await audit.ensure_genesis()
+
+    with pytest.raises(Exception, match="append-only"):
+        await db_session.execute(text("DELETE FROM audit_events"))

--- a/api/tests/v1/audit/integration/audit_chain_test.py
+++ b/api/tests/v1/audit/integration/audit_chain_test.py
@@ -91,11 +91,15 @@ async def test_verify_chain_detects_tampered_payload(db_session: AsyncSession) -
     await audit.record(action=AuditAction.REGISTER, payload={"email": "a@b.com"})
     await audit.record(action=AuditAction.LOGIN)
 
-    # Mutate the register event's payload directly in DB — bypasses app layer
+    # Disable triggers to simulate direct DB tampering, then re-enable
+    await db_session.execute(text("SET session_replication_role = 'replica'"))
     await db_session.execute(
-        text("UPDATE audit_events SET payload = :p::jsonb WHERE action = :action"),
+        text(
+            "UPDATE audit_events SET payload = CAST(:p AS jsonb) WHERE action = :action"
+        ),
         {"action": AuditAction.REGISTER, "p": '{"email":"hacked@evil.com"}'},
     )
+    await db_session.execute(text("SET session_replication_role = DEFAULT"))
     await db_session.commit()
 
     result = await audit.verify_chain()
@@ -109,9 +113,11 @@ async def test_verify_chain_detects_tampered_action(db_session: AsyncSession) ->
     actor = uuid.uuid4()
     await audit.record(action=AuditAction.LOGIN, actor_id=actor)
 
+    await db_session.execute(text("SET session_replication_role = 'replica'"))
     await db_session.execute(
         text("UPDATE audit_events SET action = 'login_failed' WHERE action = 'login'")
     )
+    await db_session.execute(text("SET session_replication_role = DEFAULT"))
     await db_session.commit()
 
     result = await audit.verify_chain()

--- a/api/tests/v1/audit/integration/conftest.py
+++ b/api/tests/v1/audit/integration/conftest.py
@@ -1,0 +1,25 @@
+from collections.abc import AsyncGenerator
+
+import pytest_asyncio
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from com.qode.qrew.v1.service.core.database import AsyncSessionLocal, engine
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def clean_db() -> None:
+    await engine.dispose()
+    async with engine.begin() as conn:
+        await conn.execute(
+            text(
+                "TRUNCATE audit_events, passkey_credentials, users"
+                " RESTART IDENTITY CASCADE"
+            )
+        )
+
+
+@pytest_asyncio.fixture
+async def db_session() -> AsyncGenerator[AsyncSession, None]:
+    async with AsyncSessionLocal() as session:
+        yield session

--- a/api/tests/v1/audit/unit/audit_service_test.py
+++ b/api/tests/v1/audit/unit/audit_service_test.py
@@ -1,0 +1,138 @@
+"""Unit tests for the Merkle hash chain logic in the audit repository."""
+
+import hashlib
+import json
+import uuid
+from datetime import UTC, datetime
+
+from com.qode.qrew.v1.service.models.audit import AuditAction, AuditEvent
+from com.qode.qrew.v1.service.repositories.audit import (
+    compute_hash,
+    event_to_hashable,
+)
+
+
+def _make_event(
+    action: str = AuditAction.GENESIS,
+    actor_id: uuid.UUID | None = None,
+    prev_hash: bytes | None = None,
+) -> AuditEvent:
+    event = AuditEvent(
+        id=uuid.uuid4(),
+        actor_id=actor_id,
+        action=action,
+        entity_type="user",
+        entity_id=None,
+        ip_address=None,
+        device_fingerprint_hash=None,
+        user_agent=None,
+        payload={},
+        created_at=datetime(2026, 5, 20, 12, 0, 0, tzinfo=UTC),
+        prev_hash=prev_hash,
+        hash=b"",
+    )
+    event.hash = compute_hash(prev_hash, event_to_hashable(event))
+    return event
+
+
+# ── compute_hash ──────────────────────────────────────────────────────────────
+
+
+def test_compute_hash_produces_32_bytes() -> None:
+    data: dict[str, object] = {"key": "value"}
+    result = compute_hash(None, data)
+    assert len(result) == 32
+
+
+def test_compute_hash_is_deterministic() -> None:
+    data: dict[str, object] = {"id": "abc", "action": "register"}
+    h1 = compute_hash(None, data)
+    h2 = compute_hash(None, data)
+    assert h1 == h2
+
+
+def test_compute_hash_changes_when_data_changes() -> None:
+    data_a: dict[str, object] = {"action": "register"}
+    data_b: dict[str, object] = {"action": "logout"}
+    assert compute_hash(None, data_a) != compute_hash(None, data_b)
+
+
+def test_compute_hash_changes_when_prev_hash_changes() -> None:
+    data: dict[str, object] = {"action": "login"}
+    prev_a = b"\x00" * 32
+    prev_b = b"\xff" * 32
+    assert compute_hash(prev_a, data) != compute_hash(prev_b, data)
+
+
+def test_compute_hash_with_none_prev_differs_from_zero_prev() -> None:
+    data: dict[str, object] = {"action": "login"}
+    assert compute_hash(None, data) != compute_hash(b"\x00" * 32, data)
+
+
+def test_compute_hash_matches_manual_sha256() -> None:
+    data: dict[str, object] = {"id": "x", "action": "genesis"}
+    canonical = json.dumps(
+        data, sort_keys=True, default=str, separators=(",", ":")
+    ).encode()
+    expected = hashlib.sha256(canonical).digest()
+    assert compute_hash(None, data) == expected
+
+
+# ── event_to_hashable ─────────────────────────────────────────────────────────
+
+
+def test_event_to_hashable_excludes_hash_fields() -> None:
+    event = _make_event()
+    hashable = event_to_hashable(event)
+    assert "hash" not in hashable
+    assert "prev_hash" not in hashable
+
+
+def test_event_to_hashable_includes_required_fields() -> None:
+    actor = uuid.uuid4()
+    event = _make_event(actor_id=actor)
+    hashable = event_to_hashable(event)
+    assert hashable["id"] == str(event.id)
+    assert hashable["actor_id"] == str(actor)
+    assert hashable["action"] == AuditAction.GENESIS
+    assert "created_at" in hashable
+
+
+# ── chain integrity ───────────────────────────────────────────────────────────
+
+
+def test_chain_of_two_events_is_valid() -> None:
+    genesis = _make_event(action=AuditAction.GENESIS, prev_hash=None)
+    second = _make_event(action=AuditAction.REGISTER, prev_hash=genesis.hash)
+
+    assert genesis.prev_hash is None
+    assert second.prev_hash == genesis.hash
+
+    # Verify genesis
+    expected_genesis = compute_hash(None, event_to_hashable(genesis))
+    assert genesis.hash == expected_genesis
+
+    # Verify second
+    expected_second = compute_hash(genesis.hash, event_to_hashable(second))
+    assert second.hash == expected_second
+
+
+def test_mutating_event_breaks_its_hash() -> None:
+    event = _make_event(action=AuditAction.REGISTER, prev_hash=None)
+    original_hash = event.hash
+
+    event.action = AuditAction.LOGOUT  # tamper
+
+    recomputed = compute_hash(event.prev_hash, event_to_hashable(event))
+    assert recomputed != original_hash
+
+
+def test_mutating_first_event_breaks_second_event_link() -> None:
+    genesis = _make_event(action=AuditAction.GENESIS, prev_hash=None)
+    second = _make_event(action=AuditAction.REGISTER, prev_hash=genesis.hash)
+
+    genesis.action = "tampered"  # mutate genesis
+
+    recomputed_genesis = compute_hash(None, event_to_hashable(genesis))
+    # genesis hash is now wrong → second's prev_hash no longer matches
+    assert second.prev_hash != recomputed_genesis

--- a/api/tests/v1/auth/integration/conftest.py
+++ b/api/tests/v1/auth/integration/conftest.py
@@ -26,7 +26,10 @@ async def clean_db() -> None:
     await engine.dispose()
     async with engine.begin() as conn:
         await conn.execute(
-            text("TRUNCATE passkey_credentials, users RESTART IDENTITY CASCADE")
+            text(
+                "TRUNCATE audit_events, passkey_credentials, users"
+                " RESTART IDENTITY CASCADE"
+            )
         )
 
 

--- a/justfile
+++ b/justfile
@@ -78,3 +78,7 @@ db-upgrade:
 # Rollback last migration
 db-downgrade:
     cd api && uv run alembic downgrade -1
+
+# Drop all tables and re-apply migrations from scratch
+db-clean:
+    cd api && uv run alembic downgrade base && uv run alembic upgrade head

--- a/uv.lock
+++ b/uv.lock
@@ -64,7 +64,7 @@ wheels = [
 
 [[package]]
 name = "api"
-version = "1.2.0"
+version = "1.3.0"
 source = { editable = "api" }
 dependencies = [
     { name = "aiosmtplib" },


### PR DESCRIPTION
## Summary

Implements a tamper-evident audit log backed by a SHA-256 Merkle hash chain. Every auditable action in the system (registration, login, KYC, passkey, tokens, etc.) is recorded as an `AuditEvent` row.

Each row stores a `prev_hash` (the hash of the previous row) and a `hash` (SHA-256 of `prev_hash_bytes || canonical_json(row_fields)`), forming a chain where any modification to a past row breaks all subsequent hashes and is detectable server-side.

All 10 services are wired with `AuditService` as the last constructor argument; audit call failures are caught and logged as warnings so they never block the main business flow.

## Verification

- `api/tests/v1/audit/unit/audit_service_test.py`
- `api/tests/v1/audit/integration/audit_chain_test.py`

## Issue Reference

Closes [QRW-71](https://github.com/cristiangilsanz/qrew/issues/71)

## Checklist
- [x] I confirm that this PR follows the project's established coding standards.