### PR TITLE
feat: implement passkey list, delete, and rename endpoints

### DIFF
--- a/api/src/com/qode/qrew/v1/service/models/audit.py
+++ b/api/src/com/qode/qrew/v1/service/models/audit.py
@@ -20,6 +20,8 @@ class AuditAction(enum.StrEnum):
     KYC_REVIEWED = "kyc_reviewed"
     PASSKEY_REGISTERED = "passkey_registered"
     PASSKEY_AUTHENTICATED = "passkey_authenticated"
+    PASSKEY_DELETED = "passkey_deleted"
+    PASSKEY_RENAMED = "passkey_renamed"
     TOKEN_REFRESHED = "token_refreshed"  # noqa: S105
     TOKEN_THEFT_DETECTED = "token_theft_detected"  # noqa: S105
     SETUP_COMPLETED = "setup_completed"

--- a/api/src/com/qode/qrew/v1/service/repositories/passkey.py
+++ b/api/src/com/qode/qrew/v1/service/repositories/passkey.py
@@ -1,6 +1,6 @@
 import uuid
 
-from sqlalchemy import select
+from sqlalchemy import delete, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from com.qode.qrew.v1.service.models.passkey import PasskeyCredential
@@ -40,6 +40,29 @@ class PasskeyCredentialRepository:
             select(PasskeyCredential).where(PasskeyCredential.user_id == user_id)
         )
         return list(result.scalars().all())
+
+    async def get_by_id(self, credential_id: uuid.UUID) -> PasskeyCredential | None:
+        """Return the credential matching the given UUID primary key."""
+        result = await self._session.execute(
+            select(PasskeyCredential)
+            .where(PasskeyCredential.id == credential_id)
+            .limit(1)
+        )
+        return result.scalar_one_or_none()
+
+    async def count_by_user_id(self, user_id: uuid.UUID) -> int:
+        """Return the number of credentials belonging to the given user."""
+        result = await self._session.execute(
+            select(func.count()).where(PasskeyCredential.user_id == user_id)
+        )
+        return result.scalar_one()
+
+    async def delete_by_id(self, credential_id: uuid.UUID) -> None:
+        """Delete the credential with the given UUID primary key."""
+        await self._session.execute(
+            delete(PasskeyCredential).where(PasskeyCredential.id == credential_id)
+        )
+        await self._session.flush()
 
     async def has_passkey(self, user_id: uuid.UUID) -> bool:
         """Return True if the user has at least one registered passkey."""

--- a/api/src/com/qode/qrew/v1/service/repositories/session.py
+++ b/api/src/com/qode/qrew/v1/service/repositories/session.py
@@ -26,7 +26,7 @@ class SessionRepository:
         return result.scalar_one_or_none()
 
     async def get_all_by_user_id(self, user_id: uuid.UUID) -> list[Session]:
