### PR TITLE
feat: implement GET /me, GET /onboarding-status, GET /admin/users

### DIFF
--- a/api/src/com/qode/qrew/v1/service/repositories/user.py
+++ b/api/src/com/qode/qrew/v1/service/repositories/user.py
@@ -1,9 +1,9 @@
 import uuid
 
-from sqlalchemy import select
+from sqlalchemy import func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from com.qode.qrew.v1.service.models.user import User
+from com.qode.qrew.v1.service.models.user import KycStatus, User
 
 
 class UserRepository:
@@ -78,3 +78,32 @@ class UserRepository:
         await self._session.flush()
         await self._session.refresh(user)
         return user
+
+    async def search_paginated(
+        self,
+        page: int,
+        page_size: int,
+        search: str | None = None,
+        kyc_status: KycStatus | None = None,
+    ) -> tuple[list[User], int]:
+        """Return a page of users matching optional filters, plus the total count."""
+        base = select(User)
+        if search:
+            pattern = f"%{search}%"
+            base = base.where(
+                or_(User.email.ilike(pattern), User.full_name.ilike(pattern))
+            )
+        if kyc_status is not None:
+            base = base.where(User.kyc_status == kyc_status)
+
+        count_result = await self._session.execute(
+            select(func.count()).select_from(base.subquery())
+        )
+        total = count_result.scalar_one()
+
+        rows = await self._session.execute(
+            base.order_by(User.created_at.desc())
+            .offset((page - 1) * page_size)
+            .limit(page_size)
+        )
+        return list(rows.scalars().all()), total

--- a/api/src/com/qode/qrew/v1/service/routers/admin.py
+++ b/api/src/com/qode/qrew/v1/service/routers/admin.py
@@ -6,7 +6,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from com.qode.qrew.v1.service.core.auth import get_admin_user
 from com.qode.qrew.v1.service.core.database import get_db
 from com.qode.qrew.v1.service.core.limiter import limiter
-from com.qode.qrew.v1.service.models.user import User
+from com.qode.qrew.v1.service.models.user import KycStatus, User
 from com.qode.qrew.v1.service.repositories.fingerprint import (
     DeviceFingerprintRepository,
 )
@@ -16,6 +16,8 @@ from com.qode.qrew.v1.service.schemas.admin import (
     FingerprintAdminResponse,
     KycReviewRequest,
     KycReviewResponse,
+    UserListResponse,
+    UserSummaryResponse,
 )
 from com.qode.qrew.v1.service.services.audit import AuditService
 from com.qode.qrew.v1.service.services.fingerprint import FingerprintService
@@ -121,4 +123,48 @@ async def get_fingerprint(
         fingerprint_hash=fingerprint_hash,
         user_ids=[str(uid) for uid in user_ids],
         account_count=len(user_ids),
+    )
+
+
+# ── User listing ──────────────────────────────────────────────────────────────
+
+
+@router.get(
+    "/users",
+    response_model=UserListResponse,
+    status_code=status.HTTP_200_OK,
+    summary="List and search users",
+)
+@limiter.limit("60/minute")  # type: ignore[misc]
+async def list_users(
+    request: Request,
+    page: int = 1,
+    page_size: int = 20,
+    search: str | None = None,
+    kyc_status: KycStatus | None = None,
+    _admin: User = Depends(get_admin_user),
+    db: AsyncSession = Depends(get_db),
+) -> UserListResponse:
+    """Return a paginated list of users with optional filters."""
+    page = max(page, 1)
+    page_size = 20 if page_size < 1 or page_size > 100 else page_size  # noqa: PLR2004
+    repo = UserRepository(db)
+    users, total = await repo.search_paginated(page, page_size, search, kyc_status)
+    return UserListResponse(
+        users=[
+            UserSummaryResponse(
+                id=u.id,
+                email=u.email,
+                full_name=u.full_name,
+                kyc_status=u.kyc_status,
+                email_verified=u.email_verified,
+                phone_verified=u.phone_number_verified,
+                is_admin=u.is_admin,
+                created_at=u.created_at,
+            )
+            for u in users
+        ],
+        total=total,
+        page=page,
+        page_size=page_size,
     )

