### PR TITLE
feat: allow resubmission of rejected KYC documents

### DIFF
--- a/api/src/com/qode/qrew/v1/service/services/kyc.py
+++ b/api/src/com/qode/qrew/v1/service/services/kyc.py
@@ -32,6 +32,19 @@ class KycService:
 
     async def upload(self, user: User, content: bytes) -> KycStatus:
         """Hash the document, mark KYC as pending (or auto-approve if enabled)."""
+        if user.kyc_status == KycStatus.approved:
+            await logger.awarning(
+                "kyc_upload_failed", reason="already_approved", user_id=str(user.id)
+            )
+            raise KycError("KYC is already approved")
+        if user.kyc_status == KycStatus.pending:
+            await logger.awarning(
+                "kyc_upload_failed",
+                reason="already_pending",
+                user_id=str(user.id),
+            )
+            raise KycError("KYC is already under review")
+
         if len(content) == 0:
             await logger.awarning(
                 "kyc_upload_failed", reason="empty_document", user_id=str(user.id)

--- a/api/tests/v1/auth/unit/kyc_test.py
+++ b/api/tests/v1/auth/unit/kyc_test.py
@@ -72,6 +72,58 @@ async def test_kyc_upload_calls_service_with_content(
     assert call_args[1] == _FAKE_DOCUMENT
 
 
+# ── Resubmission ─────────────────────────────────────────────────────────────
+
+
+async def test_kyc_resubmission_accepted_when_rejected(
+    client: AsyncClient, mock_service: AsyncMock
+) -> None:
+    # Given — service returns pending (resubmission accepted)
+    mock_service.upload.return_value = KycStatus.pending
+
+    # When
+    response = await client.post(
+        _ENDPOINT,
+        files={"document": ("id.jpg", _FAKE_DOCUMENT, "image/jpeg")},
+    )
+
+    # Then
+    assert response.status_code == 200
+    assert response.json()["kyc_status"] == "pending"
+
+
+async def test_returns_400_when_already_approved(
+    client: AsyncClient, mock_service: AsyncMock
+) -> None:
+    # Given
+    mock_service.upload.side_effect = KycError("KYC is already approved")
+
+    # When
+    response = await client.post(
+        _ENDPOINT,
+        files={"document": ("id.jpg", _FAKE_DOCUMENT, "image/jpeg")},
+    )
+
+    # Then
+    assert response.status_code == 400
+
+
+async def test_returns_400_when_already_pending(
+    client: AsyncClient, mock_service: AsyncMock
+) -> None:
+    # Given
+    mock_service.upload.side_effect = KycError("KYC is already under review")
+
+    # When
+    response = await client.post(
+        _ENDPOINT,
+        files={"document": ("id.jpg", _FAKE_DOCUMENT, "image/jpeg")},
+    )
+
+    # Then
+    assert response.status_code == 400
+
+
 # ── Domain errors (400) ───────────────────────────────────────────────────────
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -64,7 +64,7 @@ wheels = [
 
 [[package]]
 name = "api"
-version = "1.4.0"
+version = "1.5.0"
 source = { editable = "api" }
 dependencies = [
     { name = "aiosmtplib" },


### PR DESCRIPTION
## Summary

Users whose KYC was rejected were silently allowed to re-upload (no guard existed), but so were already-approved and already-pending users. It means the service had no status awareness at all.

The resubmission path is identical to the initial submission: the document hash is updated, `kyc_status` is set to `pending`, and the admin review queue picks it up as normal.

## Verification

`api/tests/v1/auth/unit/kyc_test.py`

## Issue Reference

Closes [QRW-57](https://github.com/cristiangilsanz/qrew/issues/57)

## Checklist
- [x] I confirm that this PR follows the project's established coding standards.