### PR TITLE
feat: implement password change endpoint for authenticated users

### DIFF
--- a/api/src/com/qode/qrew/v1/service/models/audit.py
+++ b/api/src/com/qode/qrew/v1/service/models/audit.py
@@ -25,6 +25,7 @@ class AuditAction(enum.StrEnum):
     TOKEN_REFRESHED = "token_refreshed"  # noqa: S105
     TOKEN_THEFT_DETECTED = "token_theft_detected"  # noqa: S105
     SETUP_COMPLETED = "setup_completed"
+    PASSWORD_CHANGED = "password_changed"  # noqa: S105
     GENESIS = "genesis"
 
 

--- a/api/src/com/qode/qrew/v1/service/routers/auth.py
+++ b/api/src/com/qode/qrew/v1/service/routers/auth.py
@@ -28,6 +28,8 @@ from com.qode.qrew.v1.service.repositories.passkey import PasskeyCredentialRepos
 from com.qode.qrew.v1.service.repositories.session import SessionRepository
 from com.qode.qrew.v1.service.repositories.user import UserRepository
 from com.qode.qrew.v1.service.schemas.auth import (
+    ChangePasswordRequest,
+    ChangePasswordResponse,
     KycUploadResponse,
     LoginRequest,
     LoginResponse,
@@ -70,6 +72,10 @@ from com.qode.qrew.v1.service.services.notification import (
     build_notification_dispatcher,
 )
 from com.qode.qrew.v1.service.services.passkey import PasskeyError, PasskeyService
+from com.qode.qrew.v1.service.services.password_change import (
+    PasswordChangeError,
+    PasswordChangeService,
+)
 from com.qode.qrew.v1.service.services.refresh import RefreshError, RefreshService
 from com.qode.qrew.v1.service.services.registration import (
     RegistrationError,
@@ -211,6 +217,19 @@ def get_complete_setup_service(
     )
 
 
+def get_password_change_service(
+    db: AsyncSession = Depends(get_db),
+    redis: Annotated[aioredis.Redis, Depends(get_redis)] = ...,  # type: ignore[type-arg, assignment]
+) -> PasswordChangeService:
+    """Build and return the password change service."""
+    return PasswordChangeService(
+        UserRepository(db),
+        SessionRepository(db),
+        redis,
+        AuditService(),
+    )
+
+
 _DomainError = (
     RegistrationError
     | VerificationError
@@ -223,6 +242,7 @@ _DomainError = (
     | PasskeyError
     | SetupError
     | SessionError
+    | PasswordChangeError
 )
 
 
@@ -673,3 +693,29 @@ async def rename_passkey(
         return await service.rename_passkey(pk_id, current_user.id, body.name)
     except PasskeyError as exc:
         raise _domain_error(exc, status.HTTP_404_NOT_FOUND) from exc
+
+
+# ── Account management ────────────────────────────────────────────────────────
+
+
+@router.post(
+    "/change-password",
+    response_model=ChangePasswordResponse,
+    status_code=status.HTTP_200_OK,
+    summary="Change the authenticated user's password",
+)
+@limiter.limit("5/hour")  # type: ignore[misc]
+async def change_password(
+    request: Request,
+    body: ChangePasswordRequest,
+    current_user: User = Depends(get_current_user),
+    service: PasswordChangeService = Depends(get_password_change_service),
+) -> ChangePasswordResponse:
+    """Verify the current password and replace it; revokes all active sessions."""
+    try:
+        await service.change_password(
+            current_user, body.current_password, body.new_password
+        )
+        return ChangePasswordResponse(message="Password changed successfully.")
+    except PasswordChangeError as exc:
+        raise _domain_error(exc, status.HTTP_400_BAD_REQUEST) from exc

--- a/api/src/com/qode/qrew/v1/service/schemas/auth.py
+++ b/api/src/com/qode/qrew/v1/service/schemas/auth.py
@@ -182,6 +182,25 @@ class AssertionResponseData(BaseModel):
     user_handle: str | None = Field(alias="userHandle", default=None)
 
 
+class ChangePasswordRequest(BaseModel):
+    current_password: str = Field(..., min_length=1)
+    new_password: str = Field(..., min_length=8)
+
+    @field_validator("new_password")
+    @classmethod
+    def validate_new_password(cls, v: str) -> str:
+        """Reject weak passwords."""
+        result = zxcvbn.zxcvbn(v)
+        if result["score"] < _PASSWORD_SECURITY_MIN_SCORE:
+            feedback = result["feedback"]["warning"] or "Password is too weak"
+            raise ValueError(feedback)
+        return v
+
+
+class ChangePasswordResponse(BaseModel):
+    message: str
+
+
 class PasskeyAuthenticationBeginRequest(BaseModel):
     email: EmailStr
 

--- a/api/src/com/qode/qrew/v1/service/services/password_change.py
+++ b/api/src/com/qode/qrew/v1/service/services/password_change.py
@@ -1,0 +1,73 @@
+import redis.asyncio as aioredis
+import structlog
+
+from com.qode.qrew.v1.service.core.errors import DomainError
+from com.qode.qrew.v1.service.core.security import (
+    hash_password,
+    is_password_pwned,
+    verify_password,
+)
+from com.qode.qrew.v1.service.models.audit import AuditAction
+from com.qode.qrew.v1.service.models.user import User
+from com.qode.qrew.v1.service.repositories.session import SessionRepository
+from com.qode.qrew.v1.service.repositories.user import UserRepository
+from com.qode.qrew.v1.service.services.audit import AuditService
+from com.qode.qrew.v1.service.services.logout import BLACKLIST_JTI_PREFIX
+from com.qode.qrew.v1.service.settings import settings
+
+logger = structlog.get_logger(__name__)
+
+
+class PasswordChangeError(DomainError):
+    """Raised when a password change cannot be completed."""
+
+
+class PasswordChangeService:
+    def __init__(
+        self,
+        user_repo: UserRepository,
+        session_repo: SessionRepository,
+        redis: aioredis.Redis,  # type: ignore[type-arg]
+        audit: AuditService,
+    ) -> None:
+        self._user_repo = user_repo
+        self._session_repo = session_repo
+        self._redis = redis
+        self._audit = audit
+
+    async def change_password(
+        self, user: User, current_password: str, new_password: str
+    ) -> None:
+        """Verify current password, update to new one, and revoke all sessions."""
+        if not verify_password(current_password, user.hashed_password):
+            raise PasswordChangeError(
+                "Current password is incorrect", field="current_password"
+            )
+
+        if await is_password_pwned(new_password):
+            raise PasswordChangeError(
+                "This password has appeared in a known data breach. "
+                "Choose a different one",
+                field="new_password",
+            )
+
+        user.hashed_password = hash_password(new_password)
+        await self._user_repo.save(user)
+
+        jtis = await self._session_repo.delete_all_by_user_id(user.id)
+        ttl = settings.refresh_token_expire_days * 24 * 3600
+        for jti in jtis:
+            await self._redis.setex(BLACKLIST_JTI_PREFIX + jti, ttl, "revoked")
+
+        await logger.ainfo("password_changed", user_id=str(user.id))
+        try:
+            await self._audit.record(
+                action=AuditAction.PASSWORD_CHANGED,
+                actor_id=user.id,
+                entity_type="user",
+                entity_id=str(user.id),
+            )
+        except Exception:
+            await logger.awarning(
+                "audit_write_failed", action=AuditAction.PASSWORD_CHANGED
+            )

--- a/api/tests/v1/auth/unit/password_change_test.py
+++ b/api/tests/v1/auth/unit/password_change_test.py
@@ -1,0 +1,120 @@
+"""Tests for the POST /v1/auth/change-password endpoint."""
+
+from collections.abc import Iterator
+from unittest.mock import AsyncMock
+
+import pytest
+from httpx import AsyncClient
+
+from com.qode.qrew.v1.service.main import app
+from com.qode.qrew.v1.service.routers.auth import get_password_change_service
+from com.qode.qrew.v1.service.services.password_change import PasswordChangeError
+
+_ENDPOINT = "/v1/auth/change-password"
+
+_VALID_BODY = {
+    "current_password": "OldPass1!",
+    "new_password": "N3wS3cur3P@ss!",
+}
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def mock_service() -> AsyncMock:
+    service = AsyncMock()
+    service.change_password = AsyncMock()
+    return service
+
+
+@pytest.fixture(autouse=True)
+def override_dependencies(mock_service: AsyncMock) -> Iterator[None]:
+    app.dependency_overrides[get_password_change_service] = lambda: mock_service
+    yield
+    app.dependency_overrides.clear()
+
+
+# ── POST /change-password ──────────────────────────────────────────────────────
+
+
+async def test_change_password_returns_200(
+    authenticated_client: AsyncClient, mock_service: AsyncMock
+) -> None:
+    # Given
+    mock_service.change_password.return_value = None
+
+    # When
+    response = await authenticated_client.post(_ENDPOINT, json=_VALID_BODY)
+
+    # Then
+    assert response.status_code == 200
+    assert response.json()["message"] == "Password changed successfully."
+    mock_service.change_password.assert_awaited_once()
+
+
+async def test_change_password_returns_400_when_wrong_current_password(
+    authenticated_client: AsyncClient, mock_service: AsyncMock
+) -> None:
+    # Given
+    mock_service.change_password.side_effect = PasswordChangeError(
+        "Current password is incorrect", field="current_password"
+    )
+
+    # When
+    response = await authenticated_client.post(_ENDPOINT, json=_VALID_BODY)
+
+    # Then
+    assert response.status_code == 400
+    assert response.json()["detail"]["field"] == "current_password"
+
+
+async def test_change_password_returns_400_when_new_password_breached(
+    authenticated_client: AsyncClient, mock_service: AsyncMock
+) -> None:
+    # Given
+    mock_service.change_password.side_effect = PasswordChangeError(
+        "This password has appeared in a known data breach. Choose a different one",
+        field="new_password",
+    )
+
+    # When
+    response = await authenticated_client.post(_ENDPOINT, json=_VALID_BODY)
+
+    # Then
+    assert response.status_code == 400
+    assert response.json()["detail"]["field"] == "new_password"
+
+
+async def test_change_password_returns_422_when_new_password_too_weak(
+    authenticated_client: AsyncClient,
+) -> None:
+    # When
+    response = await authenticated_client.post(
+        _ENDPOINT,
+        json={"current_password": "OldPass1!", "new_password": "password"},
+    )
+
+    # Then
+    assert response.status_code == 422
+
+
+async def test_change_password_returns_422_when_new_password_too_short(
+    authenticated_client: AsyncClient,
+) -> None:
+    # When
+    response = await authenticated_client.post(
+        _ENDPOINT,
+        json={"current_password": "OldPass1!", "new_password": "short"},
+    )
+
+    # Then
+    assert response.status_code == 422
+
+
+async def test_change_password_requires_auth(client: AsyncClient) -> None:
+    # When
+    response = await client.post(_ENDPOINT, json=_VALID_BODY)
+
+    # Then
+    assert response.status_code == 401


### PR DESCRIPTION
## Summary

Adds a `POST /v1/auth/change-password` endpoint that lets authenticated users update their password. The endpoint requires a valid full-access token and accepts `current_password` and `new_password` in the request body.

## Verification

`api/tests/v1/auth/unit/password_change_test.py`

## Issue Reference

Closes [QRW-63](https://github.com/cristiangilsanz/qrew/issues/63)

## Checklist
- [x] I confirm that this PR follows the project's established coding standards.