### PR TITLE
feat: implement device list and lost-device deregistration

### DIFF
--- a/api/src/com/qode/qrew/v1/service/models/audit.py
+++ b/api/src/com/qode/qrew/v1/service/models/audit.py
@@ -37,6 +37,8 @@ class AuditAction(enum.StrEnum):
     RECOVERY_FAILED = "recovery_failed"
     LOGIN_ANOMALY_DETECTED = "login_anomaly_detected"
     DEVICE_BIND = "device_bind"
+    DEVICE_REVOKE = "device_revoke"
+    DEVICE_REVOKE_ALL = "device_revoke_all"
     GENESIS = "genesis"
 
 

--- a/api/src/com/qode/qrew/v1/service/repositories/device.py
+++ b/api/src/com/qode/qrew/v1/service/repositories/device.py
@@ -1,4 +1,5 @@
 import uuid
+from datetime import UTC, datetime
 
 from sqlalchemy import delete, select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -29,6 +30,33 @@ class DeviceRepository:
             .order_by(Device.created_at.desc())
         )
         return list(result.scalars().all())
+
+    async def get_active_by_user_id(self, user_id: uuid.UUID) -> list[Device]:
+        """Return non-revoked devices for the user, newest first."""
+        result = await self._session.execute(
+            select(Device)
+            .where(Device.user_id == user_id, Device.revoked_at.is_(None))
+            .order_by(Device.created_at.desc())
+        )
+        return list(result.scalars().all())
+
+    async def revoke_all_by_user_id(
+        self, user_id: uuid.UUID, exclude_id: uuid.UUID | None = None
+    ) -> int:
+        """Mark all active devices as revoked; optionally exclude one device.
+        Returns the number of devices revoked."""
+        stmt = select(Device).where(
+            Device.user_id == user_id, Device.revoked_at.is_(None)
+        )
+        if exclude_id is not None:
+            stmt = stmt.where(Device.id != exclude_id)
+        result = await self._session.execute(stmt)
+        devices = list(result.scalars().all())
+        now = datetime.now(UTC)
+        for device in devices:
+            device.revoked_at = now
+        await self._session.flush()
+        return len(devices)
 
     async def get_by_public_key(self, public_key: bytes) -> Device | None:
         result = await self._session.execute(

--- a/api/src/com/qode/qrew/v1/service/routers/auth.py
+++ b/api/src/com/qode/qrew/v1/service/routers/auth.py
@@ -1,3 +1,4 @@
+import contextlib
 import uuid
 from typing import Annotated
 
@@ -72,6 +73,12 @@ from com.qode.qrew.v1.service.schemas.auth import (
     VerifyPhoneRequest,
     VerifyResponse,
 )
+from com.qode.qrew.v1.service.schemas.device import (
+    DeviceListResponse,
+    DeviceResponse,
+    DeviceRevokeAllResponse,
+    DeviceRevokeResponse,
+)
 from com.qode.qrew.v1.service.schemas.passkey import (
     PasskeyListResponse,
     PasskeyRenameRequest,
@@ -86,6 +93,7 @@ from com.qode.qrew.v1.service.services.complete_setup import (
     CompleteSetupService,
     SetupError,
 )
+from com.qode.qrew.v1.service.services.device import DeviceError, DeviceService
 from com.qode.qrew.v1.service.services.device_binding import (
     DeviceBindingError,
     DeviceBindingService,
@@ -321,6 +329,16 @@ def get_device_binding_service(
     return DeviceBindingService(DeviceRepository(db), redis, AuditService())
 
 
+def get_device_service(
+    db: AsyncSession = Depends(get_db),
+    redis: Annotated[aioredis.Redis, Depends(get_redis)] = ...,  # type: ignore[type-arg, assignment]
+) -> DeviceService:
+    """Build and return the device management service."""
+    return DeviceService(
+        DeviceRepository(db), SessionRepository(db), redis, AuditService()
+    )
+
+
 def get_email_change_service(
     db: AsyncSession = Depends(get_db),
     notifier: NotificationDispatcher = Depends(_get_notification_service),
@@ -359,6 +377,7 @@ _DomainError = (
     | PhoneChangeError
     | RecoveryError
     | DeviceBindingError
+    | DeviceError
 )
 
 
@@ -1054,3 +1073,86 @@ async def device_bind_complete(
         )
     except DeviceBindingError as exc:
         raise _domain_error(exc, status.HTTP_400_BAD_REQUEST) from exc
+
+
+# ── Device management ──────────────────────────────────────────────────────────
+
+
+@router.get(
+    "/devices",
+    response_model=DeviceListResponse,
+    status_code=status.HTTP_200_OK,
+    summary="List the current user's bound devices",
+)
+@limiter.limit("30/minute")  # type: ignore[misc]
+async def list_devices(
+    request: Request,
+    current_user: User = Depends(get_current_user),
+    service: DeviceService = Depends(get_device_service),
+) -> DeviceListResponse:
+    """Return all non-revoked devices registered to the authenticated user."""
+    devices = await service.list_devices(current_user)
+    return DeviceListResponse(
+        devices=[
+            DeviceResponse(
+                id=d.id,
+                name=d.name,
+                created_at=d.created_at,
+                last_seen_at=d.last_seen_at,
+            )
+            for d in devices
+        ]
+    )
+
+
+@router.post(
+    "/devices/{device_id}/revoke",
+    response_model=DeviceRevokeResponse,
+    status_code=status.HTTP_200_OK,
+    summary="Revoke a specific bound device",
+)
+@limiter.limit("20/hour")  # type: ignore[misc]
+async def revoke_device(
+    request: Request,
+    device_id: uuid.UUID,
+    current_user: User = Depends(get_current_user),
+    service: DeviceService = Depends(get_device_service),
+) -> DeviceRevokeResponse:
+    """Revoke a device and invalidate all associated sessions."""
+    calling_device_header = request.headers.get("X-Calling-Device-Id")
+    calling_device_id: uuid.UUID | None = None
+    if calling_device_header:
+        with contextlib.suppress(ValueError):
+            calling_device_id = uuid.UUID(calling_device_header)
+
+    try:
+        await service.revoke_device(current_user, device_id, calling_device_id)
+        return DeviceRevokeResponse(message="Device revoked successfully.")
+    except DeviceError as exc:
+        raise _domain_error(exc, status.HTTP_400_BAD_REQUEST) from exc
+
+
+@router.post(
+    "/devices/revoke-all",
+    response_model=DeviceRevokeAllResponse,
+    status_code=status.HTTP_200_OK,
+    summary="Revoke all bound devices except the calling one",
+)
+@limiter.limit("5/hour")  # type: ignore[misc]
+async def revoke_all_devices(
+    request: Request,
+    current_user: User = Depends(get_current_user),
+    service: DeviceService = Depends(get_device_service),
+) -> DeviceRevokeAllResponse:
+    """Panic button: revoke every device (except the caller) and kill all sessions."""
+    calling_device_header = request.headers.get("X-Calling-Device-Id")
+    calling_device_id: uuid.UUID | None = None
+    if calling_device_header:
+        with contextlib.suppress(ValueError):
+            calling_device_id = uuid.UUID(calling_device_header)
+
+    revoked_count = await service.revoke_all_devices(current_user, calling_device_id)
+    return DeviceRevokeAllResponse(
+        message=f"Revoked {revoked_count} device(s).",
+        revoked_count=revoked_count,
+    )

--- a/api/src/com/qode/qrew/v1/service/schemas/device.py
+++ b/api/src/com/qode/qrew/v1/service/schemas/device.py
@@ -1,0 +1,24 @@
+import uuid
+from datetime import datetime
+
+from pydantic import BaseModel
+
+
+class DeviceResponse(BaseModel):
+    id: uuid.UUID
+    name: str
+    created_at: datetime
+    last_seen_at: datetime | None = None
+
+
+class DeviceListResponse(BaseModel):
+    devices: list[DeviceResponse]
+
+
+class DeviceRevokeResponse(BaseModel):
+    message: str
+
+
+class DeviceRevokeAllResponse(BaseModel):
+    message: str
+    revoked_count: int

--- a/api/src/com/qode/qrew/v1/service/services/device.py
+++ b/api/src/com/qode/qrew/v1/service/services/device.py
@@ -1,0 +1,117 @@
+import uuid
+from datetime import UTC, datetime
+
+import redis.asyncio as aioredis
+import structlog
+
+from com.qode.qrew.v1.service.core.errors import DomainError
+from com.qode.qrew.v1.service.models.audit import AuditAction
+from com.qode.qrew.v1.service.models.device import Device
+from com.qode.qrew.v1.service.models.user import User
+from com.qode.qrew.v1.service.repositories.device import DeviceRepository
+from com.qode.qrew.v1.service.repositories.session import SessionRepository
+from com.qode.qrew.v1.service.services.audit import AuditService
+from com.qode.qrew.v1.service.settings import settings
+
+logger = structlog.get_logger(__name__)
+
+_BLACKLIST_JTI_PREFIX = "blacklist:jti:"
+_JTI_TTL_SECONDS = settings.refresh_token_expire_days * 86400
+
+
+class DeviceError(DomainError):
+    """Raised when a device management operation cannot be completed."""
+
+
+class DeviceService:
+    def __init__(
+        self,
+        device_repo: DeviceRepository,
+        session_repo: SessionRepository,
+        redis: aioredis.Redis,  # type: ignore[type-arg]
+        audit: AuditService,
+    ) -> None:
+        self._device_repo = device_repo
+        self._session_repo = session_repo
+        self._redis = redis
+        self._audit = audit
+
+    async def list_devices(self, user: User) -> list[Device]:
+        """Return all non-revoked devices for the user."""
+        return await self._device_repo.get_active_by_user_id(user.id)
+
+    async def revoke_device(
+        self,
+        user: User,
+        device_id: uuid.UUID,
+        calling_device_id: uuid.UUID | None = None,
+    ) -> None:
+        """Mark a device as revoked and cascade-kill all user sessions."""
+        device = await self._device_repo.get_by_id(device_id)
+        if device is None or device.user_id != user.id:
+            raise DeviceError("Device not found.", field=None)
+        if device.revoked_at is not None:
+            raise DeviceError("Device is already revoked.", field=None)
+        if calling_device_id is not None and calling_device_id == device_id:
+            raise DeviceError(
+                "Cannot revoke the device you are currently using.", field=None
+            )
+
+        device.revoked_at = datetime.now(UTC)
+        await self._device_repo.save(device)
+
+        await self._kill_all_sessions(user.id)
+
+        await logger.ainfo(
+            "device_revoked", user_id=str(user.id), device_id=str(device_id)
+        )
+        try:
+            await self._audit.record(
+                action=AuditAction.DEVICE_REVOKE,
+                actor_id=user.id,
+                entity_type="device",
+                entity_id=str(device_id),
+                payload={"reason": "user_initiated"},
+            )
+        except Exception:
+            await logger.awarning(
+                "audit_write_failed", action=AuditAction.DEVICE_REVOKE
+            )
+
+    async def revoke_all_devices(
+        self,
+        user: User,
+        calling_device_id: uuid.UUID | None = None,
+    ) -> int:
+        """Revoke every device except the calling one; returns count revoked."""
+        revoked_count = await self._device_repo.revoke_all_by_user_id(
+            user.id, exclude_id=calling_device_id
+        )
+
+        await self._kill_all_sessions(user.id)
+
+        await logger.ainfo(
+            "devices_revoke_all",
+            user_id=str(user.id),
+            revoked_count=revoked_count,
+        )
+        try:
+            await self._audit.record(
+                action=AuditAction.DEVICE_REVOKE_ALL,
+                actor_id=user.id,
+                entity_type="user",
+                entity_id=str(user.id),
+                payload={"reason": "user_initiated", "revoked_count": revoked_count},
+            )
+        except Exception:
+            await logger.awarning(
+                "audit_write_failed", action=AuditAction.DEVICE_REVOKE_ALL
+            )
+
+        return revoked_count
+
+    async def _kill_all_sessions(self, user_id: uuid.UUID) -> None:
+        """Delete all sessions for the user and blacklist their JTIs in Redis."""
+        jtis = await self._session_repo.delete_all_by_user_id(user_id)
+        for jti in jtis:
+            await self._redis.setex(_BLACKLIST_JTI_PREFIX + jti, _JTI_TTL_SECONDS, "1")

--- a/api/tests/v1/auth/unit/device_management_test.py
+++ b/api/tests/v1/auth/unit/device_management_test.py
@@ -1,0 +1,261 @@
+"""Tests for device management endpoints:
+GET  /v1/auth/devices
+POST /v1/auth/devices/{device_id}/revoke
+POST /v1/auth/devices/revoke-all
+"""
+
+import uuid
+from collections.abc import Iterator
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from httpx import AsyncClient
+
+from com.qode.qrew.v1.service.core.auth import get_current_user
+from com.qode.qrew.v1.service.main import app
+from com.qode.qrew.v1.service.routers.auth import get_device_service
+from com.qode.qrew.v1.service.services.device import DeviceError
+
+_LIST_ENDPOINT = "/v1/auth/devices"
+_REVOKE_ALL_ENDPOINT = "/v1/auth/devices/revoke-all"
+
+_DEVICE_ID = uuid.uuid4()
+_OTHER_DEVICE_ID = uuid.uuid4()
+_CALLING_DEVICE_ID = uuid.uuid4()
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+
+def _mock_user() -> MagicMock:
+    user = MagicMock()
+    user.id = uuid.uuid4()
+    user.email = "user@example.com"
+    return user
+
+
+def _mock_device(device_id: uuid.UUID = _DEVICE_ID) -> MagicMock:
+    device = MagicMock()
+    device.id = device_id
+    device.name = "Test Phone"
+    device.created_at = datetime(2026, 1, 1, tzinfo=UTC)
+    device.last_seen_at = datetime(2026, 5, 1, tzinfo=UTC)
+    return device
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def mock_service() -> AsyncMock:
+    service = AsyncMock()
+    service.list_devices = AsyncMock(
+        return_value=[_mock_device(), _mock_device(_OTHER_DEVICE_ID)]
+    )
+    service.revoke_device = AsyncMock(return_value=None)
+    service.revoke_all_devices = AsyncMock(return_value=2)
+    return service
+
+
+@pytest.fixture(autouse=True)
+def override_dependencies(mock_service: AsyncMock) -> Iterator[None]:
+    app.dependency_overrides[get_device_service] = lambda: mock_service
+    app.dependency_overrides[get_current_user] = _mock_user
+    yield
+    app.dependency_overrides.clear()
+
+
+# ── GET /devices ──────────────────────────────────────────────────────────────
+
+
+async def test_list_devices_returns_200_with_devices(
+    client: AsyncClient, mock_service: AsyncMock
+) -> None:
+    response = await client.get(_LIST_ENDPOINT)
+
+    assert response.status_code == 200
+    body = response.json()
+    assert len(body["devices"]) == 2
+    assert body["devices"][0]["name"] == "Test Phone"
+    assert "id" in body["devices"][0]
+    assert "created_at" in body["devices"][0]
+
+
+async def test_list_devices_calls_service(
+    client: AsyncClient, mock_service: AsyncMock
+) -> None:
+    await client.get(_LIST_ENDPOINT)
+
+    mock_service.list_devices.assert_awaited_once()
+
+
+async def test_list_devices_returns_empty_list_when_no_devices(
+    client: AsyncClient, mock_service: AsyncMock
+) -> None:
+    mock_service.list_devices = AsyncMock(return_value=[])
+
+    response = await client.get(_LIST_ENDPOINT)
+
+    assert response.status_code == 200
+    assert response.json()["devices"] == []
+
+
+async def test_list_devices_requires_auth(client: AsyncClient) -> None:
+    app.dependency_overrides.pop(get_current_user, None)
+
+    response = await client.get(_LIST_ENDPOINT)
+
+    assert response.status_code == 401
+
+
+# ── POST /devices/{id}/revoke ─────────────────────────────────────────────────
+
+
+async def test_revoke_device_returns_200(
+    client: AsyncClient, mock_service: AsyncMock
+) -> None:
+    response = await client.post(f"/v1/auth/devices/{_DEVICE_ID}/revoke")
+
+    assert response.status_code == 200
+    assert "revoked" in response.json()["message"].lower()
+
+
+async def test_revoke_device_calls_service_with_device_id(
+    client: AsyncClient, mock_service: AsyncMock
+) -> None:
+    await client.post(f"/v1/auth/devices/{_DEVICE_ID}/revoke")
+
+    mock_service.revoke_device.assert_awaited_once()
+    call_args = mock_service.revoke_device.call_args[0]
+    assert call_args[1] == _DEVICE_ID
+
+
+async def test_revoke_device_passes_calling_device_header(
+    client: AsyncClient, mock_service: AsyncMock
+) -> None:
+    await client.post(
+        f"/v1/auth/devices/{_DEVICE_ID}/revoke",
+        headers={"X-Calling-Device-Id": str(_CALLING_DEVICE_ID)},
+    )
+
+    call_args = mock_service.revoke_device.call_args[0]
+    assert call_args[2] == _CALLING_DEVICE_ID
+
+
+async def test_revoke_device_returns_400_on_not_found(
+    client: AsyncClient, mock_service: AsyncMock
+) -> None:
+    mock_service.revoke_device = AsyncMock(
+        side_effect=DeviceError("Device not found.", field=None)
+    )
+
+    response = await client.post(f"/v1/auth/devices/{_DEVICE_ID}/revoke")
+
+    assert response.status_code == 400
+    assert "not found" in response.json()["detail"]["message"]
+
+
+async def test_revoke_device_returns_400_on_already_revoked(
+    client: AsyncClient, mock_service: AsyncMock
+) -> None:
+    mock_service.revoke_device = AsyncMock(
+        side_effect=DeviceError("Device is already revoked.", field=None)
+    )
+
+    response = await client.post(f"/v1/auth/devices/{_DEVICE_ID}/revoke")
+
+    assert response.status_code == 400
+    assert "already revoked" in response.json()["detail"]["message"]
+
+
+async def test_revoke_device_returns_400_on_self_revoke(
+    client: AsyncClient, mock_service: AsyncMock
+) -> None:
+    mock_service.revoke_device = AsyncMock(
+        side_effect=DeviceError(
+            "Cannot revoke the device you are currently using.", field=None
+        )
+    )
+
+    response = await client.post(
+        f"/v1/auth/devices/{_DEVICE_ID}/revoke",
+        headers={"X-Calling-Device-Id": str(_DEVICE_ID)},
+    )
+
+    assert response.status_code == 400
+    assert "currently using" in response.json()["detail"]["message"]
+
+
+async def test_revoke_device_requires_auth(client: AsyncClient) -> None:
+    app.dependency_overrides.pop(get_current_user, None)
+
+    response = await client.post(f"/v1/auth/devices/{_DEVICE_ID}/revoke")
+
+    assert response.status_code == 401
+
+
+async def test_revoke_device_ignores_malformed_calling_device_header(
+    client: AsyncClient, mock_service: AsyncMock
+) -> None:
+    response = await client.post(
+        f"/v1/auth/devices/{_DEVICE_ID}/revoke",
+        headers={"X-Calling-Device-Id": "not-a-uuid"},
+    )
+
+    assert response.status_code == 200
+    call_args = mock_service.revoke_device.call_args[0]
+    assert call_args[2] is None
+
+
+# ── POST /devices/revoke-all ──────────────────────────────────────────────────
+
+
+async def test_revoke_all_returns_200_with_count(
+    client: AsyncClient, mock_service: AsyncMock
+) -> None:
+    response = await client.post(_REVOKE_ALL_ENDPOINT)
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["revoked_count"] == 2
+    assert "2" in body["message"]
+
+
+async def test_revoke_all_calls_service(
+    client: AsyncClient, mock_service: AsyncMock
+) -> None:
+    await client.post(_REVOKE_ALL_ENDPOINT)
+
+    mock_service.revoke_all_devices.assert_awaited_once()
+
+
+async def test_revoke_all_passes_calling_device_header(
+    client: AsyncClient, mock_service: AsyncMock
+) -> None:
+    await client.post(
+        _REVOKE_ALL_ENDPOINT,
+        headers={"X-Calling-Device-Id": str(_CALLING_DEVICE_ID)},
+    )
+
+    call_args = mock_service.revoke_all_devices.call_args[0]
+    assert call_args[1] == _CALLING_DEVICE_ID
+
+
+async def test_revoke_all_returns_zero_when_no_devices(
+    client: AsyncClient, mock_service: AsyncMock
+) -> None:
+    mock_service.revoke_all_devices = AsyncMock(return_value=0)
+
+    response = await client.post(_REVOKE_ALL_ENDPOINT)
+
+    assert response.status_code == 200
+    assert response.json()["revoked_count"] == 0
+
+
+async def test_revoke_all_requires_auth(client: AsyncClient) -> None:
+    app.dependency_overrides.pop(get_current_user, None)
+
+    response = await client.post(_REVOKE_ALL_ENDPOINT)
+
+    assert response.status_code == 401


### PR DESCRIPTION
## Summary

Adds three device management endpoints that let users inspect and remotely revoke their cryptographically bound devices.

## Verification

- `tests/v1/auth/unit/device_management_test.py`

## Issue Reference

Closes [QRW-68](https://github.com/cristiangilsanz/qrew/issues/68)

## Checklist
- [x] I confirm that this PR follows the project's established coding standards.