### PR TITLE
feat: implement session management endpoints

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
 
       - id: pyright
         name: pyright
-        entry: bash -c 'cd api && uv run pyright'
+        entry: bash -c 'cd api && ~/.local/bin/uv run pyright'
         language: system
         pass_filenames: false
         always_run: true

--- a/api/alembic/versions/d2e3f4a5b6c7_2026_05_24_add_sessions_table.py
+++ b/api/alembic/versions/d2e3f4a5b6c7_2026_05_24_add_sessions_table.py
@@ -1,0 +1,52 @@
+"""2026_05_24_add_sessions_table
+
+Revision ID: d2e3f4a5b6c7
+Revises: c1d2e3f4a5b6
+Create Date: 2026-05-24 00:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "d2e3f4a5b6c7"
+down_revision: str | None = "c1d2e3f4a5b6"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "sessions",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("user_id", sa.UUID(), nullable=False),
+        sa.Column("jti", sa.String(length=36), nullable=False),
+        sa.Column("ip_address", sa.String(length=45), nullable=True),
+        sa.Column("user_agent", sa.Text(), nullable=True),
+        sa.Column("device_fingerprint", sa.String(length=255), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "last_used_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("jti"),
+    )
+    op.create_index(op.f("ix_sessions_user_id"), "sessions", ["user_id"], unique=False)
+    op.create_index(op.f("ix_sessions_jti"), "sessions", ["jti"], unique=True)
+
+
+def downgrade() -> None:
+    op.drop_index(op.f("ix_sessions_jti"), table_name="sessions")
+    op.drop_index(op.f("ix_sessions_user_id"), table_name="sessions")
+    op.drop_table("sessions")

--- a/api/src/com/qode/qrew/v1/service/core/security.py
+++ b/api/src/com/qode/qrew/v1/service/core/security.py
@@ -116,3 +116,12 @@ def create_refresh_token(subject: str) -> str:
 def decode_refresh_token(token: str) -> dict[str, object]:
     """Decode and validate a refresh token; raises jwt errors on failure."""
     return jwt.decode(token, settings.secret_key, algorithms=["HS256"])  # type: ignore[no-any-return]
+
+
+def extract_jti(token: str) -> str | None:
+    """Return the JTI claim from a signed JWT, or None if absent."""
+    payload: dict[str, object] = jwt.decode(
+        token, settings.secret_key, algorithms=["HS256"]
+    )
+    jti = payload.get("jti")
+    return jti if isinstance(jti, str) else None

--- a/api/src/com/qode/qrew/v1/service/models/session.py
+++ b/api/src/com/qode/qrew/v1/service/models/session.py
@@ -1,0 +1,34 @@
+import uuid
+from datetime import datetime
+
+from sqlalchemy import DateTime, ForeignKey, String, Text, func
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from com.qode.qrew.v1.service.core.database import Base
+
+
+class Session(Base):
+    __tablename__ = "sessions"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    jti: Mapped[str] = mapped_column(
+        String(36), unique=True, index=True, nullable=False
+    )
+    ip_address: Mapped[str | None] = mapped_column(String(45), nullable=True)
+    user_agent: Mapped[str | None] = mapped_column(Text, nullable=True)
+    device_fingerprint: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    last_used_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )

--- a/api/src/com/qode/qrew/v1/service/repositories/session.py
+++ b/api/src/com/qode/qrew/v1/service/repositories/session.py
@@ -1,0 +1,61 @@
+import uuid
+from datetime import UTC, datetime
+
+from sqlalchemy import delete, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from com.qode.qrew.v1.service.models.session import Session
+
+
+class SessionRepository:
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+
+    async def create(self, session: Session) -> Session:
+        """Persist a new Session."""
+        self._session.add(session)
+        await self._session.flush()
+        await self._session.refresh(session)
+        return session
+
+    async def get_by_jti(self, jti: str) -> Session | None:
+        """Return the session matching the given JTI."""
+        result = await self._session.execute(
+            select(Session).where(Session.jti == jti).limit(1)
+        )
+        return result.scalar_one_or_none()
+
+    async def get_all_by_user_id(self, user_id: uuid.UUID) -> list[Session]:
+        """Return all sessions for the given user ordered by last_used_at descending."""
+        result = await self._session.execute(
+            select(Session)
+            .where(Session.user_id == user_id)
+            .order_by(Session.last_used_at.desc())
+        )
+        return list(result.scalars().all())
+
+    async def update_jti(self, old_jti: str, new_jti: str) -> None:
+        """Replace the JTI and refresh last_used_at for the matching session."""
+        result = await self._session.execute(
+            select(Session).where(Session.jti == old_jti).limit(1)
+        )
+        session = result.scalar_one_or_none()
+        if session is not None:
+            session.jti = new_jti
+            session.last_used_at = datetime.now(UTC)
+            await self._session.flush()
+
+    async def delete_by_jti(self, jti: str) -> None:
+        """Delete the session with the given JTI."""
+        await self._session.execute(delete(Session).where(Session.jti == jti))
+        await self._session.flush()
+
+    async def delete_all_by_user_id(self, user_id: uuid.UUID) -> list[str]:
+        """Delete all sessions for the user and return their JTIs."""
+        result = await self._session.execute(
+            select(Session.jti).where(Session.user_id == user_id)
+        )
+        jtis = list(result.scalars().all())
+        await self._session.execute(delete(Session).where(Session.user_id == user_id))
+        await self._session.flush()
+        return jtis

--- a/api/src/com/qode/qrew/v1/service/routers/auth.py
+++ b/api/src/com/qode/qrew/v1/service/routers/auth.py
@@ -13,7 +13,7 @@ from fastapi import (
 )
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from com.qode.qrew.v1.service.core.auth import get_setup_or_full_user
+from com.qode.qrew.v1.service.core.auth import get_current_user, get_setup_or_full_user
 from com.qode.qrew.v1.service.core.captcha import (
     CaptchaError,
     CaptchaService,
@@ -24,6 +24,7 @@ from com.qode.qrew.v1.service.core.limiter import limiter
 from com.qode.qrew.v1.service.core.redis import get_redis
 from com.qode.qrew.v1.service.models.user import User
 from com.qode.qrew.v1.service.repositories.passkey import PasskeyCredentialRepository
+from com.qode.qrew.v1.service.repositories.session import SessionRepository
 from com.qode.qrew.v1.service.repositories.user import UserRepository
 from com.qode.qrew.v1.service.schemas.auth import (
     KycUploadResponse,
@@ -45,6 +46,10 @@ from com.qode.qrew.v1.service.schemas.auth import (
     VerifyEmailRequest,
     VerifyPhoneRequest,
     VerifyResponse,
+)
+from com.qode.qrew.v1.service.schemas.session import (
+    RevokeAllResponse,
+    SessionListResponse,
 )
 from com.qode.qrew.v1.service.services.audit import AuditService
 from com.qode.qrew.v1.service.services.complete_setup import (
@@ -69,6 +74,7 @@ from com.qode.qrew.v1.service.services.resend_verification import (
     ResendError,
     ResendPhoneOtpService,
 )
+from com.qode.qrew.v1.service.services.session import SessionError, SessionService
 from com.qode.qrew.v1.service.services.verification import (
     EmailVerificationService,
     PhoneVerificationService,
@@ -116,7 +122,10 @@ def get_login_service(
 ) -> LoginService:
     """Build and return the login service."""
     return LoginService(
-        UserRepository(db), PasskeyCredentialRepository(db), AuditService()
+        UserRepository(db),
+        PasskeyCredentialRepository(db),
+        AuditService(),
+        SessionRepository(db),
     )
 
 
@@ -125,14 +134,25 @@ def get_refresh_service(
     redis: Annotated[aioredis.Redis, Depends(get_redis)] = ...,  # type: ignore[type-arg, assignment]
 ) -> RefreshService:
     """Build and return the refresh service."""
-    return RefreshService(UserRepository(db), redis, AuditService())
+    return RefreshService(
+        UserRepository(db), redis, AuditService(), SessionRepository(db)
+    )
 
 
 def get_logout_service(
+    db: AsyncSession = Depends(get_db),
     redis: Annotated[aioredis.Redis, Depends(get_redis)] = ...,  # type: ignore[type-arg, assignment]
 ) -> LogoutService:
     """Build and return the logout service."""
-    return LogoutService(redis, AuditService())
+    return LogoutService(redis, AuditService(), SessionRepository(db))
+
+
+def get_session_service(
+    db: AsyncSession = Depends(get_db),
+    redis: Annotated[aioredis.Redis, Depends(get_redis)] = ...,  # type: ignore[type-arg, assignment]
+) -> SessionService:
+    """Build and return the session service."""
+    return SessionService(SessionRepository(db), redis)
 
 
 def get_resend_email_verification_service(
@@ -165,7 +185,11 @@ def get_passkey_service(
 ) -> PasskeyService:
     """Build and return the passkey service."""
     return PasskeyService(
-        PasskeyCredentialRepository(db), redis, UserRepository(db), AuditService()
+        PasskeyCredentialRepository(db),
+        redis,
+        UserRepository(db),
+        AuditService(),
+        SessionRepository(db),
     )
 
 
@@ -174,7 +198,10 @@ def get_complete_setup_service(
 ) -> CompleteSetupService:
     """Build and return the complete-setup service."""
     return CompleteSetupService(
-        UserRepository(db), PasskeyCredentialRepository(db), AuditService()
+        UserRepository(db),
+        PasskeyCredentialRepository(db),
+        AuditService(),
+        SessionRepository(db),
     )
 
 
@@ -189,6 +216,7 @@ _DomainError = (
     | KycError
     | PasskeyError
     | SetupError
+    | SessionError
 )
 
 
@@ -286,8 +314,11 @@ async def login(
     service: LoginService = Depends(get_login_service),
 ) -> LoginResponse:
     """Log in as a registered user."""
+    ip_address = request.client.host if request.client else None
+    user_agent = request.headers.get("User-Agent")
+    device_fingerprint = request.headers.get("X-Device-Fingerprint")
     try:
-        return await service.login(body)
+        return await service.login(body, ip_address, user_agent, device_fingerprint)
     except LoginError as exc:
         raise _domain_error(exc, status.HTTP_401_UNAUTHORIZED) from exc
 
@@ -450,8 +481,13 @@ async def complete_setup(
     service: CompleteSetupService = Depends(get_complete_setup_service),
 ) -> LoginResponse:
     """Verify all onboarding steps are done and return full access + refresh tokens."""
+    ip_address = request.client.host if request.client else None
+    user_agent = request.headers.get("User-Agent")
+    device_fingerprint = request.headers.get("X-Device-Fingerprint")
     try:
-        return await service.complete(current_user)
+        return await service.complete(
+            current_user, ip_address, user_agent, device_fingerprint
+        )
     except SetupError as exc:
         raise _domain_error(exc, status.HTTP_400_BAD_REQUEST) from exc
 
@@ -488,7 +524,68 @@ async def passkey_authenticate_complete(
     service: PasskeyService = Depends(get_passkey_service),
 ) -> LoginResponse:
     """Verify the assertion response and return access tokens."""
+    ip_address = request.client.host if request.client else None
+    user_agent = request.headers.get("User-Agent")
+    device_fingerprint = request.headers.get("X-Device-Fingerprint")
     try:
-        return await service.complete_authentication(body)
+        return await service.complete_authentication(
+            body, ip_address, user_agent, device_fingerprint
+        )
     except PasskeyError as exc:
         raise _domain_error(exc, status.HTTP_400_BAD_REQUEST) from exc
+
+
+# ── Session management ────────────────────────────────────────────────────────
+
+
+@router.get(
+    "/sessions",
+    response_model=SessionListResponse,
+    status_code=status.HTTP_200_OK,
+    summary="List all active sessions for the current user",
+)
+@limiter.limit("20/minute")  # type: ignore[misc]
+async def list_sessions(
+    request: Request,
+    current_user: User = Depends(get_current_user),
+    service: SessionService = Depends(get_session_service),
+) -> SessionListResponse:
+    """Return all active sessions for the authenticated user."""
+    sessions = await service.list_sessions(current_user.id)
+    return SessionListResponse(sessions=sessions)
+
+
+@router.delete(
+    "/sessions/{jti}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    summary="Revoke a specific session by JTI",
+)
+@limiter.limit("20/minute")  # type: ignore[misc]
+async def revoke_session(
+    request: Request,
+    jti: str,
+    current_user: User = Depends(get_current_user),
+    service: SessionService = Depends(get_session_service),
+) -> None:
+    """Blacklist the given JTI and remove the session row."""
+    try:
+        await service.revoke_session(jti, current_user.id)
+    except SessionError as exc:
+        raise _domain_error(exc, status.HTTP_404_NOT_FOUND) from exc
+
+
+@router.post(
+    "/sessions/revoke-all",
+    response_model=RevokeAllResponse,
+    status_code=status.HTTP_200_OK,
+    summary="Revoke all sessions for the current user",
+)
+@limiter.limit("10/minute")  # type: ignore[misc]
+async def revoke_all_sessions(
+    request: Request,
+    current_user: User = Depends(get_current_user),
+    service: SessionService = Depends(get_session_service),
+) -> RevokeAllResponse:
+    """Invalidate every refresh token for the authenticated user."""
+    await service.revoke_all(current_user.id)
+    return RevokeAllResponse(message="All sessions have been revoked.")

--- a/api/src/com/qode/qrew/v1/service/routers/dev.py
+++ b/api/src/com/qode/qrew/v1/service/routers/dev.py
@@ -53,7 +53,8 @@ async def dev_reset_db(
 ) -> None:
     await db.execute(
         text(
-            "TRUNCATE audit_events, passkey_credentials, users RESTART IDENTITY CASCADE"
+            "TRUNCATE audit_events, sessions, passkey_credentials, users"
+            " RESTART IDENTITY CASCADE"
         )
     )
     await db.commit()

--- a/api/src/com/qode/qrew/v1/service/schemas/session.py
+++ b/api/src/com/qode/qrew/v1/service/schemas/session.py
@@ -1,0 +1,21 @@
+from datetime import datetime
+
+from pydantic import BaseModel
+
+
+class SessionResponse(BaseModel):
+    id: str
+    jti: str
+    ip_address: str | None
+    user_agent: str | None
+    device_fingerprint: str | None
+    created_at: datetime
+    last_used_at: datetime
+
+
+class SessionListResponse(BaseModel):
+    sessions: list[SessionResponse]
+
+
+class RevokeAllResponse(BaseModel):
+    message: str

--- a/api/src/com/qode/qrew/v1/service/services/complete_setup.py
+++ b/api/src/com/qode/qrew/v1/service/services/complete_setup.py
@@ -1,13 +1,18 @@
+import uuid
+
 import structlog
 
 from com.qode.qrew.v1.service.core.errors import DomainError
 from com.qode.qrew.v1.service.core.security import (
     create_access_token,
     create_refresh_token,
+    extract_jti,
 )
 from com.qode.qrew.v1.service.models.audit import AuditAction
+from com.qode.qrew.v1.service.models.session import Session
 from com.qode.qrew.v1.service.models.user import KycStatus, User
 from com.qode.qrew.v1.service.repositories.passkey import PasskeyCredentialRepository
+from com.qode.qrew.v1.service.repositories.session import SessionRepository
 from com.qode.qrew.v1.service.repositories.user import UserRepository
 from com.qode.qrew.v1.service.schemas.auth import LoginResponse
 from com.qode.qrew.v1.service.services.audit import AuditService
@@ -25,12 +30,20 @@ class CompleteSetupService:
         user_repo: UserRepository,
         passkey_repo: PasskeyCredentialRepository,
         audit: AuditService,
+        session_repo: SessionRepository | None = None,
     ) -> None:
         self._user_repo = user_repo
         self._passkey_repo = passkey_repo
         self._audit = audit
+        self._session_repo = session_repo
 
-    async def complete(self, user: User) -> LoginResponse:
+    async def complete(
+        self,
+        user: User,
+        ip_address: str | None = None,
+        user_agent: str | None = None,
+        device_fingerprint: str | None = None,
+    ) -> LoginResponse:
         """Issue full tokens once all onboarding steps are complete."""
         if not user.phone_number_verified:
             await logger.awarning(
@@ -55,6 +68,10 @@ class CompleteSetupService:
         access_token = create_access_token(str(user.id))
         refresh_token = create_refresh_token(str(user.id))
 
+        await self._persist_session(
+            user.id, refresh_token, ip_address, user_agent, device_fingerprint
+        )
+
         await logger.ainfo("setup_completed", user_id=str(user.id))
 
         try:
@@ -70,3 +87,27 @@ class CompleteSetupService:
             )
 
         return LoginResponse(access_token=access_token, refresh_token=refresh_token)
+
+    async def _persist_session(
+        self,
+        user_id: uuid.UUID,
+        refresh_token: str,
+        ip_address: str | None,
+        user_agent: str | None,
+        device_fingerprint: str | None,
+    ) -> None:
+        if self._session_repo is None:
+            return
+        jti = extract_jti(refresh_token)
+        if jti is None:
+            return
+        await self._session_repo.create(
+            Session(
+                id=uuid.uuid4(),
+                user_id=user_id,
+                jti=jti,
+                ip_address=ip_address,
+                user_agent=user_agent,
+                device_fingerprint=device_fingerprint,
+            )
+        )

--- a/api/src/com/qode/qrew/v1/service/services/login.py
+++ b/api/src/com/qode/qrew/v1/service/services/login.py
@@ -1,3 +1,5 @@
+import uuid
+
 import structlog
 
 from com.qode.qrew.v1.service.core.errors import DomainError
@@ -5,12 +7,15 @@ from com.qode.qrew.v1.service.core.security import (
     create_access_token,
     create_refresh_token,
     create_setup_token,
+    extract_jti,
     hash_password,
     verify_password,
 )
 from com.qode.qrew.v1.service.models.audit import AuditAction
+from com.qode.qrew.v1.service.models.session import Session
 from com.qode.qrew.v1.service.models.user import KycStatus
 from com.qode.qrew.v1.service.repositories.passkey import PasskeyCredentialRepository
+from com.qode.qrew.v1.service.repositories.session import SessionRepository
 from com.qode.qrew.v1.service.repositories.user import UserRepository
 from com.qode.qrew.v1.service.schemas.auth import LoginRequest, LoginResponse
 from com.qode.qrew.v1.service.services.audit import AuditService
@@ -30,12 +35,20 @@ class LoginService:
         repo: UserRepository,
         passkey_repo: PasskeyCredentialRepository,
         audit: AuditService,
+        session_repo: SessionRepository | None = None,
     ) -> None:
         self._repo = repo
         self._passkey_repo = passkey_repo
         self._audit = audit
+        self._session_repo = session_repo
 
-    async def login(self, request: LoginRequest) -> LoginResponse:
+    async def login(
+        self,
+        request: LoginRequest,
+        ip_address: str | None = None,
+        user_agent: str | None = None,
+        device_fingerprint: str | None = None,
+    ) -> LoginResponse:
         """Authenticate a user, returning a setup or full-access token."""
         user = await self._repo.get_by_email(request.email)
 
@@ -98,6 +111,9 @@ class LoginService:
         if setup_complete:
             access_token = create_access_token(str(user.id))
             refresh_token = create_refresh_token(str(user.id))
+            await self._persist_session(
+                user.id, refresh_token, ip_address, user_agent, device_fingerprint
+            )
             await logger.ainfo("user_logged_in", user_id=str(user.id))
             try:
                 await self._audit.record(
@@ -125,4 +141,28 @@ class LoginService:
         return LoginResponse(
             access_token=create_setup_token(str(user.id)),
             setup_required=True,
+        )
+
+    async def _persist_session(
+        self,
+        user_id: uuid.UUID,
+        refresh_token: str,
+        ip_address: str | None,
+        user_agent: str | None,
+        device_fingerprint: str | None,
+    ) -> None:
+        if self._session_repo is None:
+            return
+        jti = extract_jti(refresh_token)
+        if jti is None:
+            return
+        await self._session_repo.create(
+            Session(
+                id=uuid.uuid4(),
+                user_id=user_id,
+                jti=jti,
+                ip_address=ip_address,
+                user_agent=user_agent,
+                device_fingerprint=device_fingerprint,
+            )
         )

--- a/api/src/com/qode/qrew/v1/service/services/logout.py
+++ b/api/src/com/qode/qrew/v1/service/services/logout.py
@@ -8,6 +8,7 @@ from jwt import ExpiredSignatureError, InvalidTokenError
 from com.qode.qrew.v1.service.core.errors import DomainError
 from com.qode.qrew.v1.service.core.security import decode_refresh_token
 from com.qode.qrew.v1.service.models.audit import AuditAction
+from com.qode.qrew.v1.service.repositories.session import SessionRepository
 from com.qode.qrew.v1.service.services.audit import AuditService
 
 logger = structlog.get_logger(__name__)
@@ -21,12 +22,18 @@ class LogoutError(DomainError):
 
 
 class LogoutService:
-    def __init__(self, redis: aioredis.Redis, audit: AuditService) -> None:  # type: ignore[type-arg]
+    def __init__(
+        self,
+        redis: aioredis.Redis,  # type: ignore[type-arg]
+        audit: AuditService,
+        session_repo: SessionRepository | None = None,
+    ) -> None:
         self._redis = redis
         self._audit = audit
+        self._session_repo = session_repo
 
     async def logout(self, refresh_token: str) -> None:
-        """Blacklist the refresh token's JTI so it cannot be used again."""
+        """Blacklist the refresh token's JTI and remove the session row."""
         try:
             payload = decode_refresh_token(refresh_token)
         except ExpiredSignatureError:
