### PR TITLE
feat: implement account recovery with KYC re-verification and passkey re-enrollment

### DIFF
--- a/api/src/com/qode/qrew/v1/service/core/auth.py
+++ b/api/src/com/qode/qrew/v1/service/core/auth.py
@@ -84,6 +84,39 @@ async def get_setup_or_full_user(
     return await _resolve_user(credentials, db, allow_setup=True)
 
 
+async def get_recovery_user(
+    credentials: Annotated[HTTPAuthorizationCredentials, Depends(_bearer)],
+    db: AsyncSession = Depends(get_db),
+) -> User:
+    """Validate a recovery-scoped Bearer token and return the authenticated user."""
+    try:
+        payload = jwt.decode(
+            credentials.credentials,
+            settings.secret_key,
+            algorithms=["HS256"],
+        )
+    except (ExpiredSignatureError, InvalidTokenError) as exc:
+        raise _CREDENTIALS_EXCEPTION from exc
+
+    if payload.get("type") != "access" or payload.get("scope") != "recovery":
+        raise _CREDENTIALS_EXCEPTION
+
+    subject = payload.get("sub")
+    if not isinstance(subject, str):
+        raise _CREDENTIALS_EXCEPTION
+
+    try:
+        user_id = uuid.UUID(subject)
+    except ValueError as exc:
+        raise _CREDENTIALS_EXCEPTION from exc
+
+    user = await UserRepository(db).get_by_id(user_id)
+    if user is None or not user.is_active:
+        raise _CREDENTIALS_EXCEPTION
+
+    return user
+
+
 async def get_admin_user(
     current_user: Annotated[User, Depends(get_current_user)],
 ) -> User:

--- a/api/src/com/qode/qrew/v1/service/core/security.py
+++ b/api/src/com/qode/qrew/v1/service/core/security.py
@@ -100,6 +100,19 @@ def create_setup_token(subject: str) -> str:
     return jwt.encode(payload, settings.secret_key, algorithm="HS256")
 
 
+def create_recovery_token(subject: str) -> str:
+    """Return a short-lived JWT scoped to the account-recovery flow."""
+    now = datetime.now(UTC)
+    payload = {
+        "sub": subject,
+        "type": "access",
+        "scope": "recovery",
+        "iat": now,
+        "exp": now + timedelta(minutes=settings.setup_token_expire_minutes),
+    }
+    return jwt.encode(payload, settings.secret_key, algorithm="HS256")
+
+
 def create_refresh_token(subject: str) -> str:
     """Return a signed JWT refresh token for the given subject."""
     now = datetime.now(UTC)

--- a/api/src/com/qode/qrew/v1/service/models/audit.py
+++ b/api/src/com/qode/qrew/v1/service/models/audit.py
@@ -32,6 +32,9 @@ class AuditAction(enum.StrEnum):
     PHONE_CHANGE_CONFIRMED = "phone_change_confirmed"
     FINGERPRINT_MULTI_ACCOUNT_FLAG = "fingerprint_multi_account_flag"
     FINGERPRINT_HEADLESS_FLAG = "fingerprint_headless_flag"
+    RECOVERY_BEGIN = "recovery_begin"
+    RECOVERY_COMPLETED = "recovery_completed"
+    RECOVERY_FAILED = "recovery_failed"
     GENESIS = "genesis"
 
 

--- a/api/src/com/qode/qrew/v1/service/repositories/passkey.py
+++ b/api/src/com/qode/qrew/v1/service/repositories/passkey.py
@@ -72,3 +72,10 @@ class PasskeyCredentialRepository:
             .limit(1)
         )
         return result.scalar_one_or_none() is not None
+
+    async def delete_all_by_user_id(self, user_id: uuid.UUID) -> None:
+        """Delete all passkey credentials belonging to the given user."""
+        await self._session.execute(
+            delete(PasskeyCredential).where(PasskeyCredential.user_id == user_id)
+        )
+        await self._session.flush()

