### PR TITLE
feat: implement phone number change with re-verification

### DIFF
--- a/api/alembic/versions/f4a5b6c7d8e9_2026_05_24_add_pending_phone_to_users.py
+++ b/api/alembic/versions/f4a5b6c7d8e9_2026_05_24_add_pending_phone_to_users.py
@@ -1,0 +1,38 @@
+"""2026_05_24_add_pending_phone_to_users
+
+Revision ID: f4a5b6c7d8e9
+Revises: e3f4a5b6c7d8
+Create Date: 2026-05-24 00:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "f4a5b6c7d8e9"
+down_revision: str | None = "e3f4a5b6c7d8"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "users", sa.Column("pending_phone_number", sa.String(20), nullable=True)
+    )
+    op.add_column("users", sa.Column("pending_phone_otp", sa.String(10), nullable=True))
+    op.add_column(
+        "users",
+        sa.Column(
+            "pending_phone_otp_expires_at",
+            sa.DateTime(timezone=True),
+            nullable=True,
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("users", "pending_phone_otp_expires_at")
+    op.drop_column("users", "pending_phone_otp")
+    op.drop_column("users", "pending_phone_number")

--- a/api/src/com/qode/qrew/v1/service/models/audit.py
+++ b/api/src/com/qode/qrew/v1/service/models/audit.py
@@ -28,6 +28,8 @@ class AuditAction(enum.StrEnum):
     PASSWORD_CHANGED = "password_changed"  # noqa: S105
     EMAIL_CHANGE_REQUESTED = "email_change_requested"
     EMAIL_CHANGE_CONFIRMED = "email_change_confirmed"
+    PHONE_CHANGE_REQUESTED = "phone_change_requested"
+    PHONE_CHANGE_CONFIRMED = "phone_change_confirmed"
     GENESIS = "genesis"
 
 

--- a/api/src/com/qode/qrew/v1/service/models/user.py
+++ b/api/src/com/qode/qrew/v1/service/models/user.py
@@ -46,6 +46,12 @@ class User(Base):
         DateTime(timezone=True), nullable=True
     )
 
+    pending_phone_number: Mapped[str | None] = mapped_column(String(20), nullable=True)
+    pending_phone_otp: Mapped[str | None] = mapped_column(String(10), nullable=True)
+    pending_phone_otp_expires_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+
     pending_email: Mapped[str | None] = mapped_column(String(255), nullable=True)
     pending_email_verification_token: Mapped[str | None] = mapped_column(
         String(255), nullable=True, index=True

--- a/api/src/com/qode/qrew/v1/service/routers/auth.py
+++ b/api/src/com/qode/qrew/v1/service/routers/auth.py
@@ -32,7 +32,10 @@ from com.qode.qrew.v1.service.schemas.auth import (
     ChangeEmailResponse,
     ChangePasswordRequest,
     ChangePasswordResponse,
+    ChangePhoneRequest,
+    ChangePhoneResponse,
     ConfirmEmailChangeRequest,
+    ConfirmPhoneChangeRequest,
     KycUploadResponse,
     LoginRequest,
     LoginResponse,
@@ -82,6 +85,10 @@ from com.qode.qrew.v1.service.services.passkey import PasskeyError, PasskeyServi
 from com.qode.qrew.v1.service.services.password_change import (
     PasswordChangeError,
     PasswordChangeService,
+)
+from com.qode.qrew.v1.service.services.phone_change import (
+    PhoneChangeError,
+    PhoneChangeService,
 )
 from com.qode.qrew.v1.service.services.refresh import RefreshError, RefreshService
 from com.qode.qrew.v1.service.services.registration import (
@@ -224,6 +231,14 @@ def get_complete_setup_service(
     )
 
 
+def get_phone_change_service(
+    db: AsyncSession = Depends(get_db),
+    notifier: NotificationDispatcher = Depends(_get_notification_service),
+) -> PhoneChangeService:
+    """Build and return the phone change service."""
+    return PhoneChangeService(UserRepository(db), notifier, AuditService())
+
+
 def get_email_change_service(
     db: AsyncSession = Depends(get_db),
     notifier: NotificationDispatcher = Depends(_get_notification_service),
@@ -259,6 +274,7 @@ _DomainError = (
     | SessionError
     | PasswordChangeError
     | EmailChangeError
+    | PhoneChangeError
 )
 
 
@@ -779,4 +795,50 @@ async def confirm_email_change(
         await service.confirm_change(body.token)
         return ChangeEmailResponse(message="Email address updated successfully.")
     except EmailChangeError as exc:
+        raise _domain_error(exc, status.HTTP_400_BAD_REQUEST) from exc
+
+
+@router.post(
+    "/change-phone",
+    response_model=ChangePhoneResponse,
+    status_code=status.HTTP_200_OK,
+    summary="Request a phone number change",
+)
+@limiter.limit("3/hour")  # type: ignore[misc]
+async def change_phone(
+    request: Request,
+    body: ChangePhoneRequest,
+    current_user: User = Depends(get_current_user),
+    service: PhoneChangeService = Depends(get_phone_change_service),
+) -> ChangePhoneResponse:
+    """Store a pending phone change and send an OTP to the new number."""
+    try:
+        await service.request_change(
+            current_user, body.new_phone_number, body.current_password
+        )
+        return ChangePhoneResponse(
+            message="Verification code sent to your new phone number."
+        )
+    except PhoneChangeError as exc:
+        raise _domain_error(exc, status.HTTP_400_BAD_REQUEST) from exc
+
+
+@router.post(
+    "/confirm-phone-change",
+    response_model=ChangePhoneResponse,
+    status_code=status.HTTP_200_OK,
+    summary="Confirm a phone number change using the OTP",
+)
+@limiter.limit("10/hour")  # type: ignore[misc]
+async def confirm_phone_change(
+    request: Request,
+    body: ConfirmPhoneChangeRequest,
+    current_user: User = Depends(get_current_user),
+    service: PhoneChangeService = Depends(get_phone_change_service),
+) -> ChangePhoneResponse:
+    """Validate the OTP and swap the pending phone number into the active field."""
+    try:
+        await service.confirm_change(current_user, body.new_phone_number, body.otp)
+        return ChangePhoneResponse(message="Phone number updated successfully.")
+    except PhoneChangeError as exc:
         raise _domain_error(exc, status.HTTP_400_BAD_REQUEST) from exc

--- a/api/src/com/qode/qrew/v1/service/schemas/auth.py
+++ b/api/src/com/qode/qrew/v1/service/schemas/auth.py
@@ -182,6 +182,33 @@ class AssertionResponseData(BaseModel):
     user_handle: str | None = Field(alias="userHandle", default=None)
 
 
+class ChangePhoneRequest(BaseModel):
+    new_phone_number: str = Field(..., min_length=7, max_length=20)
+
+    @field_validator("new_phone_number")
+    @classmethod
+    def validate_new_phone_number(cls, v: str) -> str:
+        """Reject phone numbers that are not valid for their region."""
+        try:
+            parsed = phonenumbers.parse(v, None)
+        except phonenumbers.NumberParseException as exc:
+            raise ValueError("Invalid phone number") from exc
+        if not phonenumbers.is_valid_number(parsed):
+            raise ValueError("Phone number is not valid for its region")
+        return v
+
+    current_password: str = Field(..., min_length=1)
+
+
+class ConfirmPhoneChangeRequest(BaseModel):
+    new_phone_number: str = Field(..., min_length=7, max_length=20)
+    otp: str = Field(..., min_length=6, max_length=6, pattern=r"^\d{6}$")
+
+
+class ChangePhoneResponse(BaseModel):
+    message: str
+
+
 class ChangeEmailRequest(BaseModel):
     new_email: EmailStr
 

--- a/api/src/com/qode/qrew/v1/service/services/phone_change.py
+++ b/api/src/com/qode/qrew/v1/service/services/phone_change.py
@@ -1,0 +1,113 @@
+from datetime import UTC, datetime
+
+import structlog
+
+from com.qode.qrew.v1.service.core.errors import DomainError
+from com.qode.qrew.v1.service.core.security import (
+    generate_otp,
+    phone_number_otp_expiry,
+    verify_password,
+)
+from com.qode.qrew.v1.service.models.audit import AuditAction
+from com.qode.qrew.v1.service.models.user import User
+from com.qode.qrew.v1.service.repositories.user import UserRepository
+from com.qode.qrew.v1.service.services.audit import AuditService
+from com.qode.qrew.v1.service.services.notification import NotificationDispatcher
+
+logger = structlog.get_logger(__name__)
+
+
+class PhoneChangeError(DomainError):
+    """Raised when a phone number change cannot be completed."""
+
+
+class PhoneChangeService:
+    def __init__(
+        self,
+        user_repo: UserRepository,
+        notifier: NotificationDispatcher,
+        audit: AuditService,
+    ) -> None:
+        self._user_repo = user_repo
+        self._notifier = notifier
+        self._audit = audit
+
+    async def request_change(
+        self, user: User, new_phone_number: str, current_password: str
+    ) -> None:
+        """Verify password, store pending phone state, and send OTP to new number."""
+        if not verify_password(current_password, user.hashed_password):
+            raise PhoneChangeError(
+                "Current password is incorrect", field="current_password"
+            )
+
+        if new_phone_number == user.phone_number:
+            raise PhoneChangeError(
+                "New phone number must be different from the current one",
+                field="new_phone_number",
+            )
+
+        if await self._user_repo.exists_by_phone(new_phone_number):
+            raise PhoneChangeError(
+                "Phone number already in use", field="new_phone_number"
+            )
+
+        otp = generate_otp()
+        user.pending_phone_number = new_phone_number
+        user.pending_phone_otp = otp
+        user.pending_phone_otp_expires_at = phone_number_otp_expiry()
+        await self._user_repo.save(user)
+
+        await self._notifier.send_sms_otp(new_phone_number, otp)
+
+        await logger.ainfo("phone_change_requested", user_id=str(user.id))
+        try:
+            await self._audit.record(
+                action=AuditAction.PHONE_CHANGE_REQUESTED,
+                actor_id=user.id,
+                entity_type="user",
+                entity_id=str(user.id),
+            )
+        except Exception:
+            await logger.awarning(
+                "audit_write_failed", action=AuditAction.PHONE_CHANGE_REQUESTED
+            )
+
+    async def confirm_change(self, user: User, new_phone_number: str, otp: str) -> None:
+        """Validate OTP and swap the phone number."""
+        if (
+            user.pending_phone_number != new_phone_number
+            or user.pending_phone_otp != otp
+        ):
+            raise PhoneChangeError("Invalid or expired verification code", field="otp")
+
+        if (
+            user.pending_phone_otp_expires_at is None
+            or user.pending_phone_otp_expires_at < datetime.now(UTC)
+        ):
+            raise PhoneChangeError("Invalid or expired verification code", field="otp")
+
+        if await self._user_repo.exists_by_phone(new_phone_number):
+            raise PhoneChangeError(
+                "This phone number is no longer available", field="new_phone_number"
+            )
+
+        user.phone_number = new_phone_number
+        user.pending_phone_number = None
+        user.pending_phone_otp = None
+        user.pending_phone_otp_expires_at = None
+        await self._user_repo.save(user)
+
+        await logger.ainfo("phone_change_confirmed", user_id=str(user.id))
+        try:
+            await self._audit.record(
+                action=AuditAction.PHONE_CHANGE_CONFIRMED,
+                actor_id=user.id,
+                entity_type="user",
+                entity_id=str(user.id),
+                payload={"new_phone_number": new_phone_number},
+            )
+        except Exception:
+            await logger.awarning(
+                "audit_write_failed", action=AuditAction.PHONE_CHANGE_CONFIRMED
+            )

--- a/api/tests/v1/auth/unit/phone_change_test.py
+++ b/api/tests/v1/auth/unit/phone_change_test.py
@@ -1,0 +1,200 @@
+"""Tests for POST /v1/auth/change-phone and POST /v1/auth/confirm-phone-change."""
+
+from collections.abc import Iterator
+from unittest.mock import AsyncMock
+
+import pytest
+from httpx import AsyncClient
+
+from com.qode.qrew.v1.service.main import app
+from com.qode.qrew.v1.service.routers.auth import get_phone_change_service
+from com.qode.qrew.v1.service.services.phone_change import PhoneChangeError
+
+_ENDPOINT_CHANGE = "/v1/auth/change-phone"
+_ENDPOINT_CONFIRM = "/v1/auth/confirm-phone-change"
+
+_CHANGE_BODY = {
+    "new_phone_number": "+34611222333",
+    "current_password": "S3cur3P@ss!",
+}
+_CONFIRM_BODY = {
+    "new_phone_number": "+34611222333",
+    "otp": "123456",
+}
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def mock_service() -> AsyncMock:
+    service = AsyncMock()
+    service.request_change = AsyncMock()
+    service.confirm_change = AsyncMock()
+    return service
+
+
+@pytest.fixture(autouse=True)
+def override_dependencies(mock_service: AsyncMock) -> Iterator[None]:
+    app.dependency_overrides[get_phone_change_service] = lambda: mock_service
+    yield
+    app.dependency_overrides.clear()
+
+
+# ── POST /change-phone ────────────────────────────────────────────────────────
+
+
+async def test_change_phone_returns_200(
+    authenticated_client: AsyncClient, mock_service: AsyncMock
+) -> None:
+    # Given
+    mock_service.request_change.return_value = None
+
+    # When
+    response = await authenticated_client.post(_ENDPOINT_CHANGE, json=_CHANGE_BODY)
+
+    # Then
+    assert response.status_code == 200
+    assert "new phone" in response.json()["message"]
+    mock_service.request_change.assert_awaited_once()
+
+
+async def test_change_phone_returns_400_when_wrong_password(
+    authenticated_client: AsyncClient, mock_service: AsyncMock
+) -> None:
+    # Given
+    mock_service.request_change.side_effect = PhoneChangeError(
+        "Current password is incorrect", field="current_password"
+    )
+
+    # When
+    response = await authenticated_client.post(_ENDPOINT_CHANGE, json=_CHANGE_BODY)
+
+    # Then
+    assert response.status_code == 400
+    assert response.json()["detail"]["field"] == "current_password"
+
+
+async def test_change_phone_returns_400_when_same_number(
+    authenticated_client: AsyncClient, mock_service: AsyncMock
+) -> None:
+    # Given
+    mock_service.request_change.side_effect = PhoneChangeError(
+        "New phone number must be different from the current one",
+        field="new_phone_number",
+    )
+
+    # When
+    response = await authenticated_client.post(_ENDPOINT_CHANGE, json=_CHANGE_BODY)
+
+    # Then
+    assert response.status_code == 400
+    assert response.json()["detail"]["field"] == "new_phone_number"
+
+
+async def test_change_phone_returns_400_when_number_taken(
+    authenticated_client: AsyncClient, mock_service: AsyncMock
+) -> None:
+    # Given
+    mock_service.request_change.side_effect = PhoneChangeError(
+        "Phone number already in use", field="new_phone_number"
+    )
+
+    # When
+    response = await authenticated_client.post(_ENDPOINT_CHANGE, json=_CHANGE_BODY)
+
+    # Then
+    assert response.status_code == 400
+    assert response.json()["detail"]["field"] == "new_phone_number"
+
+
+async def test_change_phone_returns_422_for_invalid_number(
+    authenticated_client: AsyncClient,
+) -> None:
+    # When
+    response = await authenticated_client.post(
+        _ENDPOINT_CHANGE,
+        json={"new_phone_number": "not-a-phone", "current_password": "S3cur3P@ss!"},
+    )
+
+    # Then
+    assert response.status_code == 422
+
+
+async def test_change_phone_requires_auth(client: AsyncClient) -> None:
+    # When
+    response = await client.post(_ENDPOINT_CHANGE, json=_CHANGE_BODY)
+
+    # Then
+    assert response.status_code == 401
+
+
+# ── POST /confirm-phone-change ────────────────────────────────────────────────
+
+
+async def test_confirm_phone_change_returns_200(
+    authenticated_client: AsyncClient, mock_service: AsyncMock
+) -> None:
+    # Given
+    mock_service.confirm_change.return_value = None
+
+    # When
+    response = await authenticated_client.post(_ENDPOINT_CONFIRM, json=_CONFIRM_BODY)
+
+    # Then
+    assert response.status_code == 200
+    assert "updated" in response.json()["message"]
+    mock_service.confirm_change.assert_awaited_once()
+
+
+async def test_confirm_phone_change_returns_400_when_otp_invalid(
+    authenticated_client: AsyncClient, mock_service: AsyncMock
+) -> None:
+    # Given
+    mock_service.confirm_change.side_effect = PhoneChangeError(
+        "Invalid or expired verification code", field="otp"
+    )
+
+    # When
+    response = await authenticated_client.post(_ENDPOINT_CONFIRM, json=_CONFIRM_BODY)
+
+    # Then
+    assert response.status_code == 400
+    assert response.json()["detail"]["field"] == "otp"
+
+
+async def test_confirm_phone_change_returns_400_when_number_taken(
+    authenticated_client: AsyncClient, mock_service: AsyncMock
+) -> None:
+    # Given
+    mock_service.confirm_change.side_effect = PhoneChangeError(
+        "This phone number is no longer available", field="new_phone_number"
+    )
+
+    # When
+    response = await authenticated_client.post(_ENDPOINT_CONFIRM, json=_CONFIRM_BODY)
+
+    # Then
+    assert response.status_code == 400
+    assert response.json()["detail"]["field"] == "new_phone_number"
+
+
+async def test_confirm_phone_change_returns_422_for_invalid_otp_format(
+    authenticated_client: AsyncClient,
+) -> None:
+    # When
+    response = await authenticated_client.post(
+        _ENDPOINT_CONFIRM,
+        json={"new_phone_number": "+34611222333", "otp": "abc"},
+    )
+
+    # Then
+    assert response.status_code == 422
+
+
+async def test_confirm_phone_change_requires_auth(client: AsyncClient) -> None:
+    # When
+    response = await client.post(_ENDPOINT_CONFIRM, json=_CONFIRM_BODY)
+
+    # Then
+    assert response.status_code == 401


### PR DESCRIPTION
## Summary

Adds a two-step OTP flow for authenticated users to change their phone number..

## Verification

`api/tests/v1/auth/unit/phone_change_test.py`

## Issue Reference

Closes [QRW-62](https://github.com/cristiangilsanz/qrew/issues/62)

## Checklist
- [x] I confirm that this PR follows the project's established coding standards.