@@ -50,6 +57,9 @@ class LogoutService:
 
         if ttl > 0:
             await self._redis.setex(BLACKLIST_JTI_PREFIX + jti, ttl, "1")
+
+        if self._session_repo is not None:
+            await self._session_repo.delete_by_jti(jti)
 
         await logger.ainfo("token_revoked", jti=jti)
 

--- a/api/src/com/qode/qrew/v1/service/services/passkey.py
+++ b/api/src/com/qode/qrew/v1/service/services/passkey.py
@@ -21,11 +21,14 @@ from com.qode.qrew.v1.service.core.security import (
     create_access_token,
     create_refresh_token,
     create_setup_token,
+    extract_jti,
 )
 from com.qode.qrew.v1.service.models.audit import AuditAction
 from com.qode.qrew.v1.service.models.passkey import PasskeyCredential
+from com.qode.qrew.v1.service.models.session import Session
 from com.qode.qrew.v1.service.models.user import KycStatus, User
 from com.qode.qrew.v1.service.repositories.passkey import PasskeyCredentialRepository
+from com.qode.qrew.v1.service.repositories.session import SessionRepository
 from com.qode.qrew.v1.service.repositories.user import UserRepository
 from com.qode.qrew.v1.service.schemas.auth import (
     LoginResponse,
@@ -61,11 +64,13 @@ class PasskeyService:
         redis: aioredis.Redis,  # type: ignore[type-arg]
         user_repo: UserRepository,
         audit: AuditService,
+        session_repo: SessionRepository | None = None,
     ) -> None:
         self._passkey_repo = passkey_repo
         self._redis = redis
         self._user_repo = user_repo
         self._audit = audit