--- a/api/src/com/qode/qrew/v1/service/routers/auth.py
+++ b/api/src/com/qode/qrew/v1/service/routers/auth.py
@@ -6,6 +6,7 @@ from fastapi import (
     APIRouter,
     Depends,
     File,
+    Form,
     HTTPException,
     Request,
     Response,
@@ -14,7 +15,11 @@ from fastapi import (
 )
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from com.qode.qrew.v1.service.core.auth import get_current_user, get_setup_or_full_user
+from com.qode.qrew.v1.service.core.auth import (
+    get_current_user,
+    get_recovery_user,
+    get_setup_or_full_user,
+)
 from com.qode.qrew.v1.service.core.captcha import (
     CaptchaError,
     CaptchaService,
@@ -50,6 +55,8 @@ from com.qode.qrew.v1.service.schemas.auth import (
     PasskeyAuthenticationCompleteRequest,
     PasskeyRegistrationCompleteRequest,
     PasskeyRegistrationCompleteResponse,
+    RecoveryBeginResponse,
+    RecoveryCompleteResponse,
     RefreshRequest,
     RefreshResponse,
     RegisterRequest,
@@ -97,6 +104,7 @@ from com.qode.qrew.v1.service.services.phone_change import (
     PhoneChangeError,
     PhoneChangeService,
 )
+from com.qode.qrew.v1.service.services.recovery import RecoveryError, RecoveryService
 from com.qode.qrew.v1.service.services.refresh import RefreshError, RefreshService
 from com.qode.qrew.v1.service.services.registration import (
     RegistrationError,
@@ -251,6 +259,24 @@ def get_fingerprint_service(
     return FingerprintService(DeviceFingerprintRepository(db), AuditService())
 
 
+def get_recovery_service(
+    db: AsyncSession = Depends(get_db),
+    redis: Annotated[aioredis.Redis, Depends(get_redis)] = ...,  # type: ignore[type-arg, assignment]
+    notifier: NotificationDispatcher = Depends(_get_notification_service),
+    ocr: OcrService = Depends(get_ocr_service),
+) -> RecoveryService:
+    """Build and return the account recovery service."""
+    return RecoveryService(
+        UserRepository(db),
+        PasskeyCredentialRepository(db),
+        SessionRepository(db),
+        redis,
+        notifier,
+        AuditService(),
+        ocr,
+    )
+
+
 def get_phone_change_service(
     db: AsyncSession = Depends(get_db),
     notifier: NotificationDispatcher = Depends(_get_notification_service),
@@ -295,6 +321,7 @@ _DomainError = (
     | PasswordChangeError
     | EmailChangeError
     | PhoneChangeError
+    | RecoveryError
 )
 
 
@@ -891,3 +918,56 @@ async def report_fingerprint(
         message="Fingerprint recorded.",
         flagged=flagged,
     )
+
+
+# ── Account recovery ──────────────────────────────────────────────────────────
+
+
+@router.post(
+    "/recovery/begin",
+    response_model=RecoveryBeginResponse,
+    status_code=status.HTTP_200_OK,
+    summary="Begin account recovery by verifying identity via national ID document",
+)
+@limiter.limit("5/hour")  # type: ignore[misc]
+async def recovery_begin(
+    request: Request,
+    email: Annotated[str, Form()],
+    document: Annotated[UploadFile, File()],
+    service: RecoveryService = Depends(get_recovery_service),
+) -> RecoveryBeginResponse:
+    """Verify identity via OCR; return a recovery token and passkey challenge."""
+    content = await document.read()
+    recovery_token, passkey_options = await service.begin(email, content)
+    if recovery_token is None:
+        return RecoveryBeginResponse(
+            message=(
+                "If a matching account was found, recovery instructions have been sent."
+            )
+        )
+    return RecoveryBeginResponse(
+        message="Identity verified. Complete recovery by registering a new passkey.",
+        recovery_token=recovery_token,
+        passkey_options=passkey_options,
+    )
+
+
+@router.post(
+    "/recovery/complete",
+    response_model=RecoveryCompleteResponse,
+    status_code=status.HTTP_200_OK,
+    summary="Complete account recovery by registering a new passkey",
+)
+@limiter.limit("5/hour")  # type: ignore[misc]
+async def recovery_complete(
+    request: Request,
+    body: PasskeyRegistrationCompleteRequest,
+    current_user: User = Depends(get_recovery_user),
+    service: RecoveryService = Depends(get_recovery_service),
+) -> RecoveryCompleteResponse:
+    """Verify WebAuthn attestation, revoke all sessions, register the new passkey."""
+    try:
+        await service.complete(current_user, body)
+        return RecoveryCompleteResponse(message="Account recovery complete.")
+    except RecoveryError as exc:
+        raise _domain_error(exc, status.HTTP_400_BAD_REQUEST) from exc

--- a/api/src/com/qode/qrew/v1/service/schemas/auth.py
+++ b/api/src/com/qode/qrew/v1/service/schemas/auth.py
@@ -261,6 +261,16 @@ class FingerprintReportResponse(BaseModel):
     flagged: bool
 
 
+class RecoveryBeginResponse(BaseModel):
+    message: str
+    recovery_token: str | None = None
+    passkey_options: str | None = None
+
+
+class RecoveryCompleteResponse(BaseModel):
+    message: str
+
+
 class PasskeyAuthenticationBeginRequest(BaseModel):
     email: EmailStr
 

--- a/api/src/com/qode/qrew/v1/service/services/notification.py
+++ b/api/src/com/qode/qrew/v1/service/services/notification.py
@@ -64,6 +64,10 @@ class EmailService(Protocol):
         """Send a security notice to the old email address."""
         ...
 
+    async def send_account_recovery(self, to_email: str, full_name: str) -> None:
+        """Send a security notice that account recovery was completed."""
+        ...
+
 
 class SmsService(Protocol):
     """Sends a single type of transactional SMS."""
@@ -126,6 +130,13 @@ class StubEmailService:
         """Log email change alert."""
         await logger.ainfo(
             "email_change_alert_stub",
+            to=_mask_email(to_email),
+        )
+
+    async def send_account_recovery(self, to_email: str, full_name: str) -> None:
+        """Log account recovery notification."""
+        await logger.ainfo(
+            "account_recovery_stub",
             to=_mask_email(to_email),
         )
 
@@ -272,6 +283,36 @@ class SmtpEmailService:
                 "kyc_status_email_failed", to=_mask_email(to_email), exc_info=exc
             )
 
+    async def send_account_recovery(self, to_email: str, full_name: str) -> None:
+        """Send an account recovery security notice via SMTP."""
+        message = MIMEMultipart("alternative")
+        message["Subject"] = "Your Qrew account has been recovered"
+        message["From"] = self._from_address
+        message["To"] = to_email
+        body = (
+            f"Hello {full_name},\n\n"
+            "Your Qrew account passkey was just reset via account recovery.\n"
+            "If you did not initiate this, contact support immediately.\n\n"
+            "— The Qrew Team"
+        )
+        message.attach(MIMEText(body, "plain"))
+        try:
+            await aiosmtplib.send(
+                message,
+                hostname=self._host,
+                port=self._port,
+                username=self._user,
+                password=self._password,
+                start_tls=True,
+            )
+            await logger.ainfo("account_recovery_email_sent", to=_mask_email(to_email))
+        except Exception as exc:
+            await logger.aerror(
+                "account_recovery_email_failed",
+                to=_mask_email(to_email),
+                exc_info=exc,
+            )
+
 
 class TwilioSmsService:
     def __init__(self, account_sid: str, auth_token: str, from_number: str) -> None:
@@ -345,6 +386,10 @@ class NotificationDispatcher:
     ) -> None:
         """Dispatch a security notice to the old email address."""
         await self._email.send_email_change_alert(to_email, full_name, new_email)
+
+    async def send_account_recovery(self, to_email: str, full_name: str) -> None:
+        """Dispatch an account recovery security notice."""
+        await self._email.send_account_recovery(to_email, full_name)
 
 
 def build_notification_dispatcher() -> NotificationDispatcher:

--- a/api/src/com/qode/qrew/v1/service/services/recovery.py
+++ b/api/src/com/qode/qrew/v1/service/services/recovery.py
@@ -1,0 +1,210 @@
+import hashlib
+import uuid
+from datetime import UTC, datetime, timedelta
+
+import redis.asyncio as aioredis
+import structlog
+import webauthn
+from webauthn.helpers.base64url_to_bytes import base64url_to_bytes
+from webauthn.helpers.structs import (
+    AuthenticatorAttestationResponse,
+    AuthenticatorSelectionCriteria,
+    PublicKeyCredentialType,
+    RegistrationCredential,
+    UserVerificationRequirement,
+)
+
+from com.qode.qrew.v1.service.core.errors import DomainError
+from com.qode.qrew.v1.service.core.security import create_recovery_token
+from com.qode.qrew.v1.service.models.audit import AuditAction
+from com.qode.qrew.v1.service.models.passkey import PasskeyCredential
+from com.qode.qrew.v1.service.models.user import User
+from com.qode.qrew.v1.service.repositories.passkey import PasskeyCredentialRepository
+from com.qode.qrew.v1.service.repositories.session import SessionRepository
+from com.qode.qrew.v1.service.repositories.user import UserRepository
+from com.qode.qrew.v1.service.schemas.auth import PasskeyRegistrationCompleteRequest
+from com.qode.qrew.v1.service.services.audit import AuditService
+from com.qode.qrew.v1.service.services.notification import NotificationDispatcher
+from com.qode.qrew.v1.service.services.ocr import OcrError, OcrService
+from com.qode.qrew.v1.service.settings import settings
+
+logger = structlog.get_logger(__name__)
+
+_CHALLENGE_PREFIX = "webauthn:recovery:challenge:"
+_CHALLENGE_TTL_SECONDS = 300
+_BLACKLIST_JTI_PREFIX = "blacklist:jti:"
+
+
+class RecoveryError(DomainError):
+    """Raised when an account recovery operation cannot be completed."""
+
+
+class RecoveryService:
+    def __init__(
+        self,
+        user_repo: UserRepository,
+        passkey_repo: PasskeyCredentialRepository,
+        session_repo: SessionRepository,
+        redis: aioredis.Redis,  # type: ignore[type-arg]
+        notifier: NotificationDispatcher,
+        audit: AuditService,
+        ocr: OcrService,
+    ) -> None:
+        self._user_repo = user_repo
+        self._passkey_repo = passkey_repo
+        self._session_repo = session_repo
+        self._redis = redis
+        self._notifier = notifier
+        self._audit = audit
+        self._ocr = ocr
+
+    async def begin(self, email: str, document: bytes) -> tuple[str | None, str]:
+        """Verify identity via OCR + email and return (recovery_token, options_json).
+
+        Returns (None, "") if no match — callers must return 200 regardless to
+        prevent account enumeration.
+        """
+        try:
+            id_number = self._ocr.extract_national_id(document)
+        except OcrError:
+            await self._audit_failed(None, "ocr_failed")
+            return None, ""
+
+        id_hash = hashlib.sha256(id_number.encode()).hexdigest()
+
+        user = await self._user_repo.get_by_email(email.lower())
+        if user is None or not user.is_active or user.national_id_hash != id_hash:
+            await self._audit_failed(user.id if user else None, "identity_mismatch")
+            return None, ""
+
+        options = webauthn.generate_registration_options(
+            rp_id=settings.rp_id,
+            rp_name=settings.rp_name,
+            user_id=str(user.id).encode(),
+            user_name=user.email,
+            user_display_name=user.full_name,
+            authenticator_selection=AuthenticatorSelectionCriteria(
+                user_verification=UserVerificationRequirement.REQUIRED,
+            ),
+        )
+        await self._redis.set(
+            _CHALLENGE_PREFIX + str(user.id),
+            options.challenge,
+            ex=_CHALLENGE_TTL_SECONDS,
+        )
+
+        token = create_recovery_token(str(user.id))
+
+        await logger.ainfo("recovery_begin", user_id=str(user.id))
+        try:
+            await self._audit.record(
+                action=AuditAction.RECOVERY_BEGIN,
+                actor_id=user.id,
+                entity_type="user",
+                entity_id=str(user.id),
+            )
+        except Exception:
+            await logger.awarning(
+                "audit_write_failed", action=AuditAction.RECOVERY_BEGIN
+            )
+
+        return token, webauthn.options_to_json(options)
+
+    async def complete(
+        self,
+        user: User,
+        request: PasskeyRegistrationCompleteRequest,
+    ) -> None:
+        """Verify passkey attestation, revoke all sessions, register new credential."""
+        raw_challenge: bytes | None = await self._redis.get(
+            _CHALLENGE_PREFIX + str(user.id)
+        )
+        if raw_challenge is None:
+            raise RecoveryError(
+                "Recovery session expired. Please start again.", field=None
+            )
+
+        await self._redis.delete(_CHALLENGE_PREFIX + str(user.id))
+
+        credential = RegistrationCredential(
+            id=request.id,
+            raw_id=base64url_to_bytes(request.raw_id),
+            response=AuthenticatorAttestationResponse(
+                client_data_json=base64url_to_bytes(request.response.client_data_json),
+                attestation_object=base64url_to_bytes(
+                    request.response.attestation_object
+                ),
+            ),
+            type=PublicKeyCredentialType.PUBLIC_KEY,
+        )
+
+        try:
+            verification = webauthn.verify_registration_response(
+                credential=credential,
+                expected_challenge=raw_challenge,
+                expected_rp_id=settings.rp_id,
+                expected_origin=settings.rp_expected_origin,
+                require_user_verification=True,
+            )
+        except Exception as exc:
+            msg = (
+                f"Passkey registration failed: {exc}"
+                if settings.debug
+                else "Passkey registration failed. Please try again."
+            )
+            raise RecoveryError(msg) from exc
+
+        jtis = await self._session_repo.delete_all_by_user_id(user.id)
+        now_ts = int(datetime.now(UTC).timestamp())
+        exp_ts = now_ts + int(
+            timedelta(days=settings.refresh_token_expire_days).total_seconds()
+        )
+        ttl = exp_ts - now_ts
+        for jti in jtis:
+            await self._redis.setex(_BLACKLIST_JTI_PREFIX + jti, ttl, "1")
+
+        await self._passkey_repo.delete_all_by_user_id(user.id)
+
+        await self._passkey_repo.create(
+            PasskeyCredential(
+                id=uuid.uuid4(),
+                user_id=user.id,
+                credential_id=verification.credential_id,
+                public_key=verification.credential_public_key,
+                sign_count=verification.sign_count,
+                aaguid=str(verification.aaguid),
+            )
+        )
+
+        try:
+            await self._notifier.send_account_recovery(user.email, user.full_name)
+        except Exception:
+            await logger.awarning("notification_failed", action="account_recovery")
+
+        await logger.ainfo("recovery_completed", user_id=str(user.id))
+        try:
+            await self._audit.record(
+                action=AuditAction.RECOVERY_COMPLETED,
+                actor_id=user.id,
+                entity_type="user",
+                entity_id=str(user.id),
+            )
+        except Exception:
+            await logger.awarning(
+                "audit_write_failed", action=AuditAction.RECOVERY_COMPLETED
+            )
+
+    async def _audit_failed(self, actor_id: uuid.UUID | None, reason: str) -> None:
+        await logger.awarning("recovery_failed", reason=reason)
+        try:
+            await self._audit.record(
+                action=AuditAction.RECOVERY_FAILED,
+                actor_id=actor_id,
+                entity_type="user",
+                entity_id=str(actor_id) if actor_id else None,
+                payload={"reason": reason},
+            )
+        except Exception:
+            await logger.awarning(
+                "audit_write_failed", action=AuditAction.RECOVERY_FAILED
+            )

--- a/api/tests/v1/auth/unit/recovery_test.py
+++ b/api/tests/v1/auth/unit/recovery_test.py
@@ -1,0 +1,174 @@
+"""Tests for account-recovery endpoints:
+POST /v1/auth/recovery/begin
+POST /v1/auth/recovery/complete
+"""
+
+import uuid
+from collections.abc import Iterator
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from httpx import AsyncClient
+
+from com.qode.qrew.v1.service.core.auth import get_recovery_user
+from com.qode.qrew.v1.service.main import app
+from com.qode.qrew.v1.service.routers.auth import get_recovery_service
+from com.qode.qrew.v1.service.services.recovery import RecoveryError
+
+_BEGIN_ENDPOINT = "/v1/auth/recovery/begin"
+_COMPLETE_ENDPOINT = "/v1/auth/recovery/complete"
+
+_FAKE_DOCUMENT = b"fake-national-id-document"
+_FAKE_EMAIL = "user@example.com"
+_FAKE_RECOVERY_TOKEN = "recovery.jwt.token"
+_FAKE_PASSKEY_OPTIONS = '{"challenge":"abc123"}'
+
+_COMPLETE_BODY = {
+    "id": "credential-id",
+    "rawId": "cmF3LWlk",
+    "response": {
+        "clientDataJSON": "Y2xpZW50LWRhdGE=",
+        "attestationObject": "YXR0ZXN0YXRpb24=",
+    },
+    "type": "public-key",
+}
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+
+def _mock_user() -> MagicMock:
+    user = MagicMock()
+    user.id = uuid.uuid4()
+    return user
+
+
+@pytest.fixture
+def mock_service() -> AsyncMock:
+    service = AsyncMock()
+    service.begin = AsyncMock(
+        return_value=(_FAKE_RECOVERY_TOKEN, _FAKE_PASSKEY_OPTIONS)
+    )
+    service.complete = AsyncMock(return_value=None)
+    return service
+
+
+@pytest.fixture(autouse=True)
+def override_dependencies(mock_service: AsyncMock) -> Iterator[None]:
+    app.dependency_overrides[get_recovery_service] = lambda: mock_service
+    app.dependency_overrides[get_recovery_user] = _mock_user
+    yield
+    app.dependency_overrides.clear()
+
+
+# ── recovery/begin happy path ─────────────────────────────────────────────────
+
+
+async def test_begin_returns_200_with_token(
+    client: AsyncClient, mock_service: AsyncMock
+) -> None:
+    response = await client.post(
+        _BEGIN_ENDPOINT,
+        data={"email": _FAKE_EMAIL},
+        files={"document": ("id.jpg", _FAKE_DOCUMENT, "image/jpeg")},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["recovery_token"] == _FAKE_RECOVERY_TOKEN
+    assert body["passkey_options"] == _FAKE_PASSKEY_OPTIONS
+
+
+async def test_begin_calls_service_with_email_and_content(
+    client: AsyncClient, mock_service: AsyncMock
+) -> None:
+    await client.post(
+        _BEGIN_ENDPOINT,
+        data={"email": _FAKE_EMAIL},
+        files={"document": ("id.jpg", _FAKE_DOCUMENT, "image/jpeg")},
+    )
+
+    mock_service.begin.assert_awaited_once_with(_FAKE_EMAIL, _FAKE_DOCUMENT)
+
+
+async def test_begin_returns_200_with_no_token_when_no_match(
+    client: AsyncClient, mock_service: AsyncMock
+) -> None:
+    mock_service.begin = AsyncMock(return_value=(None, ""))
+
+    response = await client.post(
+        _BEGIN_ENDPOINT,
+        data={"email": _FAKE_EMAIL},
+        files={"document": ("id.jpg", _FAKE_DOCUMENT, "image/jpeg")},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["recovery_token"] is None
+    assert body["passkey_options"] is None
+    assert "matching account" in body["message"]
+
+
+# ── recovery/begin validation ─────────────────────────────────────────────────
+
+
+async def test_begin_requires_email_field(client: AsyncClient) -> None:
+    response = await client.post(
+        _BEGIN_ENDPOINT,
+        files={"document": ("id.jpg", _FAKE_DOCUMENT, "image/jpeg")},
+    )
+
+    assert response.status_code == 422
+
+
+async def test_begin_requires_document_field(client: AsyncClient) -> None:
+    response = await client.post(
+        _BEGIN_ENDPOINT,
+        data={"email": _FAKE_EMAIL},
+    )
+
+    assert response.status_code == 422
+
+
+# ── recovery/complete happy path ──────────────────────────────────────────────
+
+
+async def test_complete_returns_200(
+    client: AsyncClient, mock_service: AsyncMock
+) -> None:
+    response = await client.post(_COMPLETE_ENDPOINT, json=_COMPLETE_BODY)
+
+    assert response.status_code == 200
+    assert "complete" in response.json()["message"].lower()
+
+
+async def test_complete_calls_service(
+    client: AsyncClient, mock_service: AsyncMock
+) -> None:
+    await client.post(_COMPLETE_ENDPOINT, json=_COMPLETE_BODY)
+
+    mock_service.complete.assert_awaited_once()
+
+
+# ── recovery/complete error handling ─────────────────────────────────────────
+
+
+async def test_complete_returns_400_on_recovery_error(
+    client: AsyncClient, mock_service: AsyncMock
+) -> None:
+    mock_service.complete = AsyncMock(
+        side_effect=RecoveryError("Recovery session expired. Please start again.")
+    )
+
+    response = await client.post(_COMPLETE_ENDPOINT, json=_COMPLETE_BODY)
+
+    assert response.status_code == 400
+    assert "expired" in response.json()["detail"]["message"]
+
+
+async def test_complete_requires_recovery_token(client: AsyncClient) -> None:
+    app.dependency_overrides.pop(get_recovery_user, None)
+
+    response = await client.post(_COMPLETE_ENDPOINT, json=_COMPLETE_BODY)
+
+    assert response.status_code == 401


### PR DESCRIPTION
## Summary

Implements the two-step account recovery flow.

A locked-out user submits their email and a national ID document photo. The server runs OCR, hashes the extracted ID number, and matches it against the stored hash on the user record.

If the identity is verified, the server issues a short-lived `recovery`-scoped JWT and returns a WebAuthn registration challenge.

The user then completes a new passkey registration against that challenge, which atomically revokes all existing sessions (JTIs blacklisted in Redis), deletes all existing passkey credentials, and registers the new one.

A security email is sent on successful completion.

## Verification

- `tests/v1/auth/unit/recovery_test.py`

## Issue Reference

Closes [QRW-65](https://github.com/cristiangilsanz/qrew/issues/65)

## Checklist
- [x] I confirm that this PR follows the project's established coding standards.