-        """Return all sessions for the given user ordered by last_used_at descending."""
+        """Return all sessions for the given user ordered."""
         result = await self._session.execute(
             select(Session)
             .where(Session.user_id == user_id)
@@ -35,7 +35,8 @@ class SessionRepository:
         return list(result.scalars().all())
 
     async def update_jti(self, old_jti: str, new_jti: str) -> None:
-        """Replace the JTI and refresh last_used_at for the matching session."""
+        """Replace the JTI and refresh last used timestamp for
+        the matching session."""
         result = await self._session.execute(
             select(Session).where(Session.jti == old_jti).limit(1)
         )

--- a/api/src/com/qode/qrew/v1/service/routers/auth.py
+++ b/api/src/com/qode/qrew/v1/service/routers/auth.py
@@ -1,3 +1,4 @@
+import uuid
 from typing import Annotated
 
 import redis.asyncio as aioredis
@@ -46,6 +47,11 @@ from com.qode.qrew.v1.service.schemas.auth import (
     VerifyEmailRequest,
     VerifyPhoneRequest,
     VerifyResponse,
+)
+from com.qode.qrew.v1.service.schemas.passkey import (
+    PasskeyListResponse,
+    PasskeyRenameRequest,
+    PasskeyResponse,
 )
 from com.qode.qrew.v1.service.schemas.session import (
     RevokeAllResponse,
@@ -589,3 +595,81 @@ async def revoke_all_sessions(
     """Invalidate every refresh token for the authenticated user."""
     await service.revoke_all(current_user.id)
     return RevokeAllResponse(message="All sessions have been revoked.")
+
+
+# ── Passkey management ────────────────────────────────────────────────────────
+
+
+@router.get(
+    "/passkeys",
+    response_model=PasskeyListResponse,
+    status_code=status.HTTP_200_OK,
+    summary="List all passkeys for the current user",
+)
+@limiter.limit("30/minute")  # type: ignore[misc]
+async def list_passkeys(
+    request: Request,
+    current_user: User = Depends(get_current_user),
+    service: PasskeyService = Depends(get_passkey_service),
+) -> PasskeyListResponse:
+    """Return all passkeys registered by the authenticated user."""
+    return await service.list_passkeys(current_user.id)
+
+
+@router.delete(
+    "/passkeys/{passkey_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    summary="Delete a passkey by ID",
+)
+@limiter.limit("20/minute")  # type: ignore[misc]
+async def delete_passkey(
+    request: Request,
+    passkey_id: str,
+    current_user: User = Depends(get_current_user),
+    service: PasskeyService = Depends(get_passkey_service),
+) -> None:
+    """Remove a passkey; refuses if it is the user's last one (409)."""
+    try:
+        pk_id = uuid.UUID(passkey_id)
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail={"message": "Invalid passkey ID", "field": "passkey_id"},
+        ) from exc
+    try:
+        await service.delete_passkey(pk_id, current_user.id)
+    except PasskeyError as exc:
+        http_status = (
+            status.HTTP_409_CONFLICT
+            if "last passkey" in exc.message
+            else status.HTTP_404_NOT_FOUND
+        )
+        raise _domain_error(exc, http_status) from exc
+
+
+@router.patch(
+    "/passkeys/{passkey_id}",
+    response_model=PasskeyResponse,
+    status_code=status.HTTP_200_OK,
+    summary="Rename a passkey",
+)
+@limiter.limit("20/minute")  # type: ignore[misc]
+async def rename_passkey(
+    request: Request,
+    passkey_id: str,
+    body: PasskeyRenameRequest,
+    current_user: User = Depends(get_current_user),
+    service: PasskeyService = Depends(get_passkey_service),
+) -> PasskeyResponse:
+    """Update the display name of a passkey credential."""
+    try:
+        pk_id = uuid.UUID(passkey_id)
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail={"message": "Invalid passkey ID", "field": "passkey_id"},
+        ) from exc
+    try:
+        return await service.rename_passkey(pk_id, current_user.id, body.name)
+    except PasskeyError as exc:
+        raise _domain_error(exc, status.HTTP_404_NOT_FOUND) from exc

--- a/api/src/com/qode/qrew/v1/service/schemas/passkey.py
+++ b/api/src/com/qode/qrew/v1/service/schemas/passkey.py
@@ -1,0 +1,19 @@
+from datetime import datetime
+
+from pydantic import BaseModel, Field
+
+
+class PasskeyResponse(BaseModel):
+    id: str
+    name: str | None
+    aaguid: str
+    last_used_at: datetime | None
+    created_at: datetime
+
+
+class PasskeyListResponse(BaseModel):
+    passkeys: list[PasskeyResponse]
+
+
+class PasskeyRenameRequest(BaseModel):
+    name: str = Field(..., min_length=1, max_length=128)

--- a/api/src/com/qode/qrew/v1/service/services/passkey.py
+++ b/api/src/com/qode/qrew/v1/service/services/passkey.py
@@ -35,6 +35,10 @@ from com.qode.qrew.v1.service.schemas.auth import (
     PasskeyAuthenticationCompleteRequest,
     PasskeyRegistrationCompleteRequest,
 )
+from com.qode.qrew.v1.service.schemas.passkey import (
+    PasskeyListResponse,
+    PasskeyResponse,
+)
 from com.qode.qrew.v1.service.services.audit import AuditService
 from com.qode.qrew.v1.service.settings import settings
 
@@ -321,6 +325,84 @@ class PasskeyService:
         return LoginResponse(
             access_token=create_setup_token(str(user.id)),
             setup_required=True,
+        )
+
+    async def list_passkeys(self, user_id: uuid.UUID) -> PasskeyListResponse:
+        """Return all passkeys registered by the given user."""
+        credentials = await self._passkey_repo.get_all_by_user_id(user_id)
+        return PasskeyListResponse(
+            passkeys=[
+                PasskeyResponse(
+                    id=str(c.id),
+                    name=c.name,
+                    aaguid=c.aaguid,
+                    last_used_at=c.last_used_at,
+                    created_at=c.created_at,
+                )
+                for c in credentials
+            ]
+        )
+
+    async def delete_passkey(self, passkey_id: uuid.UUID, user_id: uuid.UUID) -> None:
+        """Delete a passkey by ID, refusing to remove the user's last one."""
+        credential = await self._passkey_repo.get_by_id(passkey_id)
+        if credential is None or credential.user_id != user_id:
+            raise PasskeyError("Passkey not found", field="id")
+
+        count = await self._passkey_repo.count_by_user_id(user_id)
+        if count <= 1:
+            raise PasskeyError(
+                "Cannot delete the last passkey — register a new one first",
+                field="id",
+            )
+
+        await self._passkey_repo.delete_by_id(passkey_id)
+        await logger.ainfo(
+            "passkey_deleted", user_id=str(user_id), passkey_id=str(passkey_id)
+        )
+        try:
+            await self._audit.record(
+                action=AuditAction.PASSKEY_DELETED,
+                actor_id=user_id,
+                entity_type="passkey_credential",
+                entity_id=str(passkey_id),
+            )
+        except Exception:
+            await logger.awarning(
+                "audit_write_failed", action=AuditAction.PASSKEY_DELETED
+            )
+
+    async def rename_passkey(
+        self, passkey_id: uuid.UUID, user_id: uuid.UUID, name: str
+    ) -> PasskeyResponse:
+        """Rename a passkey and return the updated representation."""
+        credential = await self._passkey_repo.get_by_id(passkey_id)
+        if credential is None or credential.user_id != user_id:
+            raise PasskeyError("Passkey not found", field="id")
+
+        credential.name = name
+        updated = await self._passkey_repo.save(credential)
+        await logger.ainfo(
+            "passkey_renamed", user_id=str(user_id), passkey_id=str(passkey_id)
+        )
+        try:
+            await self._audit.record(
+                action=AuditAction.PASSKEY_RENAMED,
+                actor_id=user_id,
+                entity_type="passkey_credential",
+                entity_id=str(passkey_id),
+                payload={"name": name},
+            )
+        except Exception:
+            await logger.awarning(
+                "audit_write_failed", action=AuditAction.PASSKEY_RENAMED
+            )
+        return PasskeyResponse(
+            id=str(updated.id),
+            name=updated.name,
+            aaguid=updated.aaguid,
+            last_used_at=updated.last_used_at,
+            created_at=updated.created_at,
         )
 
     async def _persist_session(

--- a/api/tests/v1/auth/unit/passkey_management_test.py
+++ b/api/tests/v1/auth/unit/passkey_management_test.py
@@ -1,0 +1,218 @@
+"""Tests for passkey list, delete, and rename endpoints."""
+
+import uuid
+from collections.abc import Iterator
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock
+
+import pytest
+from httpx import AsyncClient
+
+from com.qode.qrew.v1.service.main import app
+from com.qode.qrew.v1.service.routers.auth import get_passkey_service
+from com.qode.qrew.v1.service.schemas.passkey import (
+    PasskeyListResponse,
+    PasskeyResponse,
+)
+from com.qode.qrew.v1.service.services.passkey import PasskeyError
+
+_PASSKEY_ID = str(uuid.uuid4())
+_ENDPOINT_LIST = "/v1/auth/passkeys"
+_ENDPOINT_DELETE = f"/v1/auth/passkeys/{_PASSKEY_ID}"
+_ENDPOINT_RENAME = f"/v1/auth/passkeys/{_PASSKEY_ID}"
+
+_SAMPLE_PASSKEY = PasskeyResponse(
+    id=_PASSKEY_ID,
+    name="My iPhone",
+    aaguid="00000000-0000-0000-0000-000000000000",
+    last_used_at=datetime.now(UTC),
+    created_at=datetime.now(UTC),
+)
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def mock_service() -> AsyncMock:
+    service = AsyncMock()
+    service.list_passkeys = AsyncMock()
+    service.delete_passkey = AsyncMock()
+    service.rename_passkey = AsyncMock()
+    return service
+
+
+@pytest.fixture(autouse=True)
+def override_dependencies(mock_service: AsyncMock) -> Iterator[None]:
+    app.dependency_overrides[get_passkey_service] = lambda: mock_service
+    yield
+    app.dependency_overrides.clear()
+
+
+# ── GET /passkeys ──────────────────────────────────────────────────────────────
+
+
+async def test_list_passkeys_returns_200(
+    authenticated_client: AsyncClient, mock_service: AsyncMock
+) -> None:
+    # Given
+    mock_service.list_passkeys.return_value = PasskeyListResponse(
+        passkeys=[_SAMPLE_PASSKEY]
+    )
+
+    # When
+    response = await authenticated_client.get(_ENDPOINT_LIST)
+
+    # Then
+    assert response.status_code == 200
+    body = response.json()
+    assert len(body["passkeys"]) == 1
+    assert body["passkeys"][0]["id"] == _PASSKEY_ID
+    assert body["passkeys"][0]["name"] == "My iPhone"
+
+
+async def test_list_passkeys_returns_empty_list(
+    authenticated_client: AsyncClient, mock_service: AsyncMock
+) -> None:
+    # Given
+    mock_service.list_passkeys.return_value = PasskeyListResponse(passkeys=[])
+
+    # When
+    response = await authenticated_client.get(_ENDPOINT_LIST)
+
+    # Then
+    assert response.status_code == 200
+    assert response.json()["passkeys"] == []
+
+
+async def test_list_passkeys_requires_auth(client: AsyncClient) -> None:
+    # When
+    response = await client.get(_ENDPOINT_LIST)
+
+    # Then
+    assert response.status_code == 401
+
+
+# ── DELETE /passkeys/{id} ──────────────────────────────────────────────────────
+
+
+async def test_delete_passkey_returns_204(
+    authenticated_client: AsyncClient, mock_service: AsyncMock
+) -> None:
+    # When
+    response = await authenticated_client.delete(_ENDPOINT_DELETE)
+
+    # Then
+    assert response.status_code == 204
+    mock_service.delete_passkey.assert_awaited_once()
+
+
+async def test_delete_passkey_returns_404_when_not_found(
+    authenticated_client: AsyncClient, mock_service: AsyncMock
+) -> None:
+    # Given
+    mock_service.delete_passkey.side_effect = PasskeyError(
+        "Passkey not found", field="id"
+    )
+
+    # When
+    response = await authenticated_client.delete(_ENDPOINT_DELETE)
+
+    # Then
+    assert response.status_code == 404
+
+
+async def test_delete_passkey_returns_409_when_last_passkey(
+    authenticated_client: AsyncClient, mock_service: AsyncMock
+) -> None:
+    # Given
+    mock_service.delete_passkey.side_effect = PasskeyError(
+        "Cannot delete the last passkey — register a new one first", field="id"
+    )
+
+    # When
+    response = await authenticated_client.delete(_ENDPOINT_DELETE)
+
+    # Then
+    assert response.status_code == 409
+
+
+async def test_delete_passkey_returns_422_for_invalid_uuid(
+    authenticated_client: AsyncClient,
+) -> None:
+    # When
+    response = await authenticated_client.delete("/v1/auth/passkeys/not-a-uuid")
+
+    # Then
+    assert response.status_code == 422
+
+
+async def test_delete_passkey_requires_auth(client: AsyncClient) -> None:
+    # When
+    response = await client.delete(_ENDPOINT_DELETE)
+
+    # Then
+    assert response.status_code == 401
+
+
+# ── PATCH /passkeys/{id} ───────────────────────────────────────────────────────
+
+
+async def test_rename_passkey_returns_200(
+    authenticated_client: AsyncClient, mock_service: AsyncMock
+) -> None:
+    # Given
+    mock_service.rename_passkey.return_value = PasskeyResponse(
+        id=_PASSKEY_ID,
+        name="Work Laptop",
+        aaguid="00000000-0000-0000-0000-000000000000",
+        last_used_at=datetime.now(UTC),
+        created_at=datetime.now(UTC),
+    )
+
+    # When
+    response = await authenticated_client.patch(
+        _ENDPOINT_RENAME, json={"name": "Work Laptop"}
+    )
+
+    # Then
+    assert response.status_code == 200
+    assert response.json()["name"] == "Work Laptop"
+    mock_service.rename_passkey.assert_awaited_once()
+
+
+async def test_rename_passkey_returns_404_when_not_found(
+    authenticated_client: AsyncClient, mock_service: AsyncMock
+) -> None:
+    # Given
+    mock_service.rename_passkey.side_effect = PasskeyError(
+        "Passkey not found", field="id"
+    )
+
+    # When
+    response = await authenticated_client.patch(
+        _ENDPOINT_RENAME, json={"name": "New Name"}
+    )
+
+    # Then
+    assert response.status_code == 404
+
+
+async def test_rename_passkey_returns_422_for_invalid_uuid(
+    authenticated_client: AsyncClient,
+) -> None:
+    # When
+    response = await authenticated_client.patch(
+        "/v1/auth/passkeys/not-a-uuid", json={"name": "New Name"}
+    )
+
+    # Then
+    assert response.status_code == 422
+
+
+async def test_rename_passkey_requires_auth(client: AsyncClient) -> None:
+    # When
+    response = await client.patch(_ENDPOINT_RENAME, json={"name": "New Name"})
+
+    # Then
+    assert response.status_code == 401

--- a/uv.lock
+++ b/uv.lock
@@ -64,7 +64,7 @@ wheels = [
 
 [[package]]
 name = "api"
-version = "1.3.0"
+version = "1.4.0"
 source = { editable = "api" }
 dependencies = [
     { name = "aiosmtplib" },


### PR DESCRIPTION
## Summary

Implements self-service passkey management for authenticated users.

Users can now view, remove, and rename their registered passkeys via three new endpoints under `/v1/auth/passkeys`.

## Verification

- `api/tests/v1/auth/unit/passkey_management_test.py`

## Issue Reference

Closes [QRW-70](https://github.com/cristiangilsanz/qrew/issues/70)

## Checklist
- [x] I confirm that this PR follows the project's established coding standards.