+        self._session_repo = session_repo
 
     async def begin_registration(self, user: User) -> str:
         """Generate WebAuthn registration options and cache the challenge."""
@@ -192,7 +197,11 @@ class PasskeyService:
         return webauthn.options_to_json(options)
 
     async def complete_authentication(
-        self, request: PasskeyAuthenticationCompleteRequest
+        self,
+        request: PasskeyAuthenticationCompleteRequest,
+        ip_address: str | None = None,
+        user_agent: str | None = None,
+        device_fingerprint: str | None = None,
     ) -> LoginResponse:
         """Verify the assertion response and return access tokens."""
         raw_id = base64url_to_bytes(request.raw_id)
@@ -278,6 +287,9 @@ class PasskeyService:
         if setup_complete:
             access_token = create_access_token(str(user.id))
             refresh_token = create_refresh_token(str(user.id))
+            await self._persist_session(
+                user.id, refresh_token, ip_address, user_agent, device_fingerprint
+            )
             await logger.ainfo("passkey_authenticated", user_id=str(user.id))
             try:
                 await self._audit.record(
@@ -309,4 +321,28 @@ class PasskeyService:
         return LoginResponse(
             access_token=create_setup_token(str(user.id)),
             setup_required=True,
+        )
+
+    async def _persist_session(
+        self,
+        user_id: uuid.UUID,
+        refresh_token: str,
+        ip_address: str | None,
+        user_agent: str | None,
+        device_fingerprint: str | None,
+    ) -> None:
+        if self._session_repo is None:
+            return
+        jti = extract_jti(refresh_token)
+        if jti is None:
+            return
+        await self._session_repo.create(
+            Session(
+                id=uuid.uuid4(),
+                user_id=user_id,
+                jti=jti,
+                ip_address=ip_address,
+                user_agent=user_agent,
+                device_fingerprint=device_fingerprint,
+            )
         )

--- a/api/src/com/qode/qrew/v1/service/services/refresh.py
+++ b/api/src/com/qode/qrew/v1/service/services/refresh.py
@@ -10,8 +10,10 @@ from com.qode.qrew.v1.service.core.errors import DomainError
 from com.qode.qrew.v1.service.core.security import (
     create_access_token,
     create_refresh_token,
+    extract_jti,
 )
 from com.qode.qrew.v1.service.models.audit import AuditAction
+from com.qode.qrew.v1.service.repositories.session import SessionRepository
 from com.qode.qrew.v1.service.repositories.user import UserRepository
 from com.qode.qrew.v1.service.schemas.auth import RefreshRequest, RefreshResponse
 from com.qode.qrew.v1.service.services.audit import AuditService
@@ -36,10 +38,12 @@ class RefreshService:
         repo: UserRepository,
         redis: aioredis.Redis,
         audit: AuditService,  # type: ignore[type-arg]
+        session_repo: SessionRepository | None = None,
     ) -> None:
         self._repo = repo
         self._redis = redis
         self._audit = audit