--- a/api/src/com/qode/qrew/v1/service/routers/auth.py
+++ b/api/src/com/qode/qrew/v1/service/routers/auth.py
@@ -29,7 +29,7 @@ from com.qode.qrew.v1.service.core.captcha import (
 from com.qode.qrew.v1.service.core.database import get_db
 from com.qode.qrew.v1.service.core.limiter import limiter
 from com.qode.qrew.v1.service.core.redis import get_redis
-from com.qode.qrew.v1.service.models.user import User
+from com.qode.qrew.v1.service.models.user import KycStatus, User
 from com.qode.qrew.v1.service.repositories.device import DeviceRepository
 from com.qode.qrew.v1.service.repositories.fingerprint import (
     DeviceFingerprintRepository,
@@ -56,6 +56,7 @@ from com.qode.qrew.v1.service.schemas.auth import (
     LoginResponse,
     LogoutRequest,
     LogoutResponse,
+    OnboardingStatusResponse,
     PasskeyAuthenticationBeginRequest,
     PasskeyAuthenticationCompleteRequest,
     PasskeyRegistrationCompleteRequest,
@@ -69,6 +70,7 @@ from com.qode.qrew.v1.service.schemas.auth import (
     ResendEmailVerificationRequest,
     ResendPhoneOtpRequest,
     ResendResponse,
+    UserProfileResponse,
     VerifyEmailRequest,
     VerifyPhoneRequest,
     VerifyResponse,
@@ -1155,4 +1157,64 @@ async def revoke_all_devices(
     return DeviceRevokeAllResponse(
         message=f"Revoked {revoked_count} device(s).",
         revoked_count=revoked_count,
+    )
+
+
+# ── User profile ───────────────────────────────────────────────────────────────
+
+
+@router.get(
+    "/me",
+    response_model=UserProfileResponse,
+    status_code=status.HTTP_200_OK,
+    summary="Return the authenticated user's profile",
+)
+@limiter.limit("60/minute")  # type: ignore[misc]
+async def get_me(
+    request: Request,
+    current_user: User = Depends(get_current_user),
+) -> UserProfileResponse:
+    """Return public profile fields for the currently authenticated user."""
+    return UserProfileResponse(
+        id=current_user.id,
+        email=current_user.email,
+        full_name=current_user.full_name,
+        phone_number=current_user.phone_number,
+        kyc_status=current_user.kyc_status,
+        email_verified=current_user.email_verified,
+        phone_verified=current_user.phone_number_verified,
+        created_at=current_user.created_at,
+    )
+
+
+# ── Onboarding status ──────────────────────────────────────────────────────────
+
+
+@router.get(
+    "/onboarding-status",
+    response_model=OnboardingStatusResponse,
+    status_code=status.HTTP_200_OK,
+    summary="Return which onboarding steps the user has completed",
+)
+@limiter.limit("60/minute")  # type: ignore[misc]
+async def get_onboarding_status(
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_setup_or_full_user),
+) -> OnboardingStatusResponse:
+    """Return completion status for the four onboarding gates."""
+    passkey_repo = PasskeyCredentialRepository(db)
+    has_passkey = await passkey_repo.has_passkey(current_user.id)
+
+    kyc_submitted = current_user.kyc_status != KycStatus.not_submitted
+    email_verified = current_user.email_verified
+    phone_verified = current_user.phone_number_verified
+    is_complete = email_verified and phone_verified and kyc_submitted and has_passkey
+
+    return OnboardingStatusResponse(
+        email_verified=email_verified,
+        phone_verified=phone_verified,
+        kyc_submitted=kyc_submitted,
+        passkey_registered=has_passkey,
+        is_complete=is_complete,
     )

--- a/api/src/com/qode/qrew/v1/service/schemas/admin.py
+++ b/api/src/com/qode/qrew/v1/service/schemas/admin.py
@@ -1,4 +1,6 @@
 import enum
+import uuid
+from datetime import datetime
 
 from pydantic import BaseModel, Field
 
@@ -29,3 +31,21 @@ class FingerprintAdminResponse(BaseModel):
     fingerprint_hash: str
     user_ids: list[str]
     account_count: int
+
+
+class UserSummaryResponse(BaseModel):
+    id: uuid.UUID
+    email: str
+    full_name: str
+    kyc_status: str
+    email_verified: bool
+    phone_verified: bool
+    is_admin: bool
+    created_at: datetime
+
+
+class UserListResponse(BaseModel):
+    users: list[UserSummaryResponse]
+    total: int
+    page: int
+    page_size: int

--- a/api/src/com/qode/qrew/v1/service/schemas/auth.py
+++ b/api/src/com/qode/qrew/v1/service/schemas/auth.py
@@ -1,3 +1,6 @@
+import uuid
+from datetime import datetime
+
 import phonenumbers
 import zxcvbn
 from MailChecker import MailChecker  # type: ignore[import-untyped]
@@ -297,3 +300,22 @@ class PasskeyAuthenticationCompleteRequest(BaseModel):
     raw_id: str = Field(alias="rawId")
     response: AssertionResponseData
     type: str = "public-key"
+
+
+class UserProfileResponse(BaseModel):
+    id: uuid.UUID
+    email: str
+    full_name: str
+    phone_number: str
+    kyc_status: str
+    email_verified: bool
+    phone_verified: bool
+    created_at: datetime
+
+
+class OnboardingStatusResponse(BaseModel):
+    email_verified: bool
+    phone_verified: bool
+    kyc_submitted: bool
+    passkey_registered: bool
+    is_complete: bool

--- a/api/tests/v1/admin/unit/user_list_test.py
+++ b/api/tests/v1/admin/unit/user_list_test.py
@@ -1,0 +1,142 @@
+"""Tests for admin user listing endpoint:
+GET /v1/admin/users
+"""
+
+import uuid
+from collections.abc import Iterator
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from httpx import AsyncClient
+
+from com.qode.qrew.v1.service.core.auth import get_admin_user
+from com.qode.qrew.v1.service.main import app
+from com.qode.qrew.v1.service.models.user import KycStatus
+
+_ENDPOINT = "/v1/admin/users"
+_USER_REPO = "com.qode.qrew.v1.service.routers.admin.UserRepository"
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+
+def _mock_admin() -> MagicMock:
+    user = MagicMock()
+    user.id = uuid.uuid4()
+    user.is_admin = True
+    return user
+
+
+def _mock_user_row(is_admin: bool = False) -> MagicMock:
+    u = MagicMock()
+    u.id = uuid.uuid4()
+    u.email = "user@example.com"
+    u.full_name = "Test User"
+    u.kyc_status = KycStatus.approved
+    u.email_verified = True
+    u.phone_number_verified = True
+    u.is_admin = is_admin
+    u.created_at = datetime(2026, 1, 1, tzinfo=UTC)
+    return u
+
+
+@pytest.fixture(autouse=True)
+def override_admin() -> Iterator[None]:
+    app.dependency_overrides[get_admin_user] = _mock_admin
+    yield
+    app.dependency_overrides.clear()
+
+
+# ── Happy path ────────────────────────────────────────────────────────────────
+
+
+async def test_list_users_returns_200(client: AsyncClient) -> None:
+    users = [_mock_user_row(), _mock_user_row()]
+    with patch(_USER_REPO) as mock_repo_cls:
+        mock_repo_cls.return_value.search_paginated = AsyncMock(return_value=(users, 2))
+
+        response = await client.get(_ENDPOINT)
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["total"] == 2
+    assert len(body["users"]) == 2
+    assert body["page"] == 1
+    assert body["page_size"] == 20
+
+
+async def test_list_users_returns_user_fields(client: AsyncClient) -> None:
+    with patch(_USER_REPO) as mock_repo_cls:
+        mock_repo_cls.return_value.search_paginated = AsyncMock(
+            return_value=([_mock_user_row()], 1)
+        )
+
+        response = await client.get(_ENDPOINT)
+
+    user = response.json()["users"][0]
+    assert user["email"] == "user@example.com"
+    assert user["full_name"] == "Test User"
+    assert user["kyc_status"] == KycStatus.approved
+    assert user["email_verified"] is True
+    assert user["phone_verified"] is True
+    assert user["is_admin"] is False
+    assert "id" in user
+    assert "created_at" in user
+
+
+async def test_list_users_empty_result(client: AsyncClient) -> None:
+    with patch(_USER_REPO) as mock_repo_cls:
+        mock_repo_cls.return_value.search_paginated = AsyncMock(return_value=([], 0))
+
+        response = await client.get(_ENDPOINT)
+
+    assert response.status_code == 200
+    assert response.json()["users"] == []
+    assert response.json()["total"] == 0
+
+
+# ── Pagination ────────────────────────────────────────────────────────────────
+
+
+async def test_list_users_passes_pagination_params(client: AsyncClient) -> None:
+    with patch(_USER_REPO) as mock_repo_cls:
+        mock_repo = mock_repo_cls.return_value
+        mock_repo.search_paginated = AsyncMock(return_value=([], 0))
+
+        await client.get(_ENDPOINT, params={"page": 3, "page_size": 50})
+
+        mock_repo.search_paginated.assert_awaited_once_with(3, 50, None, None)
+
+
+async def test_list_users_passes_search_param(client: AsyncClient) -> None:
+    with patch(_USER_REPO) as mock_repo_cls:
+        mock_repo = mock_repo_cls.return_value
+        mock_repo.search_paginated = AsyncMock(return_value=([], 0))
+
+        await client.get(_ENDPOINT, params={"search": "alice"})
+
+        call_args = mock_repo.search_paginated.call_args[0]
+        assert call_args[2] == "alice"
+
+
+async def test_list_users_passes_kyc_status_filter(client: AsyncClient) -> None:
+    with patch(_USER_REPO) as mock_repo_cls:
+        mock_repo = mock_repo_cls.return_value
+        mock_repo.search_paginated = AsyncMock(return_value=([], 0))
+
+        await client.get(_ENDPOINT, params={"kyc_status": "pending"})
+
+        call_args = mock_repo.search_paginated.call_args[0]
+        assert call_args[3] == KycStatus.pending
+
+
+# ── Auth guard ────────────────────────────────────────────────────────────────
+
+
+async def test_list_users_requires_admin(client: AsyncClient) -> None:
+    app.dependency_overrides.pop(get_admin_user, None)
+
+    response = await client.get(_ENDPOINT)
+
+    assert response.status_code == 401

--- a/api/tests/v1/auth/unit/profile_test.py
+++ b/api/tests/v1/auth/unit/profile_test.py
@@ -1,0 +1,147 @@
+"""Tests for profile and onboarding-status endpoints:
+GET /v1/auth/me
+GET /v1/auth/onboarding-status
+"""
+
+import uuid
+from collections.abc import Iterator
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from httpx import AsyncClient
+
+from com.qode.qrew.v1.service.core.auth import get_current_user, get_setup_or_full_user
+from com.qode.qrew.v1.service.main import app
+from com.qode.qrew.v1.service.models.user import KycStatus
+
+_ME_ENDPOINT = "/v1/auth/me"
+_ONBOARDING_ENDPOINT = "/v1/auth/onboarding-status"
+
+_PASSKEY_REPO = "com.qode.qrew.v1.service.routers.auth.PasskeyCredentialRepository"
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+
+def _mock_user(
+    email_verified: bool = True,
+    phone_verified: bool = True,
+    kyc_status: KycStatus = KycStatus.approved,
+) -> MagicMock:
+    user = MagicMock()
+    user.id = uuid.uuid4()
+    user.email = "user@example.com"
+    user.full_name = "Test User"
+    user.phone_number = "+34612345678"
+    user.kyc_status = kyc_status
+    user.email_verified = email_verified
+    user.phone_number_verified = phone_verified
+    user.created_at = datetime(2026, 1, 1, tzinfo=UTC)
+    return user
+
+
+@pytest.fixture(autouse=True)
+def override_user() -> Iterator[None]:
+    app.dependency_overrides[get_current_user] = _mock_user
+    app.dependency_overrides[get_setup_or_full_user] = _mock_user
+    yield
+    app.dependency_overrides.clear()
+
+
+# ── GET /auth/me ──────────────────────────────────────────────────────────────
+
+
+async def test_me_returns_200_with_profile(client: AsyncClient) -> None:
+    response = await client.get(_ME_ENDPOINT)
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["email"] == "user@example.com"
+    assert body["full_name"] == "Test User"
+    assert body["phone_number"] == "+34612345678"
+    assert body["kyc_status"] == KycStatus.approved
+    assert body["email_verified"] is True
+    assert body["phone_verified"] is True
+    assert "id" in body
+    assert "created_at" in body
+
+
+async def test_me_requires_auth(client: AsyncClient) -> None:
+    app.dependency_overrides.pop(get_current_user, None)
+
+    response = await client.get(_ME_ENDPOINT)
+
+    assert response.status_code == 401
+
+
+# ── GET /auth/onboarding-status ───────────────────────────────────────────────
+
+
+async def test_onboarding_status_all_complete(client: AsyncClient) -> None:
+    with patch(_PASSKEY_REPO) as mock_repo_cls:
+        mock_repo_cls.return_value.has_passkey = AsyncMock(return_value=True)
+
+        response = await client.get(_ONBOARDING_ENDPOINT)
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["email_verified"] is True
+    assert body["phone_verified"] is True
+    assert body["kyc_submitted"] is True
+    assert body["passkey_registered"] is True
+    assert body["is_complete"] is True
+
+
+async def test_onboarding_status_no_passkey(client: AsyncClient) -> None:
+    with patch(_PASSKEY_REPO) as mock_repo_cls:
+        mock_repo_cls.return_value.has_passkey = AsyncMock(return_value=False)
+
+        response = await client.get(_ONBOARDING_ENDPOINT)
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["passkey_registered"] is False
+    assert body["is_complete"] is False
+
+
+async def test_onboarding_status_kyc_not_submitted(client: AsyncClient) -> None:
+    app.dependency_overrides[get_setup_or_full_user] = lambda: _mock_user(
+        kyc_status=KycStatus.not_submitted
+    )
+
+    with patch(_PASSKEY_REPO) as mock_repo_cls:
+        mock_repo_cls.return_value.has_passkey = AsyncMock(return_value=True)
+
+        response = await client.get(_ONBOARDING_ENDPOINT)
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["kyc_submitted"] is False
+    assert body["is_complete"] is False
+
+
+async def test_onboarding_status_email_not_verified(client: AsyncClient) -> None:
+    app.dependency_overrides[get_setup_or_full_user] = lambda: _mock_user(
+        email_verified=False
+    )
+
+    with patch(_PASSKEY_REPO) as mock_repo_cls:
+        mock_repo_cls.return_value.has_passkey = AsyncMock(return_value=True)
+
+        response = await client.get(_ONBOARDING_ENDPOINT)
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["email_verified"] is False
+    assert body["is_complete"] is False
+
+
+async def test_onboarding_status_requires_setup_or_full_token(
+    client: AsyncClient,
+) -> None:
+    app.dependency_overrides.pop(get_setup_or_full_user, None)
+
+    response = await client.get(_ONBOARDING_ENDPOINT)
+
+    assert response.status_code == 401


### PR DESCRIPTION
## Summary

Adds the three missing read endpoints:

- **`GET /v1/auth/me` (QRW-91)**

- **`GET /v1/auth/onboarding-status` (QRW-92)**

- **`GET /v1/admin/users` (QRW-93)**

## Verification

- `tests/v1/auth/unit/profile_test.py`
- `tests/v1/admin/unit/user_list_test.py`

## Issue Reference

Closes [QRW-91](https://github.com/cristiangilsanz/qrew/issues/91)
Closes [QRW-92](https://github.com/cristiangilsanz/qrew/issues/92)
Closes [QRW-93](https://github.com/cristiangilsanz/qrew/issues/93)

## Checklist
- [x] I confirm that this PR follows the project's established coding standards.