### PR TITLE
feat: implement cryptographic device binding

### DIFF
--- a/api/alembic/versions/6f9d4a5d9ce4_add_devices_table.py
+++ b/api/alembic/versions/6f9d4a5d9ce4_add_devices_table.py
@@ -1,0 +1,44 @@
+"""add devices table
+
+Revision ID: 6f9d4a5d9ce4
+Revises: eab10f45b3a7
+Create Date: 2026-05-24 22:30:39.350102
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "6f9d4a5d9ce4"
+down_revision: str | None = "eab10f45b3a7"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "devices",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("user_id", sa.UUID(), nullable=False),
+        sa.Column("name", sa.String(length=128), nullable=False),
+        sa.Column("public_key", sa.LargeBinary(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column("last_seen_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("revoked_at", sa.DateTime(timezone=True), nullable=True),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("public_key"),
+    )
+    op.create_index(op.f("ix_devices_user_id"), "devices", ["user_id"], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index(op.f("ix_devices_user_id"), table_name="devices")
+    op.drop_table("devices")

--- a/api/src/com/qode/qrew/v1/service/models/__init__.py
+++ b/api/src/com/qode/qrew/v1/service/models/__init__.py
@@ -1,5 +1,17 @@
 from com.qode.qrew.v1.service.core.database import Base
+from com.qode.qrew.v1.service.models.audit import AuditEvent
+from com.qode.qrew.v1.service.models.device import Device
+from com.qode.qrew.v1.service.models.fingerprint import DeviceFingerprint
 from com.qode.qrew.v1.service.models.passkey import PasskeyCredential
+from com.qode.qrew.v1.service.models.session import Session
 from com.qode.qrew.v1.service.models.user import User
 
-__all__ = ["Base", "PasskeyCredential", "User"]
+__all__ = [
+    "AuditEvent",
+    "Base",
+    "Device",
+    "DeviceFingerprint",
+    "PasskeyCredential",
+    "Session",
+    "User",
+]

--- a/api/src/com/qode/qrew/v1/service/models/audit.py
+++ b/api/src/com/qode/qrew/v1/service/models/audit.py
@@ -36,6 +36,7 @@ class AuditAction(enum.StrEnum):
     RECOVERY_COMPLETED = "recovery_completed"
     RECOVERY_FAILED = "recovery_failed"
     LOGIN_ANOMALY_DETECTED = "login_anomaly_detected"
+    DEVICE_BIND = "device_bind"
     GENESIS = "genesis"
 
 

--- a/api/src/com/qode/qrew/v1/service/models/device.py
+++ b/api/src/com/qode/qrew/v1/service/models/device.py
@@ -1,0 +1,33 @@
+import uuid
+from datetime import datetime
+
+from sqlalchemy import DateTime, ForeignKey, LargeBinary, String, func
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from com.qode.qrew.v1.service.core.database import Base
+
+
+class Device(Base):
+    __tablename__ = "devices"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    name: Mapped[str] = mapped_column(String(128), nullable=False)
+    public_key: Mapped[bytes] = mapped_column(LargeBinary, nullable=False, unique=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    last_seen_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    revoked_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )

--- a/api/src/com/qode/qrew/v1/service/repositories/device.py
+++ b/api/src/com/qode/qrew/v1/service/repositories/device.py
@@ -1,0 +1,46 @@
+import uuid
+
+from sqlalchemy import delete, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from com.qode.qrew.v1.service.models.device import Device
+
+
+class DeviceRepository:
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+
+    async def create(self, device: Device) -> Device:
+        self._session.add(device)
+        await self._session.flush()
+        await self._session.refresh(device)
+        return device
+
+    async def get_by_id(self, device_id: uuid.UUID) -> Device | None:
+        result = await self._session.execute(
+            select(Device).where(Device.id == device_id).limit(1)
+        )
+        return result.scalar_one_or_none()
+
+    async def get_all_by_user_id(self, user_id: uuid.UUID) -> list[Device]:
+        result = await self._session.execute(
+            select(Device)
+            .where(Device.user_id == user_id)
+            .order_by(Device.created_at.desc())
+        )
+        return list(result.scalars().all())
+
+    async def get_by_public_key(self, public_key: bytes) -> Device | None:
+        result = await self._session.execute(
+            select(Device).where(Device.public_key == public_key).limit(1)
+        )
+        return result.scalar_one_or_none()
+
+    async def save(self, device: Device) -> Device:
+        await self._session.flush()
+        await self._session.refresh(device)
+        return device
+
+    async def delete_by_id(self, device_id: uuid.UUID) -> None:
+        await self._session.execute(delete(Device).where(Device.id == device_id))
+        await self._session.flush()

--- a/api/src/com/qode/qrew/v1/service/routers/auth.py
+++ b/api/src/com/qode/qrew/v1/service/routers/auth.py
@@ -29,6 +29,7 @@ from com.qode.qrew.v1.service.core.database import get_db
 from com.qode.qrew.v1.service.core.limiter import limiter
 from com.qode.qrew.v1.service.core.redis import get_redis
 from com.qode.qrew.v1.service.models.user import User
+from com.qode.qrew.v1.service.repositories.device import DeviceRepository
 from com.qode.qrew.v1.service.repositories.fingerprint import (
     DeviceFingerprintRepository,
 )
@@ -44,6 +45,9 @@ from com.qode.qrew.v1.service.schemas.auth import (
     ChangePhoneResponse,
     ConfirmEmailChangeRequest,
     ConfirmPhoneChangeRequest,
+    DeviceBindBeginResponse,
+    DeviceBindCompleteRequest,
+    DeviceBindCompleteResponse,
     FingerprintReportRequest,
     FingerprintReportResponse,
     KycUploadResponse,
@@ -81,6 +85,10 @@ from com.qode.qrew.v1.service.services.audit import AuditService
 from com.qode.qrew.v1.service.services.complete_setup import (
     CompleteSetupService,
     SetupError,
+)
+from com.qode.qrew.v1.service.services.device_binding import (
+    DeviceBindingError,
+    DeviceBindingService,
 )
 from com.qode.qrew.v1.service.services.email_change import (
     EmailChangeError,
@@ -305,6 +313,14 @@ def get_phone_change_service(
     return PhoneChangeService(UserRepository(db), notifier, AuditService())
 
 
+def get_device_binding_service(
+    db: AsyncSession = Depends(get_db),
+    redis: Annotated[aioredis.Redis, Depends(get_redis)] = ...,  # type: ignore[type-arg, assignment]
+) -> DeviceBindingService:
+    """Build and return the device binding service."""
+    return DeviceBindingService(DeviceRepository(db), redis, AuditService())
+
+
 def get_email_change_service(
     db: AsyncSession = Depends(get_db),
     notifier: NotificationDispatcher = Depends(_get_notification_service),
@@ -342,6 +358,7 @@ _DomainError = (
     | EmailChangeError
     | PhoneChangeError
     | RecoveryError
+    | DeviceBindingError
 )
 
 
@@ -990,4 +1007,50 @@ async def recovery_complete(
         await service.complete(current_user, body)
         return RecoveryCompleteResponse(message="Account recovery complete.")
     except RecoveryError as exc:
+        raise _domain_error(exc, status.HTTP_400_BAD_REQUEST) from exc
+
+
+# ── Cryptographic device binding ──────────────────────────────────────────────
+
+
+@router.post(
+    "/devices/bind/begin",
+    response_model=DeviceBindBeginResponse,
+    status_code=status.HTTP_200_OK,
+    summary="Begin device binding — returns a challenge nonce to sign",
+)
+@limiter.limit("10/hour")  # type: ignore[misc]
+async def device_bind_begin(
+    request: Request,
+    current_user: User = Depends(get_current_user),
+    service: DeviceBindingService = Depends(get_device_binding_service),
+) -> DeviceBindBeginResponse:
+    """Generate a challenge for the client to sign with its private key."""
+    challenge = await service.begin(current_user)
+    return DeviceBindBeginResponse(challenge=challenge)
+
+
+@router.post(
+    "/devices/bind/complete",
+    response_model=DeviceBindCompleteResponse,
+    status_code=status.HTTP_201_CREATED,
+    summary="Complete device binding by submitting signed challenge + public key",
+)
+@limiter.limit("10/hour")  # type: ignore[misc]
+async def device_bind_complete(
+    request: Request,
+    body: DeviceBindCompleteRequest,
+    current_user: User = Depends(get_current_user),
+    service: DeviceBindingService = Depends(get_device_binding_service),
+) -> DeviceBindCompleteResponse:
+    """Verify ECDSA-P256 signature, register the public key as a bound device."""
+    try:
+        device = await service.complete(
+            current_user, body.name, body.public_key, body.signature
+        )
+        return DeviceBindCompleteResponse(
+            device_id=str(device.id),
+            message="Device bound successfully.",
+        )
+    except DeviceBindingError as exc:
         raise _domain_error(exc, status.HTTP_400_BAD_REQUEST) from exc

--- a/api/src/com/qode/qrew/v1/service/schemas/auth.py
+++ b/api/src/com/qode/qrew/v1/service/schemas/auth.py
@@ -271,6 +271,21 @@ class RecoveryCompleteResponse(BaseModel):
     message: str
 
 
+class DeviceBindBeginResponse(BaseModel):
+    challenge: str
+
+
+class DeviceBindCompleteRequest(BaseModel):
+    name: str = Field(..., min_length=1, max_length=128)
+    public_key: str = Field(..., min_length=1, max_length=512)
+    signature: str = Field(..., min_length=1, max_length=256)
+
+
+class DeviceBindCompleteResponse(BaseModel):
+    device_id: str
+    message: str
+
+
 class PasskeyAuthenticationBeginRequest(BaseModel):
     email: EmailStr
 

--- a/api/src/com/qode/qrew/v1/service/services/device_binding.py
+++ b/api/src/com/qode/qrew/v1/service/services/device_binding.py
@@ -1,0 +1,160 @@
+import base64
+import uuid
+from datetime import UTC, datetime
+
+import redis.asyncio as aioredis
+import structlog
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives.asymmetric.ec import ECDSA, EllipticCurvePublicKey
+from cryptography.hazmat.primitives.asymmetric.utils import encode_dss_signature
+from cryptography.hazmat.primitives.hashes import SHA256
+from cryptography.hazmat.primitives.serialization import load_der_public_key
+
+from com.qode.qrew.v1.service.core.errors import DomainError
+from com.qode.qrew.v1.service.models.audit import AuditAction
+from com.qode.qrew.v1.service.models.device import Device
+from com.qode.qrew.v1.service.models.user import User
+from com.qode.qrew.v1.service.repositories.device import DeviceRepository
+from com.qode.qrew.v1.service.services.audit import AuditService
+
+logger = structlog.get_logger(__name__)
+
+_CHALLENGE_PREFIX = "device:bind:challenge:"
+_CHALLENGE_TTL_SECONDS = 300
+
+
+class DeviceBindingError(DomainError):
+    """Raised when a device binding operation cannot be completed."""
+
+
+class DeviceBindingService:
+    def __init__(
+        self,
+        device_repo: DeviceRepository,
+        redis: aioredis.Redis,  # type: ignore[type-arg]
+        audit: AuditService,
+    ) -> None:
+        self._device_repo = device_repo
+        self._redis = redis
+        self._audit = audit
+
+    async def begin(self, user: User) -> str:
+        """Generate a challenge nonce and store it in Redis. Returns the challenge."""
+        challenge = str(uuid.uuid4())
+        await self._redis.set(
+            _CHALLENGE_PREFIX + str(user.id),
+            challenge,
+            ex=_CHALLENGE_TTL_SECONDS,
+        )
+        await logger.ainfo("device_bind_begin", user_id=str(user.id))
+        return challenge
+
+    async def complete(
+        self,
+        user: User,
+        name: str,
+        public_key_b64: str,
+        signature_b64: str,
+    ) -> Device:
+        """Verify ECDSA signature over the challenge, persist the device."""
+        raw_challenge: bytes | None = await self._redis.get(
+            _CHALLENGE_PREFIX + str(user.id)
+        )
+        if raw_challenge is None:
+            raise DeviceBindingError(
+                "Binding session expired. Please start again.", field=None
+            )
+        await self._redis.delete(_CHALLENGE_PREFIX + str(user.id))
+
+        challenge_str = raw_challenge.decode()
+
+        try:
+            public_key_bytes = base64.urlsafe_b64decode(_pad_b64(public_key_b64))
+        except Exception as exc:
+            raise DeviceBindingError(
+                "Invalid public key encoding.", field="public_key"
+            ) from exc
+
+        try:
+            pub_key = load_der_public_key(public_key_bytes)
+        except Exception as exc:
+            raise DeviceBindingError(
+                "Invalid public key format. Expected SPKI DER.", field="public_key"
+            ) from exc
+
+        if not isinstance(pub_key, EllipticCurvePublicKey):
+            raise DeviceBindingError(
+                "Only ECDSA P-256 keys are accepted.", field="public_key"
+            )
+
+        try:
+            sig_bytes = base64.urlsafe_b64decode(_pad_b64(signature_b64))
+        except Exception as exc:
+            raise DeviceBindingError(
+                "Invalid signature encoding.", field="signature"
+            ) from exc
+
+        _verify_ecdsa(pub_key, sig_bytes, challenge_str.encode())
+
+        existing = await self._device_repo.get_by_public_key(public_key_bytes)
+        if existing is not None:
+            raise DeviceBindingError(
+                "This key is already registered.", field="public_key"
+            )
+
+        device = await self._device_repo.create(
+            Device(
+                id=uuid.uuid4(),
+                user_id=user.id,
+                name=name,
+                public_key=public_key_bytes,
+                last_seen_at=datetime.now(UTC),
+            )
+        )
+
+        await logger.ainfo("device_bind_complete", user_id=str(user.id))
+        try:
+            await self._audit.record(
+                action=AuditAction.DEVICE_BIND,
+                actor_id=user.id,
+                entity_type="device",
+                entity_id=str(device.id),
+                payload={"device_name": name},
+            )
+        except Exception:
+            await logger.awarning("audit_write_failed", action=AuditAction.DEVICE_BIND)
+
+        return device
+
+
+def _pad_b64(value: str) -> str:
+    """Add base64url padding if missing."""
+    return value + "=" * (-len(value) % 4)
+
+
+def _verify_ecdsa(
+    pub_key: EllipticCurvePublicKey,
+    sig_bytes: bytes,
+    data: bytes,
+) -> None:
+    """Verify ECDSA-P256-SHA256. Accepts DER or raw P1363 (r||s) signatures."""
+    key_size_bytes = (pub_key.key_size + 7) // 8
+    p1363_len = key_size_bytes * 2
+
+    if len(sig_bytes) == p1363_len:
+        r = int.from_bytes(sig_bytes[:key_size_bytes], "big")
+        s = int.from_bytes(sig_bytes[key_size_bytes:], "big")
+        der_sig = encode_dss_signature(r, s)
+    else:
+        der_sig = sig_bytes
+
+    try:
+        pub_key.verify(der_sig, data, ECDSA(SHA256()))
+    except InvalidSignature as exc:
+        raise DeviceBindingError(
+            "Signature verification failed.", field="signature"
+        ) from exc
+    except Exception as exc:
+        raise DeviceBindingError(
+            "Signature verification failed.", field="signature"
+        ) from exc

--- a/api/tests/v1/auth/unit/device_binding_test.py
+++ b/api/tests/v1/auth/unit/device_binding_test.py
@@ -1,0 +1,204 @@
+"""Tests for cryptographic device-binding endpoints:
+POST /v1/auth/devices/bind/begin
+POST /v1/auth/devices/bind/complete
+"""
+
+import uuid
+from collections.abc import Iterator
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from httpx import AsyncClient
+
+from com.qode.qrew.v1.service.core.auth import get_current_user
+from com.qode.qrew.v1.service.main import app
+from com.qode.qrew.v1.service.routers.auth import get_device_binding_service
+from com.qode.qrew.v1.service.services.device_binding import DeviceBindingError
+
+_BEGIN_ENDPOINT = "/v1/auth/devices/bind/begin"
+_COMPLETE_ENDPOINT = "/v1/auth/devices/bind/complete"
+
+_FAKE_CHALLENGE = "550e8400-e29b-41d4-a716-446655440000"
+_FAKE_DEVICE_ID = uuid.uuid4()
+
+_COMPLETE_BODY = {
+    "name": "My Phone",
+    "public_key": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE",
+    "signature": "MEUCIQD",
+}
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+
+def _mock_user() -> MagicMock:
+    user = MagicMock()
+    user.id = uuid.uuid4()
+    user.email = "user@example.com"
+    return user
+
+
+def _mock_device() -> MagicMock:
+    device = MagicMock()
+    device.id = _FAKE_DEVICE_ID
+    return device
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def mock_service() -> AsyncMock:
+    service = AsyncMock()
+    service.begin = AsyncMock(return_value=_FAKE_CHALLENGE)
+    service.complete = AsyncMock(return_value=_mock_device())
+    return service
+
+
+@pytest.fixture(autouse=True)
+def override_dependencies(mock_service: AsyncMock) -> Iterator[None]:
+    app.dependency_overrides[get_device_binding_service] = lambda: mock_service
+    app.dependency_overrides[get_current_user] = _mock_user
+    yield
+    app.dependency_overrides.clear()
+
+
+# ── bind/begin happy path ─────────────────────────────────────────────────────
+
+
+async def test_begin_returns_200_with_challenge(
+    client: AsyncClient, mock_service: AsyncMock
+) -> None:
+    response = await client.post(_BEGIN_ENDPOINT)
+
+    assert response.status_code == 200
+    assert response.json()["challenge"] == _FAKE_CHALLENGE
+
+
+async def test_begin_calls_service_with_current_user(
+    client: AsyncClient, mock_service: AsyncMock
+) -> None:
+    await client.post(_BEGIN_ENDPOINT)
+
+    mock_service.begin.assert_awaited_once()
+
+
+# ── bind/begin auth guard ─────────────────────────────────────────────────────
+
+
+async def test_begin_requires_auth(client: AsyncClient) -> None:
+    app.dependency_overrides.pop(get_current_user, None)
+
+    response = await client.post(_BEGIN_ENDPOINT)
+
+    assert response.status_code == 401
+
+
+# ── bind/complete happy path ──────────────────────────────────────────────────
+
+
+async def test_complete_returns_201_with_device_id(
+    client: AsyncClient, mock_service: AsyncMock
+) -> None:
+    response = await client.post(_COMPLETE_ENDPOINT, json=_COMPLETE_BODY)
+
+    assert response.status_code == 201
+    body = response.json()
+    assert body["device_id"] == str(_FAKE_DEVICE_ID)
+    assert "successfully" in body["message"].lower()
+
+
+async def test_complete_calls_service_with_body_fields(
+    client: AsyncClient, mock_service: AsyncMock
+) -> None:
+    await client.post(_COMPLETE_ENDPOINT, json=_COMPLETE_BODY)
+
+    mock_service.complete.assert_awaited_once_with(
+        mock_service.complete.call_args[0][0],
+        _COMPLETE_BODY["name"],
+        _COMPLETE_BODY["public_key"],
+        _COMPLETE_BODY["signature"],
+    )
+
+
+# ── bind/complete validation ──────────────────────────────────────────────────
+
+
+async def test_complete_requires_name_field(client: AsyncClient) -> None:
+    body = {k: v for k, v in _COMPLETE_BODY.items() if k != "name"}
+
+    response = await client.post(_COMPLETE_ENDPOINT, json=body)
+
+    assert response.status_code == 422
+
+
+async def test_complete_requires_public_key_field(client: AsyncClient) -> None:
+    body = {k: v for k, v in _COMPLETE_BODY.items() if k != "public_key"}
+
+    response = await client.post(_COMPLETE_ENDPOINT, json=body)
+
+    assert response.status_code == 422
+
+
+async def test_complete_requires_signature_field(client: AsyncClient) -> None:
+    body = {k: v for k, v in _COMPLETE_BODY.items() if k != "signature"}
+
+    response = await client.post(_COMPLETE_ENDPOINT, json=body)
+
+    assert response.status_code == 422
+
+
+# ── bind/complete error handling ──────────────────────────────────────────────
+
+
+async def test_complete_returns_400_on_expired_challenge(
+    client: AsyncClient, mock_service: AsyncMock
+) -> None:
+    mock_service.complete = AsyncMock(
+        side_effect=DeviceBindingError(
+            "Binding session expired. Please start again.", field=None
+        )
+    )
+
+    response = await client.post(_COMPLETE_ENDPOINT, json=_COMPLETE_BODY)
+
+    assert response.status_code == 400
+    assert "expired" in response.json()["detail"]["message"]
+
+
+async def test_complete_returns_400_on_duplicate_key(
+    client: AsyncClient, mock_service: AsyncMock
+) -> None:
+    mock_service.complete = AsyncMock(
+        side_effect=DeviceBindingError(
+            "This key is already registered.", field="public_key"
+        )
+    )
+
+    response = await client.post(_COMPLETE_ENDPOINT, json=_COMPLETE_BODY)
+
+    assert response.status_code == 400
+    assert "registered" in response.json()["detail"]["message"]
+
+
+async def test_complete_returns_400_on_invalid_signature(
+    client: AsyncClient, mock_service: AsyncMock
+) -> None:
+    mock_service.complete = AsyncMock(
+        side_effect=DeviceBindingError(
+            "Signature verification failed.", field="signature"
+        )
+    )
+
+    response = await client.post(_COMPLETE_ENDPOINT, json=_COMPLETE_BODY)
+
+    assert response.status_code == 400
+    assert "signature" in response.json()["detail"]["message"].lower()
+
+
+async def test_complete_requires_auth(client: AsyncClient) -> None:
+    app.dependency_overrides.pop(get_current_user, None)
+
+    response = await client.post(_COMPLETE_ENDPOINT, json=_COMPLETE_BODY)
+
+    assert response.status_code == 401


### PR DESCRIPTION
## Summary

Implements a two-step cryptographic device binding flow that lets clients register a device-held ECDSA P-256 private key with the server, without the key ever leaving the device's Secure Enclave or TEE.

## Verification

- `tests/v1/auth/unit/device_binding_test.py`

## Issue Reference

Closes [QRW-66](https://github.com/cristiangilsanz/qrew/issues/66)

## Checklist
- [x] I confirm that this PR follows the project's established coding standards.