+        self._session_repo = session_repo
 
     async def refresh(self, request: RefreshRequest) -> RefreshResponse:
         """Issue a new access + refresh token pair, invalidating the old one."""
@@ -90,6 +94,11 @@ class RefreshService:
         access_token = create_access_token(str(user.id))
         new_refresh_token = create_refresh_token(str(user.id))
 
+        if self._session_repo is not None and isinstance(jti, str):
+            new_jti = extract_jti(new_refresh_token)
+            if new_jti is not None:
+                await self._session_repo.update_jti(jti, new_jti)
+
         await logger.ainfo("token_refreshed", user_id=str(user.id))
         try:
             await self._audit.record(
@@ -126,6 +135,12 @@ class RefreshService:
             ttl,
             str(int(datetime.now(UTC).timestamp())),
         )
+        if self._session_repo is not None:
+            try:
+                user_id = uuid.UUID(subject)
+                await self._session_repo.delete_all_by_user_id(user_id)
+            except ValueError:
+                pass
         await logger.awarning("refresh_theft_detected", user_id=subject, jti=jti)
         try:
             actor_id = uuid.UUID(subject)

--- a/api/src/com/qode/qrew/v1/service/services/session.py
+++ b/api/src/com/qode/qrew/v1/service/services/session.py
@@ -1,0 +1,65 @@
+import uuid
+
+import redis.asyncio as aioredis
+import structlog
+
+from com.qode.qrew.v1.service.core.errors import DomainError
+from com.qode.qrew.v1.service.repositories.session import SessionRepository
+from com.qode.qrew.v1.service.schemas.session import SessionResponse
+from com.qode.qrew.v1.service.services.logout import BLACKLIST_JTI_PREFIX
+from com.qode.qrew.v1.service.settings import settings
+
+logger = structlog.get_logger(__name__)
+
+
+class SessionError(DomainError):
+    """Raised when a session operation cannot be completed."""
+
+
+class SessionService:
+    def __init__(
+        self,
+        repo: SessionRepository,
+        redis: aioredis.Redis,  # type: ignore[type-arg]
+    ) -> None:
+        self._repo = repo
+        self._redis = redis
+
+    async def list_sessions(self, user_id: uuid.UUID) -> list[SessionResponse]:
+        """Return all active sessions for the given user."""
+        sessions = await self._repo.get_all_by_user_id(user_id)
+        return [
+            SessionResponse(
+                id=str(s.id),
+                jti=s.jti,
+                ip_address=s.ip_address,
+                user_agent=s.user_agent,
+                device_fingerprint=s.device_fingerprint,
+                created_at=s.created_at,
+                last_used_at=s.last_used_at,
+            )
+            for s in sessions
+        ]
+
+    async def revoke_session(self, jti: str, user_id: uuid.UUID) -> None:
+        """Blacklist a specific session JTI and delete its row."""
+        session = await self._repo.get_by_jti(jti)
+        if session is None or session.user_id != user_id:
+            raise SessionError("Session not found", field="jti")
+
+        await self._blacklist_jti(jti)
+        await self._repo.delete_by_jti(jti)
+        await logger.ainfo("session_revoked", jti=jti, user_id=str(user_id))
+
+    async def revoke_all(self, user_id: uuid.UUID) -> None:
+        """Blacklist and delete every session for the given user."""
+        jtis = await self._repo.delete_all_by_user_id(user_id)
+        for jti in jtis:
+            await self._blacklist_jti(jti)
+        await logger.ainfo(
+            "sessions_revoked_all", count=len(jtis), user_id=str(user_id)
+        )
+
+    async def _blacklist_jti(self, jti: str) -> None:
+        ttl = settings.refresh_token_expire_days * 24 * 3600
+        await self._redis.setex(BLACKLIST_JTI_PREFIX + jti, ttl, "revoked")

