### PR TITLE
feat: implement email change with re-verification

### DIFF
--- a/api/alembic/versions/e3f4a5b6c7d8_2026_05_24_add_pending_email_to_users.py
+++ b/api/alembic/versions/e3f4a5b6c7d8_2026_05_24_add_pending_email_to_users.py
@@ -1,0 +1,45 @@
+"""2026_05_24_add_pending_email_to_users
+
+Revision ID: e3f4a5b6c7d8
+Revises: d2e3f4a5b6c7
+Create Date: 2026-05-24 00:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "e3f4a5b6c7d8"
+down_revision: str | None = "d2e3f4a5b6c7"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column("users", sa.Column("pending_email", sa.String(255), nullable=True))
+    op.add_column(
+        "users",
+        sa.Column("pending_email_verification_token", sa.String(255), nullable=True),
+    )
+    op.add_column(
+        "users",
+        sa.Column(
+            "pending_email_token_expires_at",
+            sa.DateTime(timezone=True),
+            nullable=True,
+        ),
+    )
+    op.create_index(
+        "ix_users_pending_email_verification_token",
+        "users",
+        ["pending_email_verification_token"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_users_pending_email_verification_token", table_name="users")
+    op.drop_column("users", "pending_email_token_expires_at")
+    op.drop_column("users", "pending_email_verification_token")
+    op.drop_column("users", "pending_email")

--- a/api/src/com/qode/qrew/v1/service/models/audit.py
+++ b/api/src/com/qode/qrew/v1/service/models/audit.py
@@ -26,6 +26,8 @@ class AuditAction(enum.StrEnum):
     TOKEN_THEFT_DETECTED = "token_theft_detected"  # noqa: S105
     SETUP_COMPLETED = "setup_completed"
     PASSWORD_CHANGED = "password_changed"  # noqa: S105
+    EMAIL_CHANGE_REQUESTED = "email_change_requested"
+    EMAIL_CHANGE_CONFIRMED = "email_change_confirmed"
     GENESIS = "genesis"
 
 

--- a/api/src/com/qode/qrew/v1/service/models/user.py
+++ b/api/src/com/qode/qrew/v1/service/models/user.py
@@ -46,6 +46,14 @@ class User(Base):
         DateTime(timezone=True), nullable=True
     )
 
+    pending_email: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    pending_email_verification_token: Mapped[str | None] = mapped_column(
+        String(255), nullable=True, index=True
+    )
+    pending_email_token_expires_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+
     national_id_hash: Mapped[str | None] = mapped_column(String(64), nullable=True)
     kyc_status: Mapped[KycStatus] = mapped_column(
         Enum(KycStatus, name="kyc_status"),

--- a/api/src/com/qode/qrew/v1/service/repositories/user.py
+++ b/api/src/com/qode/qrew/v1/service/repositories/user.py
@@ -59,6 +59,13 @@ class UserRepository:
         await self._session.refresh(user)
         return user
 
+    async def get_by_pending_email_token(self, token: str) -> User | None:
+        """Return the user matching the given pending email verification token."""
+        result = await self._session.execute(
+            select(User).where(User.pending_email_verification_token == token).limit(1)
+        )
+        return result.scalar_one_or_none()
+
     async def save(self, user: User) -> User:
         """Flush pending changes for an already-tracked User."""
         await self._session.flush()

--- a/api/src/com/qode/qrew/v1/service/routers/auth.py
+++ b/api/src/com/qode/qrew/v1/service/routers/auth.py
@@ -28,8 +28,11 @@ from com.qode.qrew.v1.service.repositories.passkey import PasskeyCredentialRepos
 from com.qode.qrew.v1.service.repositories.session import SessionRepository
 from com.qode.qrew.v1.service.repositories.user import UserRepository
 from com.qode.qrew.v1.service.schemas.auth import (
+    ChangeEmailRequest,
+    ChangeEmailResponse,
     ChangePasswordRequest,
     ChangePasswordResponse,
+    ConfirmEmailChangeRequest,
     KycUploadResponse,
     LoginRequest,
     LoginResponse,
@@ -63,6 +66,10 @@ from com.qode.qrew.v1.service.services.audit import AuditService
 from com.qode.qrew.v1.service.services.complete_setup import (
     CompleteSetupService,
     SetupError,
+)
+from com.qode.qrew.v1.service.services.email_change import (
+    EmailChangeError,
+    EmailChangeService,
 )
 from com.qode.qrew.v1.service.services.kyc import KycError, KycService
 from com.qode.qrew.v1.service.services.login import LoginError, LoginService
@@ -217,6 +224,14 @@ def get_complete_setup_service(
     )
 
 
+def get_email_change_service(
+    db: AsyncSession = Depends(get_db),
+    notifier: NotificationDispatcher = Depends(_get_notification_service),
+) -> EmailChangeService:
+    """Build and return the email change service."""
+    return EmailChangeService(UserRepository(db), notifier, AuditService())
+
+
 def get_password_change_service(
     db: AsyncSession = Depends(get_db),
     redis: Annotated[aioredis.Redis, Depends(get_redis)] = ...,  # type: ignore[type-arg, assignment]
@@ -243,6 +258,7 @@ _DomainError = (
     | SetupError
     | SessionError
     | PasswordChangeError
+    | EmailChangeError
 )
 
 
@@ -718,4 +734,49 @@ async def change_password(
         )
         return ChangePasswordResponse(message="Password changed successfully.")
     except PasswordChangeError as exc:
+        raise _domain_error(exc, status.HTTP_400_BAD_REQUEST) from exc
+
+
+@router.post(
+    "/change-email",
+    response_model=ChangeEmailResponse,
+    status_code=status.HTTP_200_OK,
+    summary="Request an email address change",
+)
+@limiter.limit("3/hour")  # type: ignore[misc]
+async def change_email(
+    request: Request,
+    body: ChangeEmailRequest,
+    current_user: User = Depends(get_current_user),
+    service: EmailChangeService = Depends(get_email_change_service),
+) -> ChangeEmailResponse:
+    """Store a pending email change and send a confirmation link to the new address."""
+    try:
+        await service.request_change(
+            current_user, body.new_email, body.current_password
+        )
+        return ChangeEmailResponse(
+            message="Confirmation link sent to your new email address."
+        )
+    except EmailChangeError as exc:
+        raise _domain_error(exc, status.HTTP_400_BAD_REQUEST) from exc
+
+
+@router.post(
+    "/confirm-email-change",
+    response_model=ChangeEmailResponse,
+    status_code=status.HTTP_200_OK,
+    summary="Confirm an email address change using the token from the link",
+)
+@limiter.limit("10/hour")  # type: ignore[misc]
+async def confirm_email_change(
+    request: Request,
+    body: ConfirmEmailChangeRequest,
+    service: EmailChangeService = Depends(get_email_change_service),
+) -> ChangeEmailResponse:
+    """Swap the pending email into the active email field."""
+    try:
+        await service.confirm_change(body.token)
+        return ChangeEmailResponse(message="Email address updated successfully.")
+    except EmailChangeError as exc:
         raise _domain_error(exc, status.HTTP_400_BAD_REQUEST) from exc

--- a/api/src/com/qode/qrew/v1/service/schemas/auth.py
+++ b/api/src/com/qode/qrew/v1/service/schemas/auth.py
@@ -182,6 +182,28 @@ class AssertionResponseData(BaseModel):
     user_handle: str | None = Field(alias="userHandle", default=None)
 
 
+class ChangeEmailRequest(BaseModel):
+    new_email: EmailStr
+
+    @field_validator("new_email")
+    @classmethod
+    def validate_new_email(cls, v: str) -> str:
+        """Reject disposable email addresses."""
+        if not MailChecker.is_valid(v):  # type: ignore[no-untyped-call]
+            raise ValueError("Disposable email addresses are not allowed")
+        return v.lower()
+
+    current_password: str = Field(..., min_length=1)
+
+
+class ConfirmEmailChangeRequest(BaseModel):
+    token: str = Field(..., min_length=1, max_length=512)
+
+
+class ChangeEmailResponse(BaseModel):
+    message: str
+
+
 class ChangePasswordRequest(BaseModel):
     current_password: str = Field(..., min_length=1)
     new_password: str = Field(..., min_length=8)

--- a/api/src/com/qode/qrew/v1/service/services/email_change.py
+++ b/api/src/com/qode/qrew/v1/service/services/email_change.py
@@ -1,0 +1,118 @@
+from datetime import UTC, datetime, timedelta
+
+import structlog
+
+from com.qode.qrew.v1.service.core.errors import DomainError
+from com.qode.qrew.v1.service.core.security import (
+    generate_token,
+    verify_password,
+)
+from com.qode.qrew.v1.service.models.audit import AuditAction
+from com.qode.qrew.v1.service.models.user import User
+from com.qode.qrew.v1.service.repositories.user import UserRepository
+from com.qode.qrew.v1.service.services.audit import AuditService
+from com.qode.qrew.v1.service.services.notification import NotificationDispatcher
+from com.qode.qrew.v1.service.settings import settings
+
+logger = structlog.get_logger(__name__)
+
+
+class EmailChangeError(DomainError):
+    """Raised when an email change cannot be completed."""
+
+
+class EmailChangeService:
+    def __init__(
+        self,
+        user_repo: UserRepository,
+        notifier: NotificationDispatcher,
+        audit: AuditService,
+    ) -> None:
+        self._user_repo = user_repo
+        self._notifier = notifier
+        self._audit = audit
+
+    async def request_change(
+        self, user: User, new_email: str, current_password: str
+    ) -> None:
+        """Verify password, store pending email state, and send notification emails."""
+        if not verify_password(current_password, user.hashed_password):
+            raise EmailChangeError(
+                "Current password is incorrect", field="current_password"
+            )
+
+        if new_email == user.email:
+            raise EmailChangeError(
+                "New email must be different from the current one", field="new_email"
+            )
+
+        if await self._user_repo.exists_by_email(new_email):
+            raise EmailChangeError("Email already in use", field="new_email")
+
+        token = generate_token()
+        expires_at = datetime.now(UTC) + timedelta(
+            hours=settings.email_verification_token_expire_hours
+        )
+        user.pending_email = new_email
+        user.pending_email_verification_token = token
+        user.pending_email_token_expires_at = expires_at
+        await self._user_repo.save(user)
+
+        await self._notifier.send_email_change_verification(
+            new_email, user.full_name, token
+        )
+        await self._notifier.send_email_change_alert(
+            user.email, user.full_name, new_email
+        )
+
+        await logger.ainfo("email_change_requested", user_id=str(user.id))
+        try:
+            await self._audit.record(
+                action=AuditAction.EMAIL_CHANGE_REQUESTED,
+                actor_id=user.id,
+                entity_type="user",
+                entity_id=str(user.id),
+            )
+        except Exception:
+            await logger.awarning(
+                "audit_write_failed", action=AuditAction.EMAIL_CHANGE_REQUESTED
+            )
+
+    async def confirm_change(self, token: str) -> None:
+        """Confirm an email change using the token sent to the new address."""
+        user = await self._user_repo.get_by_pending_email_token(token)
+        if user is None or user.pending_email is None:
+            raise EmailChangeError("Invalid or expired token", field="token")
+
+        if (
+            user.pending_email_token_expires_at is None
+            or user.pending_email_token_expires_at < datetime.now(UTC)
+        ):
+            raise EmailChangeError("Invalid or expired token", field="token")
+
+        new_email = user.pending_email
+
+        if await self._user_repo.exists_by_email(new_email):
+            raise EmailChangeError(
+                "This email address is no longer available", field="token"
+            )
+
+        user.email = new_email
+        user.pending_email = None
+        user.pending_email_verification_token = None
+        user.pending_email_token_expires_at = None
+        await self._user_repo.save(user)
+
+        await logger.ainfo("email_change_confirmed", user_id=str(user.id))
+        try:
+            await self._audit.record(
+                action=AuditAction.EMAIL_CHANGE_CONFIRMED,
+                actor_id=user.id,
+                entity_type="user",
+                entity_id=str(user.id),
+                payload={"new_email": new_email},
+            )
+        except Exception:
+            await logger.awarning(
+                "audit_write_failed", action=AuditAction.EMAIL_CHANGE_CONFIRMED
+            )

--- a/api/src/com/qode/qrew/v1/service/services/notification.py
+++ b/api/src/com/qode/qrew/v1/service/services/notification.py
@@ -8,6 +8,12 @@ import httpx
 import structlog
 
 from com.qode.qrew.v1.service.settings import settings
+from com.qode.qrew.v1.service.templates.email_change_alert_email import (
+    email_change_alert_email,
+)
+from com.qode.qrew.v1.service.templates.email_change_verify_email import (
+    email_change_verify_email,
+)
 from com.qode.qrew.v1.service.templates.kyc_status_email import kyc_status_email
 from com.qode.qrew.v1.service.templates.verification_link_email import (
     verification_link_email,
@@ -44,6 +50,18 @@ class EmailService(Protocol):
         self, to_email: str, full_name: str, status: str, reason: str | None
     ) -> None:
         """Send a KYC approval or rejection notification."""
+        ...
+
+    async def send_email_change_verification(
+        self, to_email: str, full_name: str, token: str
+    ) -> None:
+        """Send a confirmation link to the new email address."""
+        ...
+
+    async def send_email_change_alert(
+        self, to_email: str, full_name: str, new_email: str
+    ) -> None:
+        """Send a security notice to the old email address."""
         ...
 
 
@@ -89,6 +107,26 @@ class StubEmailService:
             "kyc_status_stub",
             to=_mask_email(to_email),
             status=status,
+        )
+
+    async def send_email_change_verification(
+        self, to_email: str, full_name: str, token: str
+    ) -> None:
+        """Log email change verification link."""
+        link = f"{settings.base_url}/confirm-email-change?token={token}"
+        await logger.ainfo(
+            "email_change_verification_stub",
+            to=_mask_email(to_email),
+            link_prefix=link[:60] + "…",
+        )
+
+    async def send_email_change_alert(
+        self, to_email: str, full_name: str, new_email: str
+    ) -> None:
+        """Log email change alert."""
+        await logger.ainfo(
+            "email_change_alert_stub",
+            to=_mask_email(to_email),
         )
 
 
@@ -144,6 +182,63 @@ class SmtpEmailService:
         except Exception as exc:
             await logger.aerror(
                 "email_verification_failed", to=_mask_email(to_email), exc_info=exc
+            )
+
+    async def send_email_change_verification(
+        self, to_email: str, full_name: str, token: str
+    ) -> None:
+        """Send an email change confirmation link via SMTP."""
+        link = f"{settings.base_url}/confirm-email-change?token={token}"
+        expire_hours = settings.email_verification_token_expire_hours
+
+        message = MIMEMultipart("alternative")
+        message["Subject"] = "Confirm your new Qrew email address"
+        message["From"] = self._from_address
+        message["To"] = to_email
+        message.attach(
+            MIMEText(email_change_verify_email(full_name, link, expire_hours), "html")
+        )
+        try:
+            await aiosmtplib.send(
+                message,
+                hostname=self._host,
+                port=self._port,
+                username=self._user,
+                password=self._password,
+                start_tls=True,
+            )
+            await logger.ainfo(
+                "email_change_verification_sent", to=_mask_email(to_email)
+            )
+        except Exception as exc:
+            await logger.aerror(
+                "email_change_verification_failed",
+                to=_mask_email(to_email),
+                exc_info=exc,
+            )
+
+    async def send_email_change_alert(
+        self, to_email: str, full_name: str, new_email: str
+    ) -> None:
+        """Send an email change security alert via SMTP."""
+        message = MIMEMultipart("alternative")
+        message["Subject"] = "Email change requested on your Qrew account"
+        message["From"] = self._from_address
+        message["To"] = to_email
+        message.attach(MIMEText(email_change_alert_email(full_name, new_email), "html"))
+        try:
+            await aiosmtplib.send(
+                message,
+                hostname=self._host,
+                port=self._port,
+                username=self._user,
+                password=self._password,
+                start_tls=True,
+            )
+            await logger.ainfo("email_change_alert_sent", to=_mask_email(to_email))
+        except Exception as exc:
+            await logger.aerror(
+                "email_change_alert_failed", to=_mask_email(to_email), exc_info=exc
             )
 
     async def send_kyc_status(
@@ -238,6 +333,18 @@ class NotificationDispatcher:
     ) -> None:
         """Dispatch a KYC approval or rejection email."""
         await self._email.send_kyc_status(to_email, full_name, status, reason)
+
+    async def send_email_change_verification(
+        self, to_email: str, full_name: str, token: str
+    ) -> None:
+        """Dispatch a confirmation link to the new email address."""
+        await self._email.send_email_change_verification(to_email, full_name, token)
+
+    async def send_email_change_alert(
+        self, to_email: str, full_name: str, new_email: str
+    ) -> None:
+        """Dispatch a security notice to the old email address."""
+        await self._email.send_email_change_alert(to_email, full_name, new_email)
 
 
 def build_notification_dispatcher() -> NotificationDispatcher:

--- a/api/src/com/qode/qrew/v1/service/templates/email_change_alert_email.py
+++ b/api/src/com/qode/qrew/v1/service/templates/email_change_alert_email.py
@@ -1,0 +1,31 @@
+def email_change_alert_email(full_name: str, new_email: str) -> str:
+    masked = new_email[:2] + "***@" + new_email.split("@", 1)[1]
+    return f"""<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+  <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+    <title>Email change requested</title>
+    <style type="text/css">
+      body {{ font-family: "Nunito Sans", Helvetica, Arial, sans-serif; background-color: #F2F4F6; color: #51545E; margin: 0; padding: 0; }}
+      a {{ color: #3869D4; }}
+      h1 {{ color: #333333; font-size: 22px; font-weight: bold; }}
+      p {{ font-size: 16px; line-height: 1.625; margin: 0.4em 0 1.1875em; }}
+      p.sub {{ font-size: 13px; color: #A8AAAF; }}
+      .wrapper {{ width: 100%; background-color: #F2F4F6; padding: 25px 0; }}
+      .inner {{ width: 570px; margin: 0 auto; background-color: #FFFFFF; padding: 45px; }}
+    </style>
+  </head>
+  <body>
+    <div class="wrapper">
+      <div class="inner">
+        <h1>Email change requested</h1>
+        <p>Hi {full_name.split(maxsplit=1)[0]},</p>
+        <p>A request was made to change the email address on your Qrew account to <strong>{masked}</strong>.</p>
+        <p>If this was you, no further action is needed — you will receive a confirmation link at the new address.</p>
+        <p>If you did not make this request, please <a href="mailto:support@qrew.com">contact support</a> immediately.</p>
+        <p class="sub">Qrew &mdash; All rights reserved.</p>
+      </div>
+    </div>
+  </body>
+</html>"""

--- a/api/src/com/qode/qrew/v1/service/templates/email_change_verify_email.py
+++ b/api/src/com/qode/qrew/v1/service/templates/email_change_verify_email.py
@@ -1,0 +1,39 @@
+def email_change_verify_email(full_name: str, link: str, expire_hours: int) -> str:
+    return f"""<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+  <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+    <title>Confirm your new email address</title>
+    <style type="text/css">
+      body {{ font-family: "Nunito Sans", Helvetica, Arial, sans-serif; background-color: #F2F4F6; color: #51545E; margin: 0; padding: 0; }}
+      a {{ color: #3869D4; }}
+      h1 {{ color: #333333; font-size: 22px; font-weight: bold; }}
+      p {{ font-size: 16px; line-height: 1.625; margin: 0.4em 0 1.1875em; }}
+      p.sub {{ font-size: 13px; color: #A8AAAF; }}
+      .wrapper {{ width: 100%; background-color: #F2F4F6; padding: 25px 0; }}
+      .inner {{ width: 570px; margin: 0 auto; background-color: #FFFFFF; padding: 45px; }}
+      .button {{ background-color: #3869D4; border: 10px solid #3869D4; border-left-width: 18px; border-right-width: 18px; color: #FFF !important; text-decoration: none; border-radius: 3px; font-weight: bold; font-size: 15px; display: inline-block; }}
+      .body-action {{ width: 100%; margin: 30px auto; text-align: center; }}
+      .body-sub {{ margin-top: 25px; padding-top: 25px; border-top: 1px solid #EAEAEC; }}
+    </style>
+  </head>
+  <body>
+    <div class="wrapper">
+      <div class="inner">
+        <h1>Confirm your new email, {full_name.split(maxsplit=1)[0]}!</h1>
+        <p>You recently requested to change the email address on your Qrew account to this one.</p>
+        <p>Click the button below to confirm the change.</p>
+        <div class="body-action">
+          <a href="{link}" class="button" target="_blank">Confirm email change</a>
+        </div>
+        <p>This link expires in <strong>{expire_hours} hours</strong>.</p>
+        <p>If you did not request this change, you can safely ignore this message.</p>
+        <div class="body-sub">
+          <p class="sub">If the button above doesn't work, copy and paste this URL into your browser:</p>
+          <p class="sub"><a href="{link}">{link}</a></p>
+        </div>
+      </div>
+    </div>
+  </body>
+</html>"""

--- a/api/tests/v1/auth/unit/email_change_test.py
+++ b/api/tests/v1/auth/unit/email_change_test.py
@@ -1,0 +1,174 @@
+"""Tests for POST /v1/auth/change-email and POST /v1/auth/confirm-email-change."""
+
+from collections.abc import Iterator
+from unittest.mock import AsyncMock
+
+import pytest
+from httpx import AsyncClient
+
+from com.qode.qrew.v1.service.main import app
+from com.qode.qrew.v1.service.routers.auth import get_email_change_service
+from com.qode.qrew.v1.service.services.email_change import EmailChangeError
+
+_ENDPOINT_CHANGE = "/v1/auth/change-email"
+_ENDPOINT_CONFIRM = "/v1/auth/confirm-email-change"
+
+_CHANGE_BODY = {
+    "new_email": "new@example.com",
+    "current_password": "S3cur3P@ss!",
+}
+_CONFIRM_BODY = {"token": "somevalidtoken"}
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def mock_service() -> AsyncMock:
+    service = AsyncMock()
+    service.request_change = AsyncMock()
+    service.confirm_change = AsyncMock()
+    return service
+
+
+@pytest.fixture(autouse=True)
+def override_dependencies(mock_service: AsyncMock) -> Iterator[None]:
+    app.dependency_overrides[get_email_change_service] = lambda: mock_service
+    yield
+    app.dependency_overrides.clear()
+
+
+# ── POST /change-email ────────────────────────────────────────────────────────
+
+
+async def test_change_email_returns_200(
+    authenticated_client: AsyncClient, mock_service: AsyncMock
+) -> None:
+    # Given
+    mock_service.request_change.return_value = None
+
+    # When
+    response = await authenticated_client.post(_ENDPOINT_CHANGE, json=_CHANGE_BODY)
+
+    # Then
+    assert response.status_code == 200
+    assert "new email" in response.json()["message"]
+    mock_service.request_change.assert_awaited_once()
+
+
+async def test_change_email_returns_400_when_wrong_password(
+    authenticated_client: AsyncClient, mock_service: AsyncMock
+) -> None:
+    # Given
+    mock_service.request_change.side_effect = EmailChangeError(
+        "Current password is incorrect", field="current_password"
+    )
+
+    # When
+    response = await authenticated_client.post(_ENDPOINT_CHANGE, json=_CHANGE_BODY)
+
+    # Then
+    assert response.status_code == 400
+    assert response.json()["detail"]["field"] == "current_password"
+
+
+async def test_change_email_returns_400_when_same_email(
+    authenticated_client: AsyncClient, mock_service: AsyncMock
+) -> None:
+    # Given
+    mock_service.request_change.side_effect = EmailChangeError(
+        "New email must be different from the current one", field="new_email"
+    )
+
+    # When
+    response = await authenticated_client.post(_ENDPOINT_CHANGE, json=_CHANGE_BODY)
+
+    # Then
+    assert response.status_code == 400
+    assert response.json()["detail"]["field"] == "new_email"
+
+
+async def test_change_email_returns_400_when_email_taken(
+    authenticated_client: AsyncClient, mock_service: AsyncMock
+) -> None:
+    # Given
+    mock_service.request_change.side_effect = EmailChangeError(
+        "Email already in use", field="new_email"
+    )
+
+    # When
+    response = await authenticated_client.post(_ENDPOINT_CHANGE, json=_CHANGE_BODY)
+
+    # Then
+    assert response.status_code == 400
+    assert response.json()["detail"]["field"] == "new_email"
+
+
+async def test_change_email_returns_422_for_invalid_email(
+    authenticated_client: AsyncClient,
+) -> None:
+    # When
+    response = await authenticated_client.post(
+        _ENDPOINT_CHANGE,
+        json={"new_email": "not-an-email", "current_password": "S3cur3P@ss!"},
+    )
+
+    # Then
+    assert response.status_code == 422
+
+
+async def test_change_email_requires_auth(client: AsyncClient) -> None:
+    # When
+    response = await client.post(_ENDPOINT_CHANGE, json=_CHANGE_BODY)
+
+    # Then
+    assert response.status_code == 401
+
+
+# ── POST /confirm-email-change ────────────────────────────────────────────────
+
+
+async def test_confirm_email_change_returns_200(
+    client: AsyncClient, mock_service: AsyncMock
+) -> None:
+    # Given
+    mock_service.confirm_change.return_value = None
+
+    # When
+    response = await client.post(_ENDPOINT_CONFIRM, json=_CONFIRM_BODY)
+
+    # Then
+    assert response.status_code == 200
+    assert "updated" in response.json()["message"]
+    mock_service.confirm_change.assert_awaited_once()
+
+
+async def test_confirm_email_change_returns_400_when_token_invalid(
+    client: AsyncClient, mock_service: AsyncMock
+) -> None:
+    # Given
+    mock_service.confirm_change.side_effect = EmailChangeError(
+        "Invalid or expired token", field="token"
+    )
+
+    # When
+    response = await client.post(_ENDPOINT_CONFIRM, json=_CONFIRM_BODY)
+
+    # Then
+    assert response.status_code == 400
+    assert response.json()["detail"]["field"] == "token"
+
+
+async def test_confirm_email_change_returns_400_when_email_no_longer_available(
+    client: AsyncClient, mock_service: AsyncMock
+) -> None:
+    # Given
+    mock_service.confirm_change.side_effect = EmailChangeError(
+        "This email address is no longer available", field="token"
+    )
+
+    # When
+    response = await client.post(_ENDPOINT_CONFIRM, json=_CONFIRM_BODY)
+
+    # Then
+    assert response.status_code == 400


### PR DESCRIPTION
## Summary

Adds a two-step email change flow for authenticated users.

## Verification

`api/tests/v1/auth/unit/email_change_test.py`

## Issue Reference

Closes [QRW-61](https://github.com/cristiangilsanz/qrew/issues/61)

## Checklist
- [x] I confirm that this PR follows the project's established coding standards.