### PR TITLE
feat: implement refresh token rotation with theft detection

### DIFF
--- a/api/src/com/qode/qrew/v1/service/models/audit.py
+++ b/api/src/com/qode/qrew/v1/service/models/audit.py
@@ -21,6 +21,7 @@ class AuditAction(enum.StrEnum):
     PASSKEY_REGISTERED = "passkey_registered"
     PASSKEY_AUTHENTICATED = "passkey_authenticated"
     TOKEN_REFRESHED = "token_refreshed"  # noqa: S105
+    TOKEN_THEFT_DETECTED = "token_theft_detected"  # noqa: S105
     SETUP_COMPLETED = "setup_completed"
     GENESIS = "genesis"
 

--- a/api/src/com/qode/qrew/v1/service/schemas/auth.py
+++ b/api/src/com/qode/qrew/v1/service/schemas/auth.py
@@ -112,6 +112,7 @@ class RefreshRequest(BaseModel):
 
 class RefreshResponse(BaseModel):
     access_token: str
+    refresh_token: str
     token_type: str = "bearer"  # noqa: S105
 
 

--- a/api/src/com/qode/qrew/v1/service/services/logout.py
+++ b/api/src/com/qode/qrew/v1/service/services/logout.py
@@ -12,8 +12,8 @@ from com.qode.qrew.v1.service.services.audit import AuditService
 
 logger = structlog.get_logger(__name__)
 
-JTI_BLACKLIST_PREFIX = "blacklist:jti:"
-USER_REVOKE_ALL_PREFIX = "blacklist:all:"
+BLACKLIST_JTI_PREFIX = "blacklist:jti:"
+BLACKLIST_USER_PREFIX = "blacklist:user:"
 
 
 class LogoutError(DomainError):
@@ -49,7 +49,7 @@ class LogoutService:
         )
 
         if ttl > 0:
-            await self._redis.setex(JTI_BLACKLIST_PREFIX + jti, ttl, "1")
+            await self._redis.setex(BLACKLIST_JTI_PREFIX + jti, ttl, "1")
 
         await logger.ainfo("token_revoked", jti=jti)
 

--- a/api/src/com/qode/qrew/v1/service/services/logout.py
+++ b/api/src/com/qode/qrew/v1/service/services/logout.py
@@ -13,6 +13,7 @@ from com.qode.qrew.v1.service.services.audit import AuditService
 logger = structlog.get_logger(__name__)
 
 JTI_BLACKLIST_PREFIX = "blacklist:jti:"
+USER_REVOKE_ALL_PREFIX = "blacklist:all:"
 
 
 class LogoutError(DomainError):

--- a/api/src/com/qode/qrew/v1/service/services/refresh.py
+++ b/api/src/com/qode/qrew/v1/service/services/refresh.py
@@ -16,8 +16,8 @@ from com.qode.qrew.v1.service.repositories.user import UserRepository
 from com.qode.qrew.v1.service.schemas.auth import RefreshRequest, RefreshResponse
 from com.qode.qrew.v1.service.services.audit import AuditService
 from com.qode.qrew.v1.service.services.logout import (
-    JTI_BLACKLIST_PREFIX,
-    USER_REVOKE_ALL_PREFIX,
+    BLACKLIST_JTI_PREFIX,
+    BLACKLIST_USER_PREFIX,
 )
 from com.qode.qrew.v1.service.settings import settings
 
@@ -42,11 +42,7 @@ class RefreshService:
         self._audit = audit
 
     async def refresh(self, request: RefreshRequest) -> RefreshResponse:
-        """Issue a new access + refresh token pair, invalidating the old refresh token.
-
-        Re-use of an already-rotated token is treated as theft: all tokens for
-        the user are immediately revoked via a per-user revocation timestamp.
-        """
+        """Issue a new access + refresh token pair, invalidating the old one."""
         try:
             payload = jwt.decode(
                 request.refresh_token,
@@ -66,7 +62,7 @@ class RefreshService:
 
         jti = payload.get("jti")
         subject = payload.get("sub")
-        jti_key = JTI_BLACKLIST_PREFIX + jti if isinstance(jti, str) else None
+        jti_key = BLACKLIST_JTI_PREFIX + jti if isinstance(jti, str) else None
 
         if jti_key:
             await self._check_jti(jti_key, subject, jti)
@@ -126,7 +122,7 @@ class RefreshService:
         """Revoke all tokens for the user and record the theft event."""
         ttl = settings.refresh_token_expire_days * 24 * 3600
         await self._redis.setex(
-            USER_REVOKE_ALL_PREFIX + subject,
+            BLACKLIST_USER_PREFIX + subject,
             ttl,
             str(int(datetime.now(UTC).timestamp())),
         )
@@ -148,7 +144,7 @@ class RefreshService:
     async def _check_user_revocation(self, subject: str, iat: object) -> None:
         """Raise if a user-level revocation covers this token's issue time."""
         revoked_at_raw: bytes | None = await self._redis.get(
-            USER_REVOKE_ALL_PREFIX + subject
+            BLACKLIST_USER_PREFIX + subject
         )
         if (
             revoked_at_raw is not None
@@ -159,7 +155,7 @@ class RefreshService:
             raise RefreshError("Refresh token has been revoked")
 
     async def _rotate_jti(self, jti_key: str, exp: object) -> None:
-        """Blacklist the old JTI as 'rotated' so any replay triggers theft detection."""
+        """Blacklist the old JTI as rotated so any replay triggers theft detection."""
         ttl = (
             int(exp) - int(datetime.now(UTC).timestamp())
             if isinstance(exp, (int, float))

--- a/api/src/com/qode/qrew/v1/service/services/refresh.py
+++ b/api/src/com/qode/qrew/v1/service/services/refresh.py
@@ -1,4 +1,5 @@
 import uuid
+from datetime import UTC, datetime
 
 import jwt
 import redis.asyncio as aioredis
@@ -6,15 +7,23 @@ import structlog
 from jwt import ExpiredSignatureError, InvalidTokenError
 
 from com.qode.qrew.v1.service.core.errors import DomainError
-from com.qode.qrew.v1.service.core.security import create_access_token
+from com.qode.qrew.v1.service.core.security import (
+    create_access_token,
+    create_refresh_token,
+)
 from com.qode.qrew.v1.service.models.audit import AuditAction
 from com.qode.qrew.v1.service.repositories.user import UserRepository
 from com.qode.qrew.v1.service.schemas.auth import RefreshRequest, RefreshResponse
 from com.qode.qrew.v1.service.services.audit import AuditService
-from com.qode.qrew.v1.service.services.logout import JTI_BLACKLIST_PREFIX
+from com.qode.qrew.v1.service.services.logout import (
+    JTI_BLACKLIST_PREFIX,
+    USER_REVOKE_ALL_PREFIX,
+)
 from com.qode.qrew.v1.service.settings import settings
 
 logger = structlog.get_logger(__name__)
+
+_ROTATED = b"rotated"
 
 
 class RefreshError(DomainError):
@@ -33,7 +42,11 @@ class RefreshService:
         self._audit = audit
 
     async def refresh(self, request: RefreshRequest) -> RefreshResponse:
-        """Issue a new access token from a valid refresh token."""
+        """Issue a new access + refresh token pair, invalidating the old refresh token.
+
+        Re-use of an already-rotated token is treated as theft: all tokens for
+        the user are immediately revoked via a per-user revocation timestamp.
+        """
         try:
             payload = jwt.decode(
                 request.refresh_token,
@@ -52,15 +65,17 @@ class RefreshService:
             raise RefreshError("Invalid token type")
 
         jti = payload.get("jti")
-        key = JTI_BLACKLIST_PREFIX + jti if isinstance(jti, str) else None
-        if key and await self._redis.exists(key):
-            await logger.awarning("refresh_failed", reason="token_revoked")
-            raise RefreshError("Refresh token has been revoked")
-
         subject = payload.get("sub")
+        jti_key = JTI_BLACKLIST_PREFIX + jti if isinstance(jti, str) else None
+
+        if jti_key:
+            await self._check_jti(jti_key, subject, jti)
+
         if not isinstance(subject, str):
             await logger.awarning("refresh_failed", reason="invalid_subject")
             raise RefreshError("Invalid refresh token")
+
+        await self._check_user_revocation(subject, payload.get("iat"))
 
         try:
             user_id = uuid.UUID(subject)
@@ -73,9 +88,13 @@ class RefreshService:
             await logger.awarning("refresh_failed", reason="user_not_found_or_inactive")
             raise RefreshError("Invalid refresh token")
 
-        access_token = create_access_token(str(user.id))
-        await logger.ainfo("token_refreshed", user_id=str(user.id))
+        if jti_key:
+            await self._rotate_jti(jti_key, payload.get("exp"))
 
+        access_token = create_access_token(str(user.id))
+        new_refresh_token = create_refresh_token(str(user.id))
+
+        await logger.ainfo("token_refreshed", user_id=str(user.id))
         try:
             await self._audit.record(
                 action=AuditAction.TOKEN_REFRESHED,
@@ -88,4 +107,63 @@ class RefreshService:
                 "audit_write_failed", action=AuditAction.TOKEN_REFRESHED
             )
 
-        return RefreshResponse(access_token=access_token)
+        return RefreshResponse(
+            access_token=access_token,
+            refresh_token=new_refresh_token,
+        )
+
+    async def _check_jti(self, jti_key: str, subject: object, jti: object) -> None:
+        """Raise if the JTI is blacklisted; trigger theft detection on replay."""
+        stored: bytes | None = await self._redis.get(jti_key)
+        if stored is None:
+            return
+        if stored == _ROTATED and isinstance(subject, str) and isinstance(jti, str):
+            await self._handle_theft(subject, jti)
+        await logger.awarning("refresh_failed", reason="token_revoked")
+        raise RefreshError("Refresh token has been revoked")
+
+    async def _handle_theft(self, subject: str, jti: str) -> None:
+        """Revoke all tokens for the user and record the theft event."""
+        ttl = settings.refresh_token_expire_days * 24 * 3600
+        await self._redis.setex(
+            USER_REVOKE_ALL_PREFIX + subject,
+            ttl,
+            str(int(datetime.now(UTC).timestamp())),
+        )
+        await logger.awarning("refresh_theft_detected", user_id=subject, jti=jti)
+        try:
+            actor_id = uuid.UUID(subject)
+            await self._audit.record(
+                action=AuditAction.TOKEN_THEFT_DETECTED,
+                actor_id=actor_id,
+                entity_type="user",
+                entity_id=subject,
+                payload={"jti": jti},
+            )
+        except Exception:
+            await logger.awarning(
+                "audit_write_failed", action=AuditAction.TOKEN_THEFT_DETECTED
+            )
+
+    async def _check_user_revocation(self, subject: str, iat: object) -> None:
+        """Raise if a user-level revocation covers this token's issue time."""
+        revoked_at_raw: bytes | None = await self._redis.get(
+            USER_REVOKE_ALL_PREFIX + subject
+        )
+        if (
+            revoked_at_raw is not None
+            and isinstance(iat, (int, float))
+            and int(iat) <= int(revoked_at_raw)
+        ):
+            await logger.awarning("refresh_failed", reason="all_tokens_revoked")
+            raise RefreshError("Refresh token has been revoked")
+
+    async def _rotate_jti(self, jti_key: str, exp: object) -> None:
+        """Blacklist the old JTI as 'rotated' so any replay triggers theft detection."""
+        ttl = (
+            int(exp) - int(datetime.now(UTC).timestamp())
+            if isinstance(exp, (int, float))
+            else 0
+        )
+        if ttl > 0:
+            await self._redis.setex(jti_key, ttl, "rotated")

--- a/api/tests/v1/admin/integration/kyc_review_flow_test.py
+++ b/api/tests/v1/admin/integration/kyc_review_flow_test.py
@@ -71,17 +71,20 @@ async def test_admin_can_approve_pending_kyc(
     client: AsyncClient,
     db_session: AsyncSession,
 ) -> None:
+    # Given
     user = await _create_pending_user(client, db_session)
 
     user.is_admin = True
     await db_session.commit()
 
+    # When
     response = await client.post(
         f"/v1/admin/kyc/{user.id}/review",
         json={"action": "approve"},
         headers=_admin_auth(user),
     )
 
+    # Then
     assert response.status_code == 200
     body = response.json()
     assert body["kyc_status"] == "approved"
@@ -96,17 +99,20 @@ async def test_admin_can_reject_pending_kyc_with_reason(
     client: AsyncClient,
     db_session: AsyncSession,
 ) -> None:
+    # Given
     user = await _create_pending_user(client, db_session)
 
     user.is_admin = True
     await db_session.commit()
 
+    # When
     response = await client.post(
         f"/v1/admin/kyc/{user.id}/review",
         json={"action": "reject", "reason": "Document is not readable"},
         headers=_admin_auth(user),
     )
 
+    # Then
     assert response.status_code == 200
     assert response.json()["kyc_status"] == "rejected"
 
@@ -122,13 +128,17 @@ async def test_non_admin_cannot_review_kyc(
     client: AsyncClient,
     db_session: AsyncSession,
 ) -> None:
+    # Given
     user = await _create_pending_user(client, db_session)
 
+    # When
     response = await client.post(
         f"/v1/admin/kyc/{user.id}/review",
         json={"action": "approve"},
         headers=_admin_auth(user),
     )
+
+    # Then
     assert response.status_code == 403
 
 
@@ -137,17 +147,21 @@ async def test_cannot_review_non_pending_kyc(
     client: AsyncClient,
     db_session: AsyncSession,
 ) -> None:
+    # Given
     user = await _create_pending_user(client, db_session)
 
     user.is_admin = True
     user.kyc_status = KycStatus.approved
     await db_session.commit()
 
+    # When
     response = await client.post(
         f"/v1/admin/kyc/{user.id}/review",
         json={"action": "approve"},
         headers=_admin_auth(user),
     )
+
+    # Then
     assert response.status_code == 400
     assert "not pending" in response.json()["detail"]["message"].lower()
 
@@ -157,6 +171,7 @@ async def test_returns_400_for_unknown_user(
     client: AsyncClient,
     db_session: AsyncSession,
 ) -> None:
+    # Given
     result = await db_session.execute(select(User).limit(1))
     existing = result.scalar_one_or_none()
     if existing is None:
@@ -166,11 +181,15 @@ async def test_returns_400_for_unknown_user(
     await db_session.commit()
 
     fake_id = uuid.uuid4()
+
+    # When
     response = await client.post(
         f"/v1/admin/kyc/{fake_id}/review",
         json={"action": "approve"},
         headers=_admin_auth(existing),
     )
+
+    # Then
     assert response.status_code == 400
     assert "not found" in response.json()["detail"]["message"].lower()
 
@@ -184,6 +203,7 @@ async def test_kyc_upload_auto_approves_when_flag_enabled(
     db_session: AsyncSession,
 ) -> None:
     """When kyc_auto_approve is True the upload response returns approved."""
+    # Given
     r = await client.post("/v1/auth/register", json=_REGISTER_PAYLOAD)
     assert r.status_code == 201
 
@@ -199,6 +219,7 @@ async def test_kyc_upload_auto_approves_when_flag_enabled(
     )
     auth = {"Authorization": f"Bearer {r.json()['access_token']}"}
 
+    # When
     with patch("com.qode.qrew.v1.service.services.kyc.settings") as mock_settings:
         mock_settings.kyc_auto_approve = True
         mock_settings.max_file_bytes = 10 * 1024 * 1024
@@ -209,6 +230,7 @@ async def test_kyc_upload_auto_approves_when_flag_enabled(
             headers=auth,
         )
 
+    # Then
     assert r.status_code == 200
     assert r.json()["kyc_status"] == "approved"
 

--- a/api/tests/v1/admin/unit/kyc_review_test.py
+++ b/api/tests/v1/admin/unit/kyc_review_test.py
@@ -54,8 +54,10 @@ def override_dependencies(mock_service: AsyncMock) -> Iterator[None]:
 async def test_approve_returns_200_with_approved_status(
     client: AsyncClient, mock_service: AsyncMock
 ) -> None:
+    # When
     response = await client.post(_ENDPOINT, json={"action": "approve"})
 
+    # Then
     assert response.status_code == 200
     body = response.json()
     assert body["kyc_status"] == "approved"
@@ -65,12 +67,15 @@ async def test_approve_returns_200_with_approved_status(
 async def test_reject_returns_200_with_rejected_status(
     client: AsyncClient, mock_service: AsyncMock
 ) -> None:
+    # Given
     mock_service.review.return_value = _mock_reviewed_user(KycStatus.rejected)
 
+    # When
     response = await client.post(
         _ENDPOINT, json={"action": "reject", "reason": "Blurry document"}
     )
 
+    # Then
     assert response.status_code == 200
     assert response.json()["kyc_status"] == "rejected"
 
@@ -78,9 +83,12 @@ async def test_reject_returns_200_with_rejected_status(
 async def test_calls_service_with_correct_args(
     client: AsyncClient, mock_service: AsyncMock
 ) -> None:
+    # When
     await client.post(
         _ENDPOINT, json={"action": "reject", "reason": "Could not verify"}
     )
+
+    # Then
     mock_service.review.assert_awaited_once()
     call_kwargs = mock_service.review.call_args
     assert call_kwargs.args[1].value == "reject"
@@ -88,7 +96,10 @@ async def test_calls_service_with_correct_args(
 
 
 async def test_reason_is_optional(client: AsyncClient, mock_service: AsyncMock) -> None:
+    # When
     response = await client.post(_ENDPOINT, json={"action": "approve"})
+
+    # Then
     assert response.status_code == 200
 
 
@@ -98,8 +109,13 @@ async def test_reason_is_optional(client: AsyncClient, mock_service: AsyncMock) 
 async def test_returns_400_when_user_not_found(
     client: AsyncClient, mock_service: AsyncMock
 ) -> None:
+    # Given
     mock_service.review.side_effect = KycReviewError("User not found", field="user_id")
+
+    # When
     response = await client.post(_ENDPOINT, json={"action": "approve"})
+
+    # Then
     assert response.status_code == 400
     assert response.json()["detail"]["field"] == "user_id"
 
@@ -107,10 +123,15 @@ async def test_returns_400_when_user_not_found(
 async def test_returns_400_when_kyc_not_pending(
     client: AsyncClient, mock_service: AsyncMock
 ) -> None:
+    # Given
     mock_service.review.side_effect = KycReviewError(
         "KYC is not pending (current status: approved)", field="kyc_status"
     )
+
+    # When
     response = await client.post(_ENDPOINT, json={"action": "approve"})
+
+    # Then
     assert response.status_code == 400
     assert response.json()["detail"]["field"] == "kyc_status"
 
@@ -119,13 +140,18 @@ async def test_returns_400_when_kyc_not_pending(
 
 
 async def test_returns_403_for_non_admin(client: AsyncClient) -> None:
+    # Given
     app.dependency_overrides[get_admin_user] = lambda: (_ for _ in ()).throw(
         __import__("fastapi").HTTPException(
             status_code=403,
             detail={"message": "Admin access required", "field": None},
         )
     )
+
+    # When
     response = await client.post(_ENDPOINT, json={"action": "approve"})
+
+    # Then
     assert response.status_code == 403
 
 
@@ -133,17 +159,26 @@ async def test_returns_403_for_non_admin(client: AsyncClient) -> None:
 
 
 async def test_rejects_invalid_action(client: AsyncClient) -> None:
+    # When
     response = await client.post(_ENDPOINT, json={"action": "delete"})
+
+    # Then
     assert response.status_code == 422
 
 
 async def test_rejects_missing_action(client: AsyncClient) -> None:
+    # When
     response = await client.post(_ENDPOINT, json={})
+
+    # Then
     assert response.status_code == 422
 
 
 async def test_rejects_reason_too_long(client: AsyncClient) -> None:
+    # When
     response = await client.post(
         _ENDPOINT, json={"action": "reject", "reason": "x" * 501}
     )
+
+    # Then
     assert response.status_code == 422

--- a/api/tests/v1/audit/integration/audit_chain_test.py
+++ b/api/tests/v1/audit/integration/audit_chain_test.py
@@ -19,9 +19,13 @@ pytestmark = pytest.mark.integration
 
 
 async def test_record_persists_event(db_session: AsyncSession) -> None:
+    # Given
     audit = AuditService()
+
+    # When
     await audit.record(action=AuditAction.REGISTER, payload={"test": True})
 
+    # Then
     result = await db_session.execute(
         select(AuditEvent).where(AuditEvent.action == AuditAction.REGISTER)
     )
@@ -32,9 +36,13 @@ async def test_record_persists_event(db_session: AsyncSession) -> None:
 
 
 async def test_genesis_event_has_no_prev_hash(db_session: AsyncSession) -> None:
+    # Given
     audit = AuditService()
+
+    # When
     await audit.ensure_genesis()
 
+    # Then
     result = await db_session.execute(
         select(AuditEvent).where(AuditEvent.action == AuditAction.GENESIS)
     )
@@ -45,10 +53,14 @@ async def test_genesis_event_has_no_prev_hash(db_session: AsyncSession) -> None:
 async def test_second_event_prev_hash_equals_genesis_hash(
     db_session: AsyncSession,
 ) -> None:
+    # Given
     audit = AuditService()
     await audit.ensure_genesis()
+
+    # When
     await audit.record(action=AuditAction.REGISTER)
 
+    # Then
     result = await db_session.execute(
         select(AuditEvent).order_by(AuditEvent.created_at.asc(), AuditEvent.id.asc())
     )
@@ -59,10 +71,14 @@ async def test_second_event_prev_hash_equals_genesis_hash(
 
 
 async def test_ensure_genesis_is_idempotent(db_session: AsyncSession) -> None:
+    # Given
     audit = AuditService()
+
+    # When
     await audit.ensure_genesis()
     await audit.ensure_genesis()
 
+    # Then
     result = await db_session.execute(
         select(AuditEvent).where(AuditEvent.action == AuditAction.GENESIS)
     )
@@ -73,25 +89,29 @@ async def test_ensure_genesis_is_idempotent(db_session: AsyncSession) -> None:
 
 
 async def test_verify_chain_passes_for_untampered_chain() -> None:
+    # Given
     audit = AuditService()
     await audit.ensure_genesis()
     await audit.record(action=AuditAction.REGISTER)
     await audit.record(action=AuditAction.VERIFY_EMAIL)
     await audit.record(action=AuditAction.LOGIN)
 
+    # When
     result = await audit.verify_chain()
+
+    # Then
     assert result.valid is True
     assert result.event_count == 4
     assert result.tampered_ids == []
 
 
 async def test_verify_chain_detects_tampered_payload(db_session: AsyncSession) -> None:
+    # Given
     audit = AuditService()
     await audit.ensure_genesis()
     await audit.record(action=AuditAction.REGISTER, payload={"email": "a@b.com"})
     await audit.record(action=AuditAction.LOGIN)
 
-    # Disable triggers to simulate direct DB tampering, then re-enable
     await db_session.execute(text("SET session_replication_role = 'replica'"))
     await db_session.execute(
         text(
@@ -102,12 +122,16 @@ async def test_verify_chain_detects_tampered_payload(db_session: AsyncSession) -
     await db_session.execute(text("SET session_replication_role = DEFAULT"))
     await db_session.commit()
 
+    # When
     result = await audit.verify_chain()
+
+    # Then
     assert result.valid is False
     assert len(result.tampered_ids) == 1
 
 
 async def test_verify_chain_detects_tampered_action(db_session: AsyncSession) -> None:
+    # Given
     audit = AuditService()
     await audit.ensure_genesis()
     actor = uuid.uuid4()
@@ -120,15 +144,20 @@ async def test_verify_chain_detects_tampered_action(db_session: AsyncSession) ->
     await db_session.execute(text("SET session_replication_role = DEFAULT"))
     await db_session.commit()
 
+    # When
     result = await audit.verify_chain()
+
+    # Then
     assert result.valid is False
 
 
 async def test_append_only_trigger_blocks_update(db_session: AsyncSession) -> None:
     """The DB trigger must reject any UPDATE on audit_events."""
+    # Given
     audit = AuditService()
     await audit.ensure_genesis()
 
+    # When / Then
     with pytest.raises(Exception, match="append-only"):
         await db_session.execute(
             text("UPDATE audit_events SET action = 'tampered' WHERE action = 'genesis'")
@@ -137,8 +166,10 @@ async def test_append_only_trigger_blocks_update(db_session: AsyncSession) -> No
 
 async def test_append_only_trigger_blocks_delete(db_session: AsyncSession) -> None:
     """The DB trigger must reject any DELETE on audit_events."""
+    # Given
     audit = AuditService()
     await audit.ensure_genesis()
 
+    # When / Then
     with pytest.raises(Exception, match="append-only"):
         await db_session.execute(text("DELETE FROM audit_events"))

--- a/api/tests/v1/audit/unit/audit_service_test.py
+++ b/api/tests/v1/audit/unit/audit_service_test.py
@@ -39,42 +39,64 @@ def _make_event(
 
 
 def test_compute_hash_produces_32_bytes() -> None:
+    # Given
     data: dict[str, object] = {"key": "value"}
+
+    # When
     result = compute_hash(None, data)
+
+    # Then
     assert len(result) == 32
 
 
 def test_compute_hash_is_deterministic() -> None:
+    # Given
     data: dict[str, object] = {"id": "abc", "action": "register"}
+
+    # When
     h1 = compute_hash(None, data)
     h2 = compute_hash(None, data)
+
+    # Then
     assert h1 == h2
 
 
 def test_compute_hash_changes_when_data_changes() -> None:
+    # Given
     data_a: dict[str, object] = {"action": "register"}
     data_b: dict[str, object] = {"action": "logout"}
+
+    # Then
     assert compute_hash(None, data_a) != compute_hash(None, data_b)
 
 
 def test_compute_hash_changes_when_prev_hash_changes() -> None:
+    # Given
     data: dict[str, object] = {"action": "login"}
     prev_a = b"\x00" * 32
     prev_b = b"\xff" * 32
+
+    # Then
     assert compute_hash(prev_a, data) != compute_hash(prev_b, data)
 
 
 def test_compute_hash_with_none_prev_differs_from_zero_prev() -> None:
+    # Given
     data: dict[str, object] = {"action": "login"}
+
+    # Then
     assert compute_hash(None, data) != compute_hash(b"\x00" * 32, data)
 
 
 def test_compute_hash_matches_manual_sha256() -> None:
+    # Given
     data: dict[str, object] = {"id": "x", "action": "genesis"}
     canonical = json.dumps(
         data, sort_keys=True, default=str, separators=(",", ":")
     ).encode()
     expected = hashlib.sha256(canonical).digest()
+
+    # Then
     assert compute_hash(None, data) == expected
 
 
@@ -82,16 +104,26 @@ def test_compute_hash_matches_manual_sha256() -> None:
 
 
 def test_event_to_hashable_excludes_hash_fields() -> None:
+    # Given
     event = _make_event()
+
+    # When
     hashable = event_to_hashable(event)
+
+    # Then
     assert "hash" not in hashable
     assert "prev_hash" not in hashable
 
 
 def test_event_to_hashable_includes_required_fields() -> None:
+    # Given
     actor = uuid.uuid4()
     event = _make_event(actor_id=actor)
+
+    # When
     hashable = event_to_hashable(event)
+
+    # Then
     assert hashable["id"] == str(event.id)
     assert hashable["actor_id"] == str(actor)
     assert hashable["action"] == AuditAction.GENESIS
@@ -102,37 +134,42 @@ def test_event_to_hashable_includes_required_fields() -> None:
 
 
 def test_chain_of_two_events_is_valid() -> None:
+    # Given
     genesis = _make_event(action=AuditAction.GENESIS, prev_hash=None)
     second = _make_event(action=AuditAction.REGISTER, prev_hash=genesis.hash)
 
+    # Then
     assert genesis.prev_hash is None
     assert second.prev_hash == genesis.hash
 
-    # Verify genesis
     expected_genesis = compute_hash(None, event_to_hashable(genesis))
     assert genesis.hash == expected_genesis
 
-    # Verify second
     expected_second = compute_hash(genesis.hash, event_to_hashable(second))
     assert second.hash == expected_second
 
 
 def test_mutating_event_breaks_its_hash() -> None:
+    # Given
     event = _make_event(action=AuditAction.REGISTER, prev_hash=None)
     original_hash = event.hash
 
-    event.action = AuditAction.LOGOUT  # tamper
+    # When
+    event.action = AuditAction.LOGOUT
 
+    # Then
     recomputed = compute_hash(event.prev_hash, event_to_hashable(event))
     assert recomputed != original_hash
 
 
 def test_mutating_first_event_breaks_second_event_link() -> None:
+    # Given
     genesis = _make_event(action=AuditAction.GENESIS, prev_hash=None)
     second = _make_event(action=AuditAction.REGISTER, prev_hash=genesis.hash)
 
-    genesis.action = "tampered"  # mutate genesis
+    # When
+    genesis.action = "tampered"
 
+    # Then
     recomputed_genesis = compute_hash(None, event_to_hashable(genesis))
-    # genesis hash is now wrong → second's prev_hash no longer matches
     assert second.prev_hash != recomputed_genesis

--- a/api/tests/v1/auth/integration/auth_flow_test.py
+++ b/api/tests/v1/auth/integration/auth_flow_test.py
@@ -464,3 +464,58 @@ async def test_logout_with_invalid_token_returns_401(
         "/v1/auth/logout", json={"refresh_token": "not.a.valid.token"}
     )
     assert r.status_code == 401
+
+
+# ── Refresh token rotation ────────────────────────────────────────────────────
+
+
+@pytest.mark.integration
+async def test_refresh_rotates_token(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Each /refresh call returns a new refresh token; old one is invalidated."""
+    await _register(client)
+    user = await _fetch_user(db_session)
+    await _verify_email(client, str(user.email_verification_token))
+
+    original = create_refresh_token(str(user.id))
+
+    r = await client.post("/v1/auth/refresh", json={"refresh_token": original})
+    assert r.status_code == 200
+    body = r.json()
+    assert "access_token" in body
+    assert "refresh_token" in body
+    new_token = body["refresh_token"]
+    assert new_token != original
+
+    # Old token must now be rejected
+    r2 = await client.post("/v1/auth/refresh", json={"refresh_token": original})
+    assert r2.status_code == 401
+    assert "revoked" in r2.json()["detail"]["message"].lower()
+
+
+@pytest.mark.integration
+async def test_refresh_reuse_after_rotation_triggers_revocation(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Replaying a rotated refresh token invalidates all tokens for the user."""
+    await _register(client)
+    user = await _fetch_user(db_session)
+    await _verify_email(client, str(user.email_verification_token))
+
+    original = create_refresh_token(str(user.id))
+
+    # First rotation — legitimate
+    r = await client.post("/v1/auth/refresh", json={"refresh_token": original})
+    assert r.status_code == 200
+    new_token = r.json()["refresh_token"]
+
+    # Replay the already-rotated original → theft detected, all tokens revoked
+    r2 = await client.post("/v1/auth/refresh", json={"refresh_token": original})
+    assert r2.status_code == 401
+
+    # The newly issued token is now also revoked because of the user-level revocation
+    r3 = await client.post("/v1/auth/refresh", json={"refresh_token": new_token})
+    assert r3.status_code == 401

--- a/api/tests/v1/auth/integration/auth_flow_test.py
+++ b/api/tests/v1/auth/integration/auth_flow_test.py
@@ -86,12 +86,11 @@ async def test_full_post_login_verification_flow(  # noqa: PLR0915
 ) -> None:
     """register → verify email → login → verify phone → KYC upload → passkey begin/complete"""  # noqa: E501
 
-    # 1. Register
+    # Given
     response = await client.post("/v1/auth/register", json=_REGISTER_PAYLOAD)
     assert response.status_code == 201
     assert "Registration successful" in response.json()["message"]
 
-    # 2. Read token + OTP
     user = await _fetch_user(db_session)
     assert not user.email_verified
     assert not user.phone_number_verified
@@ -102,14 +101,15 @@ async def test_full_post_login_verification_flow(  # noqa: PLR0915
     assert email_token is not None
     assert phone_otp is not None
 
-    # 3. Verify email
     response = await client.post("/v1/auth/verify-email", json={"token": email_token})
     assert response.status_code == 200
 
-    # 4. Login
+    # When
     response = await client.post(
         "/v1/auth/login", json={"email": _EMAIL, "password": _PASSWORD}
     )
+
+    # Then
     assert response.status_code == 200
     body = response.json()
     assert body["setup_required"] is True
@@ -117,7 +117,6 @@ async def test_full_post_login_verification_flow(  # noqa: PLR0915
     access_token = body["access_token"]
     auth = {"Authorization": f"Bearer {access_token}"}
 
-    # 5. Verify phone
     response = await client.post(
         "/v1/auth/verify-phone",
         json={"phone_number": _PHONE, "otp": phone_otp},
@@ -129,7 +128,6 @@ async def test_full_post_login_verification_flow(  # noqa: PLR0915
     assert user.phone_number_verified
     assert user.phone_number_otp is None
 
-    # 6. KYC upload
     response = await client.post(
         "/v1/auth/kyc/upload",
         files={"document": ("id.jpg", b"fake-national-id-content", "image/jpeg")},
@@ -142,7 +140,6 @@ async def test_full_post_login_verification_flow(  # noqa: PLR0915
     assert user.kyc_status == KycStatus.pending
     assert user.national_id_hash is not None
 
-    # 7. Passkey register/begin
     response = await client.post("/v1/auth/passkey/register/begin", headers=auth)
     assert response.status_code == 200
     assert "challenge" in response.json()
@@ -150,7 +147,6 @@ async def test_full_post_login_verification_flow(  # noqa: PLR0915
     challenge_key = f"webauthn:challenge:{user.id}"
     assert await redis_test.get(challenge_key) is not None
 
-    # 8. Passkey register/complete
     with patch(
         "com.qode.qrew.v1.service.services.passkey.webauthn.verify_registration_response",
         return_value=_fake_verified_registration(),
@@ -173,7 +169,6 @@ async def test_full_post_login_verification_flow(  # noqa: PLR0915
     assert cred.public_key == b"fake-public-key"
     assert cred.sign_count == 0
 
-    # 9. Complete setup
     response = await client.post("/v1/auth/complete-setup", headers=auth)
     assert response.status_code == 200
     full = response.json()
@@ -190,11 +185,15 @@ async def test_login_rejected_before_email_verification(
     client: AsyncClient,
 ) -> None:
     """Login must be blocked until the user verifies their email."""
+    # Given
     await _register(client)
 
+    # When
     response = await client.post(
         "/v1/auth/login", json={"email": _EMAIL, "password": _PASSWORD}
     )
+
+    # Then
     assert response.status_code == 401
     assert "email" in response.json()["detail"]["message"].lower()
 
@@ -205,6 +204,7 @@ async def test_phone_verify_rejected_for_wrong_number(
     db_session: AsyncSession,
 ) -> None:
     """A user must not be able to verify a phone number that isn't theirs."""
+    # Given
     await _register(client)
     user = await _fetch_user(db_session)
     assert user.email_verification_token is not None
@@ -213,11 +213,14 @@ async def test_phone_verify_rejected_for_wrong_number(
     await _verify_email(client, user.email_verification_token)
     access_token = await _login(client)
 
+    # When
     response = await client.post(
         "/v1/auth/verify-phone",
         json={"phone_number": "+34699999999", "otp": user.phone_number_otp},
         headers={"Authorization": f"Bearer {access_token}"},
     )
+
+    # Then
     assert response.status_code == 403
 
 
@@ -227,6 +230,7 @@ async def test_kyc_upload_rejects_empty_file(
     db_session: AsyncSession,
 ) -> None:
     """KYC upload must reject an empty file with 400."""
+    # Given
     await _register(client)
     user = await _fetch_user(db_session)
     assert user.email_verification_token is not None
@@ -234,11 +238,14 @@ async def test_kyc_upload_rejects_empty_file(
     await _verify_email(client, user.email_verification_token)
     access_token = await _login(client)
 
+    # When
     response = await client.post(
         "/v1/auth/kyc/upload",
         files={"document": ("id.jpg", b"", "image/jpeg")},
         headers={"Authorization": f"Bearer {access_token}"},
     )
+
+    # Then
     assert response.status_code == 400
 
     await db_session.refresh(user)
@@ -251,6 +258,7 @@ async def test_passkey_complete_without_begin_is_rejected(
     db_session: AsyncSession,
 ) -> None:
     """Completing passkey registration without a prior begin must return 400."""
+    # Given
     await _register(client)
     user = await _fetch_user(db_session)
     assert user.email_verification_token is not None
@@ -258,7 +266,7 @@ async def test_passkey_complete_without_begin_is_rejected(
     await _verify_email(client, user.email_verification_token)
     access_token = await _login(client)
 
-    # Skip begin — no challenge in Redis
+    # When
     with patch(
         "com.qode.qrew.v1.service.services.passkey.webauthn.verify_registration_response",
         return_value=_fake_verified_registration(),
@@ -268,6 +276,8 @@ async def test_passkey_complete_without_begin_is_rejected(
             json=_FAKE_ATTESTATION,
             headers={"Authorization": f"Bearer {access_token}"},
         )
+
+    # Then
     assert response.status_code == 400
     assert "expired" in response.json()["detail"]["message"].lower()
 
@@ -279,7 +289,7 @@ async def test_passkey_authentication_flow(
     redis_test: aioredis.Redis,  # type: ignore[type-arg]
 ) -> None:
     """Full passkey authentication: register passkey then authenticate with it."""
-    # 1. Complete the full onboarding flow first (reuse helpers)
+    # Given
     await _register(client)
     user = await _fetch_user(db_session)
     assert user.email_verification_token is not None
@@ -288,21 +298,18 @@ async def test_passkey_authentication_flow(
     setup_token = await _login(client)
     auth = {"Authorization": f"Bearer {setup_token}"}
 
-    # Verify phone
     await client.post(
         "/v1/auth/verify-phone",
         json={"phone_number": _PHONE, "otp": user.phone_number_otp},
         headers=auth,
     )
 
-    # KYC upload
     await client.post(
         "/v1/auth/kyc/upload",
         files={"document": ("id.jpg", b"fake-content", "image/jpeg")},
         headers=auth,
     )
 
-    # Register passkey
     await client.post("/v1/auth/passkey/register/begin", headers=auth)
     with patch(
         "com.qode.qrew.v1.service.services.passkey.webauthn.verify_registration_response",
@@ -314,18 +321,19 @@ async def test_passkey_authentication_flow(
             headers=auth,
         )
 
-    # 2. Authenticate: begin — returns assertion options with a Redis challenge
+    # When
     response = await client.post(
         "/v1/auth/passkey/authenticate/begin",
         json={"email": _EMAIL},
     )
+
+    # Then
     assert response.status_code == 200
     assert "challenge" in response.json()
 
     challenge_key = f"webauthn:auth:challenge:{user.id}"
     assert await redis_test.get(challenge_key) is not None
 
-    # 3. Authenticate: complete — mock assertion verification
     fake_assertion: dict[str, object] = {
         "id": "ZmFrZS1jcmVkZW50aWFsLWlk",
         "rawId": "ZmFrZS1jcmVkZW50aWFsLWlk",
@@ -357,10 +365,8 @@ async def test_passkey_authentication_flow(
     assert body["refresh_token"] is not None
     assert body["access_token"] is not None
 
-    # Challenge must be consumed
     assert await redis_test.get(challenge_key) is None
 
-    # sign_count and last_used_at must be updated in DB
     await db_session.refresh(user)
     result = await db_session.execute(
         select(PasskeyCredential).where(PasskeyCredential.user_id == user.id)
@@ -375,10 +381,13 @@ async def test_passkey_authenticate_begin_rejected_for_unknown_email(
     client: AsyncClient,
 ) -> None:
     """Begin must return 400 for an email that has no account."""
+    # When
     response = await client.post(
         "/v1/auth/passkey/authenticate/begin",
         json={"email": "nobody@example.com"},
     )
+
+    # Then
     assert response.status_code == 400
 
 
@@ -388,6 +397,7 @@ async def test_passkey_authenticate_complete_without_begin_is_rejected(
     db_session: AsyncSession,
 ) -> None:
     """Completing passkey authentication without a prior begin must return 400."""
+    # Given
     await _register(client)
     user = await _fetch_user(db_session)
     assert user.email_verification_token is not None
@@ -396,7 +406,6 @@ async def test_passkey_authenticate_complete_without_begin_is_rejected(
     setup_token = await _login(client)
     auth = {"Authorization": f"Bearer {setup_token}"}
 
-    # Register a passkey so the credential exists in the DB
     await client.post("/v1/auth/passkey/register/begin", headers=auth)
     with patch(
         "com.qode.qrew.v1.service.services.passkey.webauthn.verify_registration_response",
@@ -408,7 +417,6 @@ async def test_passkey_authenticate_complete_without_begin_is_rejected(
             headers=auth,
         )
 
-    # Skip authenticate/begin — no auth challenge in Redis
     fake_assertion: dict[str, object] = {
         "id": "ZmFrZS1jcmVkZW50aWFsLWlk",
         "rawId": "ZmFrZS1jcmVkZW50aWFsLWlk",
@@ -419,6 +427,8 @@ async def test_passkey_authenticate_complete_without_begin_is_rejected(
         },
         "type": "public-key",
     }
+
+    # When
     with patch(
         "com.qode.qrew.v1.service.services.passkey.webauthn.verify_authentication_response",
         return_value=MagicMock(new_sign_count=1),
@@ -427,6 +437,8 @@ async def test_passkey_authenticate_complete_without_begin_is_rejected(
             "/v1/auth/passkey/authenticate/complete",
             json=fake_assertion,
         )
+
+    # Then
     assert response.status_code == 400
     assert "expired" in response.json()["detail"]["message"].lower()
 
@@ -440,13 +452,17 @@ async def test_logout_invalidates_refresh_token(
     db_session: AsyncSession,
 ) -> None:
     """Logout → subsequent refresh is rejected with 401."""
+    # Given
     await _register(client)
     user = await _fetch_user(db_session)
     await _verify_email(client, str(user.email_verification_token))
 
     refresh_token = create_refresh_token(str(user.id))
 
+    # When
     r = await client.post("/v1/auth/logout", json={"refresh_token": refresh_token})
+
+    # Then
     assert r.status_code == 200
     assert "logged out" in r.json()["message"].lower()
 
@@ -460,9 +476,12 @@ async def test_logout_with_invalid_token_returns_401(
     client: AsyncClient,
     db_session: AsyncSession,
 ) -> None:
+    # When
     r = await client.post(
         "/v1/auth/logout", json={"refresh_token": "not.a.valid.token"}
     )
+
+    # Then
     assert r.status_code == 401
 
 
@@ -475,13 +494,17 @@ async def test_refresh_rotates_token(
     db_session: AsyncSession,
 ) -> None:
     """Each /refresh call returns a new refresh token; old one is invalidated."""
+    # Given
     await _register(client)
     user = await _fetch_user(db_session)
     await _verify_email(client, str(user.email_verification_token))
 
     original = create_refresh_token(str(user.id))
 
+    # When
     r = await client.post("/v1/auth/refresh", json={"refresh_token": original})
+
+    # Then
     assert r.status_code == 200
     body = r.json()
     assert "access_token" in body
@@ -489,7 +512,6 @@ async def test_refresh_rotates_token(
     new_token = body["refresh_token"]
     assert new_token != original
 
-    # Old token must now be rejected
     r2 = await client.post("/v1/auth/refresh", json={"refresh_token": original})
     assert r2.status_code == 401
     assert "revoked" in r2.json()["detail"]["message"].lower()
@@ -501,21 +523,22 @@ async def test_refresh_reuse_after_rotation_triggers_revocation(
     db_session: AsyncSession,
 ) -> None:
     """Replaying a rotated refresh token invalidates all tokens for the user."""
+    # Given
     await _register(client)
     user = await _fetch_user(db_session)
     await _verify_email(client, str(user.email_verification_token))
 
     original = create_refresh_token(str(user.id))
 
-    # First rotation — legitimate
     r = await client.post("/v1/auth/refresh", json={"refresh_token": original})
     assert r.status_code == 200
     new_token = r.json()["refresh_token"]
 
-    # Replay the already-rotated original → theft detected, all tokens revoked
+    # When
     r2 = await client.post("/v1/auth/refresh", json={"refresh_token": original})
+
+    # Then
     assert r2.status_code == 401
 
-    # The newly issued token is now also revoked because of the user-level revocation
     r3 = await client.post("/v1/auth/refresh", json={"refresh_token": new_token})
     assert r3.status_code == 401

--- a/api/tests/v1/auth/unit/auth_test.py
+++ b/api/tests/v1/auth/unit/auth_test.py
@@ -14,12 +14,15 @@ _USER_ID = "00000000-0000-0000-0000-000000000001"
 
 async def test_get_current_user_rejects_setup_token_with_403() -> None:
     """A setup-scoped token must be rejected with 403 by get_current_user."""
+    # Given
     token = create_setup_token(_USER_ID)
     credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials=token)
 
+    # When
     with pytest.raises(HTTPException) as exc_info:
         await get_current_user(credentials=credentials, db=AsyncMock())
 
+    # Then
     assert exc_info.value.status_code == 403
     detail: dict[str, str | None] = exc_info.value.detail  # type: ignore[assignment]
     assert "Setup not complete" in (detail["message"] or "")

--- a/api/tests/v1/auth/unit/complete_setup_test.py
+++ b/api/tests/v1/auth/unit/complete_setup_test.py
@@ -43,13 +43,16 @@ def override_dependencies(mock_service: AsyncMock) -> Iterator[None]:
 async def test_complete_setup_returns_200_with_full_tokens(
     client: AsyncClient, mock_service: AsyncMock
 ) -> None:
+    # Given
     mock_service.complete.return_value = LoginResponse(
         access_token="full.access.token",
         refresh_token="full.refresh.token",
     )
 
+    # When
     response = await client.post(_ENDPOINT)
 
+    # Then
     assert response.status_code == 200
     body = response.json()
     assert body["access_token"] == "full.access.token"
@@ -60,10 +63,15 @@ async def test_complete_setup_returns_200_with_full_tokens(
 async def test_complete_setup_calls_service_with_current_user(
     client: AsyncClient, mock_service: AsyncMock
 ) -> None:
+    # Given
     mock_service.complete.return_value = LoginResponse(
         access_token="a.b.c", refresh_token="d.e.f"
     )
+
+    # When
     await client.post(_ENDPOINT)
+
+    # Then
     mock_service.complete.assert_awaited_once()
 
 
@@ -73,10 +81,15 @@ async def test_complete_setup_calls_service_with_current_user(
 async def test_returns_400_when_phone_not_verified(
     client: AsyncClient, mock_service: AsyncMock
 ) -> None:
+    # Given
     mock_service.complete.side_effect = SetupError(
         "Phone number is not verified", field="phone_number"
     )
+
+    # When
     response = await client.post(_ENDPOINT)
+
+    # Then
     assert response.status_code == 400
     assert response.json()["detail"]["field"] == "phone_number"
 
@@ -84,10 +97,15 @@ async def test_returns_400_when_phone_not_verified(
 async def test_returns_400_when_kyc_not_submitted(
     client: AsyncClient, mock_service: AsyncMock
 ) -> None:
+    # Given
     mock_service.complete.side_effect = SetupError(
         "KYC document has not been submitted", field="kyc"
     )
+
+    # When
     response = await client.post(_ENDPOINT)
+
+    # Then
     assert response.status_code == 400
     assert response.json()["detail"]["field"] == "kyc"
 
@@ -95,9 +113,14 @@ async def test_returns_400_when_kyc_not_submitted(
 async def test_returns_400_when_passkey_not_registered(
     client: AsyncClient, mock_service: AsyncMock
 ) -> None:
+    # Given
     mock_service.complete.side_effect = SetupError(
         "Passkey has not been registered", field="passkey"
     )
+
+    # When
     response = await client.post(_ENDPOINT)
+
+    # Then
     assert response.status_code == 400
     assert response.json()["detail"]["field"] == "passkey"

--- a/api/tests/v1/auth/unit/kyc_test.py
+++ b/api/tests/v1/auth/unit/kyc_test.py
@@ -44,11 +44,13 @@ def override_dependencies(mock_service: AsyncMock) -> Iterator[None]:
 async def test_kyc_upload_returns_200(
     client: AsyncClient, mock_service: AsyncMock
 ) -> None:
+    # When
     response = await client.post(
         _ENDPOINT,
         files={"document": ("id.jpg", _FAKE_DOCUMENT, "image/jpeg")},
     )
 
+    # Then
     assert response.status_code == 200
     body = response.json()
     assert "submitted" in body["message"].lower()
@@ -58,11 +60,13 @@ async def test_kyc_upload_returns_200(
 async def test_kyc_upload_calls_service_with_content(
     client: AsyncClient, mock_service: AsyncMock
 ) -> None:
+    # When
     await client.post(
         _ENDPOINT,
         files={"document": ("id.jpg", _FAKE_DOCUMENT, "image/jpeg")},
     )
 
+    # Then
     mock_service.upload.assert_awaited_once()
     call_args = mock_service.upload.call_args[0]
     assert call_args[1] == _FAKE_DOCUMENT
@@ -74,24 +78,34 @@ async def test_kyc_upload_calls_service_with_content(
 async def test_returns_400_on_empty_document(
     client: AsyncClient, mock_service: AsyncMock
 ) -> None:
+    # Given
     mock_service.upload.side_effect = KycError("Document cannot be empty")
+
+    # When
     response = await client.post(
         _ENDPOINT,
         files={"document": ("id.jpg", b"", "image/jpeg")},
     )
+
+    # Then
     assert response.status_code == 400
 
 
 async def test_returns_400_on_oversized_document(
     client: AsyncClient, mock_service: AsyncMock
 ) -> None:
+    # Given
     mock_service.upload.side_effect = KycError(
         "Document exceeds the maximum allowed size of 10 MB"
     )
+
+    # When
     response = await client.post(
         _ENDPOINT,
         files={"document": ("id.jpg", _FAKE_DOCUMENT, "image/jpeg")},
     )
+
+    # Then
     assert response.status_code == 400
 
 
@@ -99,5 +113,8 @@ async def test_returns_400_on_oversized_document(
 
 
 async def test_rejects_missing_file(client: AsyncClient) -> None:
+    # When
     response = await client.post(_ENDPOINT)
+
+    # Then
     assert response.status_code == 422

--- a/api/tests/v1/auth/unit/login_test.py
+++ b/api/tests/v1/auth/unit/login_test.py
@@ -42,13 +42,16 @@ def override_dependencies(mock_service: AsyncMock) -> Iterator[None]:
 async def test_login_returns_200_with_tokens(
     client: AsyncClient, mock_service: AsyncMock
 ) -> None:
+    # Given
     mock_service.login.return_value = LoginResponse(
         access_token="a.b.c",
         refresh_token="d.e.f",
     )
 
+    # When
     response = await client.post(_ENDPOINT, json=_VALID_PAYLOAD)
 
+    # Then
     assert response.status_code == 200
     body = response.json()
     assert body["access_token"] == "a.b.c"
@@ -60,13 +63,16 @@ async def test_login_returns_200_with_tokens(
 async def test_login_returns_setup_token_when_setup_incomplete(
     client: AsyncClient, mock_service: AsyncMock
 ) -> None:
+    # Given
     mock_service.login.return_value = LoginResponse(
         access_token="setup.token",
         setup_required=True,
     )
 
+    # When
     response = await client.post(_ENDPOINT, json=_VALID_PAYLOAD)
 
+    # Then
     assert response.status_code == 200
     body = response.json()
     assert body["access_token"] == "setup.token"
@@ -77,13 +83,16 @@ async def test_login_returns_setup_token_when_setup_incomplete(
 async def test_login_calls_service_with_correct_args(
     client: AsyncClient, mock_service: AsyncMock
 ) -> None:
+    # Given
     mock_service.login.return_value = LoginResponse(
         access_token="a.b.c",
         refresh_token="d.e.f",
     )
 
+    # When
     await client.post(_ENDPOINT, json=_VALID_PAYLOAD)
 
+    # Then
     mock_service.login.assert_awaited_once()
     call_args = mock_service.login.call_args
     request_body = call_args[0][0]
@@ -95,31 +104,50 @@ async def test_login_calls_service_with_correct_args(
 
 
 async def test_rejects_missing_email(client: AsyncClient) -> None:
+    # Given
     payload = {k: v for k, v in _VALID_PAYLOAD.items() if k != "email"}
+
+    # When
     response = await client.post(_ENDPOINT, json=payload)
+
+    # Then
     assert response.status_code == 422
 
 
 async def test_rejects_missing_password(client: AsyncClient) -> None:
+    # Given
     payload = {k: v for k, v in _VALID_PAYLOAD.items() if k != "password"}
+
+    # When
     response = await client.post(_ENDPOINT, json=payload)
+
+    # Then
     assert response.status_code == 422
 
 
 async def test_rejects_invalid_email_format(client: AsyncClient) -> None:
+    # When
     response = await client.post(
         _ENDPOINT, json={**_VALID_PAYLOAD, "email": "not-an-email"}
     )
+
+    # Then
     assert response.status_code == 422
 
 
 async def test_rejects_empty_password(client: AsyncClient) -> None:
+    # When
     response = await client.post(_ENDPOINT, json={**_VALID_PAYLOAD, "password": ""})
+
+    # Then
     assert response.status_code == 422
 
 
 async def test_rejects_empty_body(client: AsyncClient) -> None:
+    # When
     response = await client.post(_ENDPOINT, json={})
+
+    # Then
     assert response.status_code == 422
 
 
@@ -129,32 +157,52 @@ async def test_rejects_empty_body(client: AsyncClient) -> None:
 async def test_returns_401_on_invalid_credentials(
     client: AsyncClient, mock_service: AsyncMock
 ) -> None:
+    # Given
     mock_service.login.side_effect = LoginError("Invalid email or password")
+
+    # When
     response = await client.post(_ENDPOINT, json=_VALID_PAYLOAD)
+
+    # Then
     assert response.status_code == 401
 
 
 async def test_returns_401_on_unverified_email(
     client: AsyncClient, mock_service: AsyncMock
 ) -> None:
+    # Given
     mock_service.login.side_effect = LoginError(
         "Please verify your email before logging in"
     )
+
+    # When
     response = await client.post(_ENDPOINT, json=_VALID_PAYLOAD)
+
+    # Then
     assert response.status_code == 401
 
 
 async def test_returns_401_on_deactivated_account(
     client: AsyncClient, mock_service: AsyncMock
 ) -> None:
+    # Given
     mock_service.login.side_effect = LoginError("Account has been deactivated")
+
+    # When
     response = await client.post(_ENDPOINT, json=_VALID_PAYLOAD)
+
+    # Then
     assert response.status_code == 401
 
 
 async def test_credential_error_has_no_field(
     client: AsyncClient, mock_service: AsyncMock
 ) -> None:
+    # Given
     mock_service.login.side_effect = LoginError("Invalid email or password")
+
+    # When
     response = await client.post(_ENDPOINT, json=_VALID_PAYLOAD)
+
+    # Then
     assert response.json()["detail"]["field"] is None

--- a/api/tests/v1/auth/unit/logout_test.py
+++ b/api/tests/v1/auth/unit/logout_test.py
@@ -35,8 +35,10 @@ def override_dependencies(mock_service: AsyncMock) -> Iterator[None]:
 
 
 async def test_logout_returns_200(client: AsyncClient, mock_service: AsyncMock) -> None:
+    # When
     response = await client.post(_ENDPOINT, json=_VALID_PAYLOAD)
 
+    # Then
     assert response.status_code == 200
     assert "logged out" in response.json()["message"].lower()
 
@@ -44,8 +46,10 @@ async def test_logout_returns_200(client: AsyncClient, mock_service: AsyncMock) 
 async def test_logout_calls_service_with_token(
     client: AsyncClient, mock_service: AsyncMock
 ) -> None:
+    # When
     await client.post(_ENDPOINT, json=_VALID_PAYLOAD)
 
+    # Then
     mock_service.logout.assert_awaited_once_with("a.valid.refresh.token")
 
 
@@ -53,7 +57,10 @@ async def test_expired_token_still_returns_200(
     client: AsyncClient, mock_service: AsyncMock
 ) -> None:
     """Expired tokens are silently accepted — no error, no blacklist entry."""
+    # When
     response = await client.post(_ENDPOINT, json=_VALID_PAYLOAD)
+
+    # Then
     assert response.status_code == 200
 
 
@@ -63,16 +70,26 @@ async def test_expired_token_still_returns_200(
 async def test_returns_401_on_invalid_token(
     client: AsyncClient, mock_service: AsyncMock
 ) -> None:
+    # Given
     mock_service.logout.side_effect = LogoutError("Invalid refresh token")
+
+    # When
     response = await client.post(_ENDPOINT, json=_VALID_PAYLOAD)
+
+    # Then
     assert response.status_code == 401
 
 
 async def test_returns_401_on_wrong_token_type(
     client: AsyncClient, mock_service: AsyncMock
 ) -> None:
+    # Given
     mock_service.logout.side_effect = LogoutError("Invalid token type")
+
+    # When
     response = await client.post(_ENDPOINT, json=_VALID_PAYLOAD)
+
+    # Then
     assert response.status_code == 401
 
 
@@ -80,10 +97,16 @@ async def test_returns_401_on_wrong_token_type(
 
 
 async def test_rejects_missing_refresh_token(client: AsyncClient) -> None:
+    # When
     response = await client.post(_ENDPOINT, json={})
+
+    # Then
     assert response.status_code == 422
 
 
 async def test_rejects_empty_refresh_token(client: AsyncClient) -> None:
+    # When
     response = await client.post(_ENDPOINT, json={"refresh_token": ""})
+
+    # Then
     assert response.status_code == 422

--- a/api/tests/v1/auth/unit/passkey_test.py
+++ b/api/tests/v1/auth/unit/passkey_test.py
@@ -99,8 +99,10 @@ def override_dependencies(mock_service: AsyncMock) -> Iterator[None]:
 async def test_register_begin_returns_200_with_options(
     client: AsyncClient, mock_service: AsyncMock
 ) -> None:
+    # When
     response = await client.post(_REGISTER_BEGIN_ENDPOINT)
 
+    # Then
     assert response.status_code == 200
     body = response.json()
     assert body["rp"]["name"] == "Qrew"
@@ -110,7 +112,10 @@ async def test_register_begin_returns_200_with_options(
 async def test_register_begin_calls_service_with_current_user(
     client: AsyncClient, mock_service: AsyncMock
 ) -> None:
+    # When
     await client.post(_REGISTER_BEGIN_ENDPOINT)
+
+    # Then
     mock_service.begin_registration.assert_awaited_once()
 
 
@@ -120,8 +125,10 @@ async def test_register_begin_calls_service_with_current_user(
 async def test_register_complete_returns_200(
     client: AsyncClient, mock_service: AsyncMock
 ) -> None:
+    # When
     response = await client.post(_REGISTER_COMPLETE_ENDPOINT, json=_REGISTER_PAYLOAD)
 
+    # Then
     assert response.status_code == 200
     assert "registered" in response.json()["message"].lower()
 
@@ -129,39 +136,62 @@ async def test_register_complete_returns_200(
 async def test_register_complete_calls_service_with_credential(
     client: AsyncClient, mock_service: AsyncMock
 ) -> None:
+    # When
     await client.post(_REGISTER_COMPLETE_ENDPOINT, json=_REGISTER_PAYLOAD)
+
+    # Then
     mock_service.complete_registration.assert_awaited_once()
 
 
 async def test_register_complete_returns_400_on_expired_challenge(
     client: AsyncClient, mock_service: AsyncMock
 ) -> None:
+    # Given
     mock_service.complete_registration.side_effect = PasskeyError(
         "Registration session expired. Please start again."
     )
+
+    # When
     response = await client.post(_REGISTER_COMPLETE_ENDPOINT, json=_REGISTER_PAYLOAD)
+
+    # Then
     assert response.status_code == 400
 
 
 async def test_register_complete_returns_400_on_verification_failure(
     client: AsyncClient, mock_service: AsyncMock
 ) -> None:
+    # Given
     mock_service.complete_registration.side_effect = PasskeyError(
         "Passkey registration failed. Please try again."
     )
+
+    # When
     response = await client.post(_REGISTER_COMPLETE_ENDPOINT, json=_REGISTER_PAYLOAD)
+
+    # Then
     assert response.status_code == 400
 
 
 async def test_register_complete_rejects_missing_id(client: AsyncClient) -> None:
+    # Given
     payload = {k: v for k, v in _REGISTER_PAYLOAD.items() if k != "id"}
+
+    # When
     response = await client.post(_REGISTER_COMPLETE_ENDPOINT, json=payload)
+
+    # Then
     assert response.status_code == 422
 
 
 async def test_register_complete_rejects_missing_response(client: AsyncClient) -> None:
+    # Given
     payload = {k: v for k, v in _REGISTER_PAYLOAD.items() if k != "response"}
+
+    # When
     response = await client.post(_REGISTER_COMPLETE_ENDPOINT, json=payload)
+
+    # Then
     assert response.status_code == 422
 
 
@@ -171,8 +201,10 @@ async def test_register_complete_rejects_missing_response(client: AsyncClient) -
 async def test_auth_begin_returns_200_with_assertion_options(
     client: AsyncClient, mock_service: AsyncMock
 ) -> None:
+    # When
     response = await client.post(_AUTH_BEGIN_ENDPOINT, json=_AUTH_BEGIN_PAYLOAD)
 
+    # Then
     assert response.status_code == 200
     body = response.json()
     assert "challenge" in body
@@ -182,22 +214,33 @@ async def test_auth_begin_returns_200_with_assertion_options(
 async def test_auth_begin_calls_service_with_email(
     client: AsyncClient, mock_service: AsyncMock
 ) -> None:
+    # When
     await client.post(_AUTH_BEGIN_ENDPOINT, json=_AUTH_BEGIN_PAYLOAD)
+
+    # Then
     mock_service.begin_authentication.assert_awaited_once_with("alice@example.com")
 
 
 async def test_auth_begin_returns_400_when_no_passkey(
     client: AsyncClient, mock_service: AsyncMock
 ) -> None:
+    # Given
     mock_service.begin_authentication.side_effect = PasskeyError(
         "No passkey registered for this account"
     )
+
+    # When
     response = await client.post(_AUTH_BEGIN_ENDPOINT, json=_AUTH_BEGIN_PAYLOAD)
+
+    # Then
     assert response.status_code == 400
 
 
 async def test_auth_begin_rejects_invalid_email(client: AsyncClient) -> None:
+    # When
     response = await client.post(_AUTH_BEGIN_ENDPOINT, json={"email": "not-an-email"})
+
+    # Then
     assert response.status_code == 422
 
 
@@ -207,8 +250,10 @@ async def test_auth_begin_rejects_invalid_email(client: AsyncClient) -> None:
 async def test_auth_complete_returns_200_with_full_tokens(
     client: AsyncClient, mock_service: AsyncMock
 ) -> None:
+    # When
     response = await client.post(_AUTH_COMPLETE_ENDPOINT, json=_AUTH_COMPLETE_PAYLOAD)
 
+    # Then
     assert response.status_code == 200
     body = response.json()
     assert body["access_token"] == "full.access.token"
@@ -219,12 +264,16 @@ async def test_auth_complete_returns_200_with_full_tokens(
 async def test_auth_complete_returns_200_with_setup_token_when_incomplete(
     client: AsyncClient, mock_service: AsyncMock
 ) -> None:
+    # Given
     mock_service.complete_authentication.return_value = LoginResponse(
         access_token="setup.token",
         setup_required=True,
     )
+
+    # When
     response = await client.post(_AUTH_COMPLETE_ENDPOINT, json=_AUTH_COMPLETE_PAYLOAD)
 
+    # Then
     assert response.status_code == 200
     body = response.json()
     assert body["setup_required"] is True
@@ -234,37 +283,60 @@ async def test_auth_complete_returns_200_with_setup_token_when_incomplete(
 async def test_auth_complete_calls_service_with_assertion(
     client: AsyncClient, mock_service: AsyncMock
 ) -> None:
+    # When
     await client.post(_AUTH_COMPLETE_ENDPOINT, json=_AUTH_COMPLETE_PAYLOAD)
+
+    # Then
     mock_service.complete_authentication.assert_awaited_once()
 
 
 async def test_auth_complete_returns_400_on_expired_session(
     client: AsyncClient, mock_service: AsyncMock
 ) -> None:
+    # Given
     mock_service.complete_authentication.side_effect = PasskeyError(
         "Authentication session expired. Please start again."
     )
+
+    # When
     response = await client.post(_AUTH_COMPLETE_ENDPOINT, json=_AUTH_COMPLETE_PAYLOAD)
+
+    # Then
     assert response.status_code == 400
 
 
 async def test_auth_complete_returns_400_on_verification_failure(
     client: AsyncClient, mock_service: AsyncMock
 ) -> None:
+    # Given
     mock_service.complete_authentication.side_effect = PasskeyError(
         "Passkey authentication failed. Please try again."
     )
+
+    # When
     response = await client.post(_AUTH_COMPLETE_ENDPOINT, json=_AUTH_COMPLETE_PAYLOAD)
+
+    # Then
     assert response.status_code == 400
 
 
 async def test_auth_complete_rejects_missing_id(client: AsyncClient) -> None:
+    # Given
     payload = {k: v for k, v in _AUTH_COMPLETE_PAYLOAD.items() if k != "id"}
+
+    # When
     response = await client.post(_AUTH_COMPLETE_ENDPOINT, json=payload)
+
+    # Then
     assert response.status_code == 422
 
 
 async def test_auth_complete_rejects_missing_response(client: AsyncClient) -> None:
+    # Given
     payload = {k: v for k, v in _AUTH_COMPLETE_PAYLOAD.items() if k != "response"}
+
+    # When
     response = await client.post(_AUTH_COMPLETE_ENDPOINT, json=payload)
+
+    # Then
     assert response.status_code == 422

--- a/api/tests/v1/auth/unit/refresh_test.py
+++ b/api/tests/v1/auth/unit/refresh_test.py
@@ -38,23 +38,28 @@ def override_dependencies(mock_service: AsyncMock) -> Iterator[None]:
 # ── Happy path ────────────────────────────────────────────────────────────────
 
 
-async def test_refresh_returns_200_with_access_token(
+async def test_refresh_returns_200_with_tokens(
     client: AsyncClient, mock_service: AsyncMock
 ) -> None:
-    mock_service.refresh.return_value = RefreshResponse(access_token="x.y.z")
+    mock_service.refresh.return_value = RefreshResponse(
+        access_token="x.y.z", refresh_token="new.refresh.token"
+    )
 
     response = await client.post(_ENDPOINT, json=_VALID_PAYLOAD)
 
     assert response.status_code == 200
     body = response.json()
     assert body["access_token"] == "x.y.z"
+    assert body["refresh_token"] == "new.refresh.token"
     assert body["token_type"] == "bearer"
 
 
 async def test_refresh_calls_service_with_token(
     client: AsyncClient, mock_service: AsyncMock
 ) -> None:
-    mock_service.refresh.return_value = RefreshResponse(access_token="x.y.z")
+    mock_service.refresh.return_value = RefreshResponse(
+        access_token="x.y.z", refresh_token="new.refresh.token"
+    )
 
     await client.post(_ENDPOINT, json=_VALID_PAYLOAD)
 

--- a/api/tests/v1/auth/unit/refresh_test.py
+++ b/api/tests/v1/auth/unit/refresh_test.py
@@ -41,12 +41,15 @@ def override_dependencies(mock_service: AsyncMock) -> Iterator[None]:
 async def test_refresh_returns_200_with_tokens(
     client: AsyncClient, mock_service: AsyncMock
 ) -> None:
+    # Given
     mock_service.refresh.return_value = RefreshResponse(
         access_token="x.y.z", refresh_token="new.refresh.token"
     )
 
+    # When
     response = await client.post(_ENDPOINT, json=_VALID_PAYLOAD)
 
+    # Then
     assert response.status_code == 200
     body = response.json()
     assert body["access_token"] == "x.y.z"
@@ -57,12 +60,15 @@ async def test_refresh_returns_200_with_tokens(
 async def test_refresh_calls_service_with_token(
     client: AsyncClient, mock_service: AsyncMock
 ) -> None:
+    # Given
     mock_service.refresh.return_value = RefreshResponse(
         access_token="x.y.z", refresh_token="new.refresh.token"
     )
 
+    # When
     await client.post(_ENDPOINT, json=_VALID_PAYLOAD)
 
+    # Then
     mock_service.refresh.assert_awaited_once()
     call_args = mock_service.refresh.call_args
     assert call_args[0][0].refresh_token == "a.valid.refresh.token"
@@ -72,12 +78,18 @@ async def test_refresh_calls_service_with_token(
 
 
 async def test_rejects_missing_refresh_token(client: AsyncClient) -> None:
+    # When
     response = await client.post(_ENDPOINT, json={})
+
+    # Then
     assert response.status_code == 422
 
 
 async def test_rejects_empty_refresh_token(client: AsyncClient) -> None:
+    # When
     response = await client.post(_ENDPOINT, json={"refresh_token": ""})
+
+    # Then
     assert response.status_code == 422
 
 
@@ -87,44 +99,74 @@ async def test_rejects_empty_refresh_token(client: AsyncClient) -> None:
 async def test_returns_401_on_expired_token(
     client: AsyncClient, mock_service: AsyncMock
 ) -> None:
+    # Given
     mock_service.refresh.side_effect = RefreshError("Refresh token has expired")
+
+    # When
     response = await client.post(_ENDPOINT, json=_VALID_PAYLOAD)
+
+    # Then
     assert response.status_code == 401
 
 
 async def test_returns_401_on_invalid_token(
     client: AsyncClient, mock_service: AsyncMock
 ) -> None:
+    # Given
     mock_service.refresh.side_effect = RefreshError("Invalid refresh token")
+
+    # When
     response = await client.post(_ENDPOINT, json=_VALID_PAYLOAD)
+
+    # Then
     assert response.status_code == 401
 
 
 async def test_returns_401_on_wrong_token_type(
     client: AsyncClient, mock_service: AsyncMock
 ) -> None:
+    # Given
     mock_service.refresh.side_effect = RefreshError("Invalid token type")
+
+    # When
     response = await client.post(_ENDPOINT, json=_VALID_PAYLOAD)
+
+    # Then
     assert response.status_code == 401
 
 
 async def test_returns_401_on_inactive_user(
     client: AsyncClient, mock_service: AsyncMock
 ) -> None:
+    # Given
     mock_service.refresh.side_effect = RefreshError("Invalid refresh token")
+
+    # When
     response = await client.post(_ENDPOINT, json=_VALID_PAYLOAD)
+
+    # Then
     assert response.status_code == 401
 
 
 async def test_error_has_no_field(client: AsyncClient, mock_service: AsyncMock) -> None:
+    # Given
     mock_service.refresh.side_effect = RefreshError("Invalid refresh token")
+
+    # When
     response = await client.post(_ENDPOINT, json=_VALID_PAYLOAD)
+
+    # Then
     assert response.json()["detail"]["field"] is None
 
 
 async def test_returns_401_on_revoked_token(
     client: AsyncClient, mock_service: AsyncMock
 ) -> None:
+    # Given
     mock_service.refresh.side_effect = RefreshError("Refresh token has been revoked")
+
+    # When
     response = await client.post(_ENDPOINT, json=_VALID_PAYLOAD)
+
+    # Then
     assert response.status_code == 401

--- a/api/tests/v1/auth/unit/register_test.py
+++ b/api/tests/v1/auth/unit/register_test.py
@@ -47,13 +47,16 @@ def override_dependencies(mock_service: AsyncMock) -> Iterator[None]:
 async def test_register_returns_201_with_user_id(
     client: AsyncClient, mock_service: AsyncMock
 ) -> None:
+    # Given
     mock_service.register.return_value = RegisterResponse(
         id="11111111-1111-1111-1111-111111111111",
         message="Registration successful. Check your email to verify your account.",
     )
 
+    # When
     response = await client.post(_ENDPOINT, json=_VALID_PAYLOAD)
 
+    # Then
     assert response.status_code == 201
     body = response.json()
     assert body["id"] == "11111111-1111-1111-1111-111111111111"
@@ -63,13 +66,16 @@ async def test_register_returns_201_with_user_id(
 async def test_register_calls_service_with_correct_args(
     client: AsyncClient, mock_service: AsyncMock
 ) -> None:
+    # Given
     mock_service.register.return_value = RegisterResponse(
         id="22222222-2222-2222-2222-222222222222",
         message="Registration successful. Check your email to verify your account.",
     )
 
+    # When
     await client.post(_ENDPOINT, json=_VALID_PAYLOAD)
 
+    # Then
     mock_service.register.assert_awaited_once()
     call_args = mock_service.register.call_args
     request_body = call_args[0][0]
@@ -82,50 +88,73 @@ async def test_register_calls_service_with_correct_args(
 
 
 async def test_rejects_missing_captcha_token(client: AsyncClient) -> None:
+    # Given
     payload = {k: v for k, v in _VALID_PAYLOAD.items() if k != "captcha_token"}
+
+    # When
     response = await client.post(_ENDPOINT, json=payload)
+
+    # Then
     assert response.status_code == 422
 
 
 async def test_rejects_disposable_email(client: AsyncClient) -> None:
+    # When
     response = await client.post(
         _ENDPOINT, json={**_VALID_PAYLOAD, "email": "user@mailinator.com"}
     )
+
+    # Then
     assert response.status_code == 422
     assert any("disposable" in str(e).lower() for e in response.json()["detail"])
 
 
 async def test_rejects_password_too_short(client: AsyncClient) -> None:
+    # When
     response = await client.post(
         _ENDPOINT, json={**_VALID_PAYLOAD, "password": "Short1!"}
     )
+
+    # Then
     assert response.status_code == 422
 
 
 async def test_rejects_weak_password(client: AsyncClient) -> None:
+    # When
     response = await client.post(
         _ENDPOINT, json={**_VALID_PAYLOAD, "password": "password123"}
     )
+
+    # Then
     assert response.status_code == 422
 
 
 async def test_rejects_terms_not_accepted(client: AsyncClient) -> None:
+    # When
     response = await client.post(
         _ENDPOINT, json={**_VALID_PAYLOAD, "terms_accepted": False}
     )
+
+    # Then
     assert response.status_code == 422
     assert any("terms" in str(e).lower() for e in response.json()["detail"])
 
 
 async def test_rejects_invalid_phone_number(client: AsyncClient) -> None:
+    # When
     response = await client.post(
         _ENDPOINT, json={**_VALID_PAYLOAD, "phone_number": "not-a-phone!!!"}
     )
+
+    # Then
     assert response.status_code == 422
 
 
 async def test_rejects_missing_required_fields(client: AsyncClient) -> None:
+    # When
     response = await client.post(_ENDPOINT, json={})
+
+    # Then
     assert response.status_code == 422
 
 
@@ -135,10 +164,15 @@ async def test_rejects_missing_required_fields(client: AsyncClient) -> None:
 async def test_returns_409_on_duplicate_email(
     client: AsyncClient, mock_service: AsyncMock
 ) -> None:
+    # Given
     mock_service.register.side_effect = RegistrationError(
         "email already registered", field="email"
     )
+
+    # When
     response = await client.post(_ENDPOINT, json=_VALID_PAYLOAD)
+
+    # Then
     assert response.status_code == 409
     assert response.json()["detail"]["field"] == "email"
 
@@ -146,10 +180,15 @@ async def test_returns_409_on_duplicate_email(
 async def test_returns_409_on_duplicate_phone(
     client: AsyncClient, mock_service: AsyncMock
 ) -> None:
+    # Given
     mock_service.register.side_effect = RegistrationError(
         "phone number already registered", field="phone_number"
     )
+
+    # When
     response = await client.post(_ENDPOINT, json=_VALID_PAYLOAD)
+
+    # Then
     assert response.status_code == 409
     assert response.json()["detail"]["field"] == "phone_number"
 
@@ -157,10 +196,15 @@ async def test_returns_409_on_duplicate_phone(
 async def test_returns_409_on_breached_password(
     client: AsyncClient, mock_service: AsyncMock
 ) -> None:
+    # Given
     mock_service.register.side_effect = RegistrationError(
         "this password has appeared in a known data breach", field="password"
     )
+
+    # When
     response = await client.post(_ENDPOINT, json=_VALID_PAYLOAD)
+
+    # Then
     assert response.status_code == 409
     assert response.json()["detail"]["field"] == "password"
 
@@ -171,9 +215,14 @@ async def test_returns_409_on_breached_password(
 async def test_returns_400_on_captcha_failure(
     client: AsyncClient, mock_service: AsyncMock
 ) -> None:
+    # Given
     mock_service.register.side_effect = CaptchaError(
         "CAPTCHA verification failed", field="captcha_token"
     )
+
+    # When
     response = await client.post(_ENDPOINT, json=_VALID_PAYLOAD)
+
+    # Then
     assert response.status_code == 400
     assert response.json()["detail"]["field"] == "captcha_token"

--- a/api/tests/v1/auth/unit/resend_verification_test.py
+++ b/api/tests/v1/auth/unit/resend_verification_test.py
@@ -55,10 +55,13 @@ def override_dependencies(
 async def test_resend_email_returns_200(
     client: AsyncClient, mock_email_service: AsyncMock
 ) -> None:
+    # Given
     mock_email_service.resend.return_value = None
 
+    # When
     response = await client.post(_EMAIL_ENDPOINT, json=_VALID_EMAIL_PAYLOAD)
 
+    # Then
     assert response.status_code == 200
     assert "message" in response.json()
 
@@ -66,50 +69,74 @@ async def test_resend_email_returns_200(
 async def test_resend_email_calls_service_with_email(
     client: AsyncClient, mock_email_service: AsyncMock
 ) -> None:
+    # Given
     mock_email_service.resend.return_value = None
 
+    # When
     await client.post(_EMAIL_ENDPOINT, json=_VALID_EMAIL_PAYLOAD)
 
+    # Then
     mock_email_service.resend.assert_awaited_once_with("alice@example.com")
 
 
 async def test_resend_email_rejects_missing_email(client: AsyncClient) -> None:
+    # When
     response = await client.post(_EMAIL_ENDPOINT, json={})
+
+    # Then
     assert response.status_code == 422
 
 
 async def test_resend_email_rejects_invalid_email_format(client: AsyncClient) -> None:
+    # When
     response = await client.post(_EMAIL_ENDPOINT, json={"email": "not-an-email"})
+
+    # Then
     assert response.status_code == 422
 
 
 async def test_resend_email_returns_400_when_user_not_found(
     client: AsyncClient, mock_email_service: AsyncMock
 ) -> None:
+    # Given
     mock_email_service.resend.side_effect = ResendError(
         "No account found with that email address", field="email"
     )
+
+    # When
     response = await client.post(_EMAIL_ENDPOINT, json=_VALID_EMAIL_PAYLOAD)
+
+    # Then
     assert response.status_code == 400
 
 
 async def test_resend_email_returns_400_when_already_verified(
     client: AsyncClient, mock_email_service: AsyncMock
 ) -> None:
+    # Given
     mock_email_service.resend.side_effect = ResendError(
         "This email address is already verified", field="email"
     )
+
+    # When
     response = await client.post(_EMAIL_ENDPOINT, json=_VALID_EMAIL_PAYLOAD)
+
+    # Then
     assert response.status_code == 400
 
 
 async def test_resend_email_error_includes_field(
     client: AsyncClient, mock_email_service: AsyncMock
 ) -> None:
+    # Given
     mock_email_service.resend.side_effect = ResendError(
         "This email address is already verified", field="email"
     )
+
+    # When
     response = await client.post(_EMAIL_ENDPOINT, json=_VALID_EMAIL_PAYLOAD)
+
+    # Then
     assert response.json()["detail"]["field"] == "email"
 
 
@@ -119,10 +146,13 @@ async def test_resend_email_error_includes_field(
 async def test_resend_phone_returns_200(
     client: AsyncClient, mock_phone_service: AsyncMock
 ) -> None:
+    # Given
     mock_phone_service.resend.return_value = None
 
+    # When
     response = await client.post(_PHONE_ENDPOINT, json=_VALID_PHONE_PAYLOAD)
 
+    # Then
     assert response.status_code == 200
     assert "message" in response.json()
 
@@ -130,48 +160,72 @@ async def test_resend_phone_returns_200(
 async def test_resend_phone_calls_service_with_phone_number(
     client: AsyncClient, mock_phone_service: AsyncMock
 ) -> None:
+    # Given
     mock_phone_service.resend.return_value = None
 
+    # When
     await client.post(_PHONE_ENDPOINT, json=_VALID_PHONE_PAYLOAD)
 
+    # Then
     mock_phone_service.resend.assert_awaited_once_with("+34612345678")
 
 
 async def test_resend_phone_rejects_missing_phone(client: AsyncClient) -> None:
+    # When
     response = await client.post(_PHONE_ENDPOINT, json={})
+
+    # Then
     assert response.status_code == 422
 
 
 async def test_resend_phone_rejects_invalid_phone_format(client: AsyncClient) -> None:
+    # When
     response = await client.post(_PHONE_ENDPOINT, json={"phone_number": "not-a-phone"})
+
+    # Then
     assert response.status_code == 422
 
 
 async def test_resend_phone_returns_400_when_user_not_found(
     client: AsyncClient, mock_phone_service: AsyncMock
 ) -> None:
+    # Given
     mock_phone_service.resend.side_effect = ResendError(
         "No account found with that phone number", field="phone_number"
     )
+
+    # When
     response = await client.post(_PHONE_ENDPOINT, json=_VALID_PHONE_PAYLOAD)
+
+    # Then
     assert response.status_code == 400
 
 
 async def test_resend_phone_returns_400_when_already_verified(
     client: AsyncClient, mock_phone_service: AsyncMock
 ) -> None:
+    # Given
     mock_phone_service.resend.side_effect = ResendError(
         "This phone number is already verified", field="phone_number"
     )
+
+    # When
     response = await client.post(_PHONE_ENDPOINT, json=_VALID_PHONE_PAYLOAD)
+
+    # Then
     assert response.status_code == 400
 
 
 async def test_resend_phone_error_includes_field(
     client: AsyncClient, mock_phone_service: AsyncMock
 ) -> None:
+    # Given
     mock_phone_service.resend.side_effect = ResendError(
         "This phone number is already verified", field="phone_number"
     )
+
+    # When
     response = await client.post(_PHONE_ENDPOINT, json=_VALID_PHONE_PAYLOAD)
+
+    # Then
     assert response.json()["detail"]["field"] == "phone_number"

--- a/api/tests/v1/auth/unit/verify_email_test.py
+++ b/api/tests/v1/auth/unit/verify_email_test.py
@@ -37,8 +37,10 @@ def override_dependencies(mock_service: AsyncMock) -> Iterator[None]:
 async def test_verify_email_returns_200(
     client: AsyncClient, mock_service: AsyncMock
 ) -> None:
+    # When
     response = await client.post(_ENDPOINT, json={"token": _VALID_TOKEN})
 
+    # Then
     assert response.status_code == 200
     assert "verified" in response.json()["message"].lower()
     mock_service.verify.assert_awaited_once_with(_VALID_TOKEN)
@@ -50,11 +52,15 @@ async def test_verify_email_returns_200(
 async def test_returns_400_on_invalid_token(
     client: AsyncClient, mock_service: AsyncMock
 ) -> None:
+    # Given
     mock_service.verify.side_effect = VerificationError(
         "invalid or expired verification link", field="token"
     )
+
+    # When
     response = await client.post(_ENDPOINT, json={"token": "bad-token"})
 
+    # Then
     assert response.status_code == 400
     assert response.json()["detail"]["field"] == "token"
 
@@ -62,11 +68,15 @@ async def test_returns_400_on_invalid_token(
 async def test_returns_400_on_expired_token(
     client: AsyncClient, mock_service: AsyncMock
 ) -> None:
+    # Given
     mock_service.verify.side_effect = VerificationError(
         "this verification link has expired; request a new one", field="token"
     )
+
+    # When
     response = await client.post(_ENDPOINT, json={"token": _VALID_TOKEN})
 
+    # Then
     assert response.status_code == 400
     assert "expired" in response.json()["detail"]["message"].lower()
 
@@ -74,11 +84,15 @@ async def test_returns_400_on_expired_token(
 async def test_returns_400_on_already_verified(
     client: AsyncClient, mock_service: AsyncMock
 ) -> None:
+    # Given
     mock_service.verify.side_effect = VerificationError(
         "this email address is already verified", field="token"
     )
+
+    # When
     response = await client.post(_ENDPOINT, json={"token": _VALID_TOKEN})
 
+    # Then
     assert response.status_code == 400
     assert "already" in response.json()["detail"]["message"].lower()
 
@@ -87,10 +101,16 @@ async def test_returns_400_on_already_verified(
 
 
 async def test_rejects_missing_token(client: AsyncClient) -> None:
+    # When
     response = await client.post(_ENDPOINT, json={})
+
+    # Then
     assert response.status_code == 422
 
 
 async def test_rejects_empty_token(client: AsyncClient) -> None:
+    # When
     response = await client.post(_ENDPOINT, json={"token": ""})
+
+    # Then
     assert response.status_code == 422

--- a/api/tests/v1/auth/unit/verify_phone_test.py
+++ b/api/tests/v1/auth/unit/verify_phone_test.py
@@ -48,8 +48,10 @@ def override_dependencies(mock_service: AsyncMock) -> Iterator[None]:
 async def test_verify_phone_returns_200(
     client: AsyncClient, mock_service: AsyncMock
 ) -> None:
+    # When
     response = await client.post(_ENDPOINT, json=_VALID_PAYLOAD)
 
+    # Then
     assert response.status_code == 200
     assert "verified" in response.json()["message"].lower()
     mock_service.verify.assert_awaited_once_with(
@@ -63,8 +65,13 @@ async def test_verify_phone_returns_200(
 async def test_returns_403_on_phone_number_mismatch(
     client: AsyncClient, mock_service: AsyncMock
 ) -> None:
+    # Given
     payload = {**_VALID_PAYLOAD, "phone_number": "+34699999999"}
+
+    # When
     response = await client.post(_ENDPOINT, json=payload)
+
+    # Then
     assert response.status_code == 403
 
 
@@ -74,11 +81,15 @@ async def test_returns_403_on_phone_number_mismatch(
 async def test_returns_400_on_invalid_otp(
     client: AsyncClient, mock_service: AsyncMock
 ) -> None:
+    # Given
     mock_service.verify.side_effect = VerificationError(
         "invalid or expired OTP", field="otp"
     )
+
+    # When
     response = await client.post(_ENDPOINT, json=_VALID_PAYLOAD)
 
+    # Then
     assert response.status_code == 400
     assert response.json()["detail"]["field"] == "otp"
 
@@ -86,11 +97,15 @@ async def test_returns_400_on_invalid_otp(
 async def test_returns_400_on_expired_otp(
     client: AsyncClient, mock_service: AsyncMock
 ) -> None:
+    # Given
     mock_service.verify.side_effect = VerificationError(
         "this OTP has expired; request a new one", field="otp"
     )
+
+    # When
     response = await client.post(_ENDPOINT, json=_VALID_PAYLOAD)
 
+    # Then
     assert response.status_code == 400
     assert "expired" in response.json()["detail"]["message"].lower()
 
@@ -98,11 +113,15 @@ async def test_returns_400_on_expired_otp(
 async def test_returns_400_on_already_verified(
     client: AsyncClient, mock_service: AsyncMock
 ) -> None:
+    # Given
     mock_service.verify.side_effect = VerificationError(
         "this phone number is already verified", field="otp"
     )
+
+    # When
     response = await client.post(_ENDPOINT, json=_VALID_PAYLOAD)
 
+    # Then
     assert response.status_code == 400
     assert "already" in response.json()["detail"]["message"].lower()
 
@@ -111,22 +130,34 @@ async def test_returns_400_on_already_verified(
 
 
 async def test_rejects_non_digit_otp(client: AsyncClient) -> None:
+    # When
     response = await client.post(_ENDPOINT, json={**_VALID_PAYLOAD, "otp": "abcdef"})
+
+    # Then
     assert response.status_code == 422
 
 
 async def test_rejects_otp_wrong_length(client: AsyncClient) -> None:
+    # When
     response = await client.post(_ENDPOINT, json={**_VALID_PAYLOAD, "otp": "12345"})
+
+    # Then
     assert response.status_code == 422
 
 
 async def test_rejects_invalid_phone_format(client: AsyncClient) -> None:
+    # When
     response = await client.post(
         _ENDPOINT, json={**_VALID_PAYLOAD, "phone_number": "not-a-phone!!!"}
     )
+
+    # Then
     assert response.status_code == 422
 
 
 async def test_rejects_missing_required_fields(client: AsyncClient) -> None:
+    # When
     response = await client.post(_ENDPOINT, json={})
+
+    # Then
     assert response.status_code == 422

--- a/api/tests/v1/health_test.py
+++ b/api/tests/v1/health_test.py
@@ -4,8 +4,10 @@ from httpx import AsyncClient
 
 @pytest.mark.asyncio
 async def test_health(client: AsyncClient) -> None:
+    # When
     response = await client.get("/v1/health")
 
+    # Then
     assert response.status_code == 200
     body = response.json()
     assert body["status"] == "ok"


### PR DESCRIPTION
## Summary

Each call to `POST /v1/auth/refresh` now issues a brand-new refresh token and immediately blacklists the old one's JTI. Clients must store the new refresh token returned on every refresh call.

The key design decision is how to handle replay attacks. If a refresh token that has already been rotated is submitted again, that is treated as evidence of theft. The attacker obtained the old token before or after the legitimate client used it.

On detection, a per-user revocation timestamp is written to Redis (`blacklist:all:{user_id}`), which invalidates every refresh token issued before that moment, including any the attacker may hold. A `TOKEN_THEFT_DETECTED` audit event is recorded.

The blacklist logic lives in two layers:
- **Per-JTI**.
- **Per-user**.

## Verification

- `api/tests/v1/auth/unit/refresh_test.py`
- `api/tests/v1/auth/integration/auth_flow_test.py`

## Issue Reference

Closes [QRW-58](https://github.com/cristiangilsanz/qrew/issues/58)

## Checklist
- [x] I confirm that this PR follows the project's established coding standards.