--- a/api/tests/v1/auth/conftest.py
+++ b/api/tests/v1/auth/conftest.py
@@ -1,9 +1,50 @@
-import pytest
+import uuid
+from collections.abc import AsyncGenerator
 
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+from com.qode.qrew.v1.service.core.auth import get_current_user
 from com.qode.qrew.v1.service.core.limiter import limiter
+from com.qode.qrew.v1.service.core.security import create_access_token
+from com.qode.qrew.v1.service.main import app
+from com.qode.qrew.v1.service.models.user import User
 
 
 @pytest.fixture(autouse=True)
 def reset_rate_limiter() -> None:
     """Clear slowapi's in-memory storage before each test."""
     limiter.reset()
+
+
+@pytest_asyncio.fixture
+async def authenticated_client() -> AsyncGenerator[AsyncClient, None]:
+    """Test client with a valid full-access token and a stubbed current user."""
+    user_id = uuid.uuid4()
+    token = create_access_token(str(user_id))
+
+    fake_user = User(
+        id=user_id,
+        full_name="Test User",
+        email="test@example.com",
+        phone_number="+34600000001",
+        hashed_password="x",
+        is_active=True,
+        is_admin=False,
+        terms_accepted_at=__import__("datetime").datetime.now(
+            __import__("datetime").timezone.utc
+        ),
+        registration_ip="127.0.0.1",
+    )
+
+    app.dependency_overrides[get_current_user] = lambda: fake_user
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://testserver",
+        headers={"Authorization": f"Bearer {token}"},
+    ) as ac:
+        yield ac
+
+    app.dependency_overrides.pop(get_current_user, None)

--- a/api/tests/v1/auth/integration/auth_flow_test.py
+++ b/api/tests/v1/auth/integration/auth_flow_test.py
@@ -75,6 +75,24 @@ async def _login(client: AsyncClient) -> str:
     return str(r.json()["access_token"])
 
 
+async def _make_setup_complete(db: AsyncSession, user: User) -> None:
+    """Force a user into a fully-setup state via direct DB writes."""
+    user.phone_number_verified = True
+    user.kyc_status = KycStatus.pending
+    db.add(
+        PasskeyCredential(
+            id=uuid.uuid4(),
+            user_id=user.id,
+            credential_id=b"cred",
+            public_key=b"pk",
+            sign_count=0,
+            aaguid="00000000-0000-0000-0000-000000000000",
+        )
+    )
+    await db.commit()
+    await db.refresh(user)
+
+
 # ── Happy path ────────────────────────────────────────────────────────────────
 
 
@@ -542,3 +560,104 @@ async def test_refresh_reuse_after_rotation_triggers_revocation(
 
     r3 = await client.post("/v1/auth/refresh", json={"refresh_token": new_token})
     assert r3.status_code == 401
+
+
+# ── Session management ────────────────────────────────────────────────────────
+
+
+@pytest.mark.integration
+async def test_login_creates_session(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """A full login persists a session row visible via GET /sessions."""
+    # Given
+    await _register(client)
+    user = await _fetch_user(db_session)
+    await _verify_email(client, str(user.email_verification_token))
+    await _make_setup_complete(db_session, user)
+    access_token = await _login(client)
+
+    # When
+    r = await client.get(
+        "/v1/auth/sessions",
+        headers={"Authorization": f"Bearer {access_token}"},
+    )
+
+    # Then
+    assert r.status_code == 200
+    sessions = r.json()["sessions"]
+    assert len(sessions) == 1
+    assert sessions[0]["jti"] is not None
+
+
+@pytest.mark.integration
+async def test_revoke_session_invalidates_refresh_token(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Revoking a session via DELETE /sessions/{jti} blacklists its refresh token."""
+    # Given
+    await _register(client)
+    user = await _fetch_user(db_session)
+    await _verify_email(client, str(user.email_verification_token))
+    await _make_setup_complete(db_session, user)
+    access_token = await _login(client)
+    auth = {"Authorization": f"Bearer {access_token}"}
+
+    r = await client.get("/v1/auth/sessions", headers=auth)
+    jti = r.json()["sessions"][0]["jti"]
+
+    # When
+    r = await client.delete(f"/v1/auth/sessions/{jti}", headers=auth)
+
+    # Then
+    assert r.status_code == 204
+
+    r = await client.get("/v1/auth/sessions", headers=auth)
+    assert r.json()["sessions"] == []
+
+
+@pytest.mark.integration
+async def test_revoke_all_sessions(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """POST /sessions/revoke-all removes all sessions for the user."""
+    # Given
+    await _register(client)
+    user = await _fetch_user(db_session)
+    await _verify_email(client, str(user.email_verification_token))
+    await _make_setup_complete(db_session, user)
+    access_token = await _login(client)
+    auth = {"Authorization": f"Bearer {access_token}"}
+
+    # When
+    r = await client.post("/v1/auth/sessions/revoke-all", headers=auth)
+
+    # Then
+    assert r.status_code == 200
+    assert "revoked" in r.json()["message"].lower()
+
+    r = await client.get("/v1/auth/sessions", headers=auth)
+    assert r.json()["sessions"] == []
+
+
+@pytest.mark.integration
+async def test_revoke_nonexistent_session_returns_404(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    # Given
+    await _register(client)
+    user = await _fetch_user(db_session)
+    await _verify_email(client, str(user.email_verification_token))
+    await _make_setup_complete(db_session, user)
+    access_token = await _login(client)
+    auth = {"Authorization": f"Bearer {access_token}"}
+
+    # When
+    r = await client.delete("/v1/auth/sessions/no-such-jti", headers=auth)
+
+    # Then
+    assert r.status_code == 404

--- a/api/tests/v1/auth/unit/session_test.py
+++ b/api/tests/v1/auth/unit/session_test.py
@@ -1,0 +1,151 @@
+"""Tests for session management endpoints."""
+
+import uuid
+from collections.abc import Iterator
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock
+
+import pytest
+from httpx import AsyncClient
+
+from com.qode.qrew.v1.service.main import app
+from com.qode.qrew.v1.service.routers.auth import get_session_service
+from com.qode.qrew.v1.service.schemas.session import (
+    SessionResponse,
+)
+from com.qode.qrew.v1.service.services.session import SessionError
+
+_ENDPOINT_LIST = "/v1/auth/sessions"
+_ENDPOINT_REVOKE_ALL = "/v1/auth/sessions/revoke-all"
+_JTI = "test-jti-value"
+_ENDPOINT_REVOKE = f"/v1/auth/sessions/{_JTI}"
+
+_SAMPLE_SESSION = SessionResponse(
+    id=str(uuid.uuid4()),
+    jti=_JTI,
+    ip_address="1.2.3.4",
+    user_agent="Mozilla/5.0",
+    device_fingerprint=None,
+    created_at=datetime.now(UTC),
+    last_used_at=datetime.now(UTC),
+)
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def mock_service() -> AsyncMock:
+    service = AsyncMock()
+    service.list_sessions = AsyncMock()
+    service.revoke_session = AsyncMock()
+    service.revoke_all = AsyncMock()
+    return service
+
+
+@pytest.fixture(autouse=True)
+def override_dependencies(mock_service: AsyncMock) -> Iterator[None]:
+    app.dependency_overrides[get_session_service] = lambda: mock_service
+    yield
+    app.dependency_overrides.clear()
+
+
+# ── GET /sessions ─────────────────────────────────────────────────────────────
+
+
+async def test_list_sessions_returns_200(
+    authenticated_client: AsyncClient, mock_service: AsyncMock
+) -> None:
+    # Given
+    mock_service.list_sessions.return_value = [_SAMPLE_SESSION]
+
+    # When
+    response = await authenticated_client.get(_ENDPOINT_LIST)
+
+    # Then
+    assert response.status_code == 200
+    body = response.json()
+    assert len(body["sessions"]) == 1
+    assert body["sessions"][0]["jti"] == _JTI
+
+
+async def test_list_sessions_returns_empty_list(
+    authenticated_client: AsyncClient, mock_service: AsyncMock
+) -> None:
+    # Given
+    mock_service.list_sessions.return_value = []
+
+    # When
+    response = await authenticated_client.get(_ENDPOINT_LIST)
+
+    # Then
+    assert response.status_code == 200
+    assert response.json()["sessions"] == []
+
+
+async def test_list_sessions_requires_auth(client: AsyncClient) -> None:
+    # When
+    response = await client.get(_ENDPOINT_LIST)
+
+    # Then
+    assert response.status_code == 401
+
+
+# ── DELETE /sessions/{jti} ────────────────────────────────────────────────────
+
+
+async def test_revoke_session_returns_204(
+    authenticated_client: AsyncClient, mock_service: AsyncMock
+) -> None:
+    # When
+    response = await authenticated_client.delete(_ENDPOINT_REVOKE)
+
+    # Then
+    assert response.status_code == 204
+    mock_service.revoke_session.assert_awaited_once()
+
+
+async def test_revoke_session_returns_404_when_not_found(
+    authenticated_client: AsyncClient, mock_service: AsyncMock
+) -> None:
+    # Given
+    mock_service.revoke_session.side_effect = SessionError(
+        "Session not found", field="jti"
+    )
+
+    # When
+    response = await authenticated_client.delete(_ENDPOINT_REVOKE)
+
+    # Then
+    assert response.status_code == 404
+
+
+async def test_revoke_session_requires_auth(client: AsyncClient) -> None:
+    # When
+    response = await client.delete(_ENDPOINT_REVOKE)
+
+    # Then
+    assert response.status_code == 401
+
+
+# ── POST /sessions/revoke-all ─────────────────────────────────────────────────
+
+
+async def test_revoke_all_returns_200(
+    authenticated_client: AsyncClient, mock_service: AsyncMock
+) -> None:
+    # When
+    response = await authenticated_client.post(_ENDPOINT_REVOKE_ALL)
+
+    # Then
+    assert response.status_code == 200
+    assert "revoked" in response.json()["message"].lower()
+    mock_service.revoke_all.assert_awaited_once()
+
+
+async def test_revoke_all_requires_auth(client: AsyncClient) -> None:
+    # When
+    response = await client.post(_ENDPOINT_REVOKE_ALL)
+
+    # Then
+    assert response.status_code == 401


### PR DESCRIPTION
## Summary

Implements session tracking and management for authenticated users.

Every time a user logs in, completes setup, or authenticates via passkey, a `Session` row is created in the database storing the JTI, IP address, user agent, and device fingerprint.

Sessions are updated on refresh token rotation and deleted on logout or revocation.

## Verification

- `api/tests/v1/auth/unit/session_test.py`
- `api/tests/v1/auth/integration/auth_flow_test.py`

## Issue Reference

Closes [QRW-59](https://github.com/cristiangilsanz/qrew/issues/59)

## Checklist
- [x] I confirm that this PR follows the project's established coding standards.