### PR TITLE
feat: bind device_id to sessions for device-bound refresh tokens

### DIFF
--- a/api/alembic/versions/7a8b9c0d1e2f_2026_05_26_add_device_id_to_sessions.py
+++ b/api/alembic/versions/7a8b9c0d1e2f_2026_05_26_add_device_id_to_sessions.py
@@ -1,0 +1,44 @@
+"""add device_id to sessions
+
+Revision ID: 7a8b9c0d1e2f
+Revises: 6f9d4a5d9ce4
+Create Date: 2026-05-26 12:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "7a8b9c0d1e2f"
+down_revision: str | None = "6f9d4a5d9ce4"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "sessions",
+        sa.Column("device_id", sa.UUID(), nullable=True),
+    )
+    op.create_foreign_key(
+        "fk_sessions_device_id_devices",
+        "sessions",
+        "devices",
+        ["device_id"],
+        ["id"],
+        ondelete="SET NULL",
+    )
+    op.create_index(
+        op.f("ix_sessions_device_id"),
+        "sessions",
+        ["device_id"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(op.f("ix_sessions_device_id"), table_name="sessions")
+    op.drop_constraint("fk_sessions_device_id_devices", "sessions", type_="foreignkey")
+    op.drop_column("sessions", "device_id")

--- a/api/src/com/qode/qrew/v1/service/core/security.py
+++ b/api/src/com/qode/qrew/v1/service/core/security.py
@@ -74,16 +74,18 @@ def phone_number_otp_expiry() -> datetime:
     )
 
 
-def create_access_token(subject: str) -> str:
+def create_access_token(subject: str, device_id: str | None = None) -> str:
     """Return a signed JWT access token for the given subject."""
     now = datetime.now(UTC)
-    payload = {
+    payload: dict[str, object] = {
         "sub": subject,
         "type": "access",
         "scope": "access",
         "iat": now,
         "exp": now + timedelta(minutes=settings.access_token_expire_minutes),
     }
+    if device_id is not None:
+        payload["device_id"] = device_id
     return jwt.encode(payload, settings.secret_key, algorithm="HS256")
 
 

--- a/api/src/com/qode/qrew/v1/service/models/session.py
+++ b/api/src/com/qode/qrew/v1/service/models/session.py
@@ -26,6 +26,12 @@ class Session(Base):
     ip_address: Mapped[str | None] = mapped_column(String(45), nullable=True)
     user_agent: Mapped[str | None] = mapped_column(Text, nullable=True)
     device_fingerprint: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    device_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("devices.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+    )
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False
     )

--- a/api/src/com/qode/qrew/v1/service/routers/auth.py
+++ b/api/src/com/qode/qrew/v1/service/routers/auth.py
@@ -205,6 +205,7 @@ def get_login_service(
         AuditService(),
         session_repo,
         anomaly,
+        DeviceRepository(db),
     )
 
 
@@ -480,8 +481,15 @@ async def login(
     ip_address = request.client.host if request.client else None
     user_agent = request.headers.get("User-Agent")
     device_fingerprint = request.headers.get("X-Device-Fingerprint")
+    device_id: uuid.UUID | None = None
+    device_id_header = request.headers.get("X-Device-Id")
+    if device_id_header:
+        with contextlib.suppress(ValueError):
+            device_id = uuid.UUID(device_id_header)
     try:
-        return await service.login(body, ip_address, user_agent, device_fingerprint)
+        return await service.login(
+            body, ip_address, user_agent, device_fingerprint, device_id
+        )
     except LoginError as exc:
         raise _domain_error(exc, status.HTTP_401_UNAUTHORIZED) from exc
 
@@ -499,8 +507,13 @@ async def refresh(
     service: RefreshService = Depends(get_refresh_service),
 ) -> RefreshResponse:
     """Issue a new access token from a valid refresh token."""
+    device_id: uuid.UUID | None = None
+    device_id_header = request.headers.get("X-Device-Id")
+    if device_id_header:
+        with contextlib.suppress(ValueError):
+            device_id = uuid.UUID(device_id_header)
     try:
-        return await service.refresh(body)
+        return await service.refresh(body, device_id)
     except RefreshError as exc:
         raise _domain_error(exc, status.HTTP_401_UNAUTHORIZED) from exc
 

--- a/api/src/com/qode/qrew/v1/service/services/login.py
+++ b/api/src/com/qode/qrew/v1/service/services/login.py
@@ -14,6 +14,7 @@ from com.qode.qrew.v1.service.core.security import (
 from com.qode.qrew.v1.service.models.audit import AuditAction
 from com.qode.qrew.v1.service.models.session import Session
 from com.qode.qrew.v1.service.models.user import KycStatus
+from com.qode.qrew.v1.service.repositories.device import DeviceRepository
 from com.qode.qrew.v1.service.repositories.passkey import PasskeyCredentialRepository
 from com.qode.qrew.v1.service.repositories.session import SessionRepository
 from com.qode.qrew.v1.service.repositories.user import UserRepository
@@ -38,12 +39,14 @@ class LoginService:
         audit: AuditService,
         session_repo: SessionRepository | None = None,
         anomaly: LoginAnomalyService | None = None,
+        device_repo: DeviceRepository | None = None,
     ) -> None:
         self._repo = repo
         self._passkey_repo = passkey_repo
         self._audit = audit
         self._session_repo = session_repo
         self._anomaly = anomaly
+        self._device_repo = device_repo
 
     async def login(
         self,
@@ -51,6 +54,7 @@ class LoginService:
         ip_address: str | None = None,
         user_agent: str | None = None,
         device_fingerprint: str | None = None,
+        device_id: uuid.UUID | None = None,
     ) -> LoginResponse:
         """Authenticate a user, returning a setup or full-access token."""
         user = await self._repo.get_by_email(request.email)
@@ -112,10 +116,19 @@ class LoginService:
         )
 
         if setup_complete:
-            access_token = create_access_token(str(user.id))
+            bound_device_id = await self.resolve_bound_device(user.id, device_id)
+            access_token = create_access_token(
+                str(user.id),
+                device_id=str(bound_device_id) if bound_device_id else None,
+            )
             refresh_token = create_refresh_token(str(user.id))
             await self._persist_session(
-                user.id, refresh_token, ip_address, user_agent, device_fingerprint
+                user.id,
+                refresh_token,
+                ip_address,
+                user_agent,
+                device_fingerprint,
+                bound_device_id,
             )
             await logger.ainfo("user_logged_in", user_id=str(user.id))
             try:
@@ -161,6 +174,7 @@ class LoginService:
         ip_address: str | None,
         user_agent: str | None,
         device_fingerprint: str | None,
+        device_id: uuid.UUID | None = None,
     ) -> None:
         if self._session_repo is None:
             return
@@ -175,5 +189,17 @@ class LoginService:
                 ip_address=ip_address,
                 user_agent=user_agent,
                 device_fingerprint=device_fingerprint,
+                device_id=device_id,
             )
         )
+
+    async def resolve_bound_device(
+        self, user_id: uuid.UUID, device_id: uuid.UUID | None
+    ) -> uuid.UUID | None:
+        """Return device_id if it belongs to the user and is not revoked."""
+        if device_id is None or self._device_repo is None:
+            return None
+        device = await self._device_repo.get_by_id(device_id)
+        if device is None or device.user_id != user_id or device.revoked_at is not None:
+            return None
+        return device.id

--- a/api/src/com/qode/qrew/v1/service/services/refresh.py
+++ b/api/src/com/qode/qrew/v1/service/services/refresh.py
@@ -45,7 +45,11 @@ class RefreshService:
         self._audit = audit
         self._session_repo = session_repo
 
-    async def refresh(self, request: RefreshRequest) -> RefreshResponse:
+    async def refresh(
+        self,
+        request: RefreshRequest,
+        device_id: uuid.UUID | None = None,
+    ) -> RefreshResponse:
         """Issue a new access + refresh token pair, invalidating the old one."""
         try:
             payload = jwt.decode(
@@ -88,10 +92,15 @@ class RefreshService:
             await logger.awarning("refresh_failed", reason="user_not_found_or_inactive")
             raise RefreshError("Invalid refresh token")
 
+        bound_device_id = await self.check_device_binding(jti, device_id)
+
         if jti_key:
             await self._rotate_jti(jti_key, payload.get("exp"))
 
-        access_token = create_access_token(str(user.id))
+        access_token = create_access_token(
+            str(user.id),
+            device_id=str(bound_device_id) if bound_device_id else None,
+        )
         new_refresh_token = create_refresh_token(str(user.id))
 
         if self._session_repo is not None and isinstance(jti, str):
@@ -168,6 +177,24 @@ class RefreshService:
         ):
             await logger.awarning("refresh_failed", reason="all_tokens_revoked")
             raise RefreshError("Refresh token has been revoked")
+
+    async def check_device_binding(
+        self, jti: object, device_id: uuid.UUID | None
+    ) -> uuid.UUID | None:
+        """If the session is device-bound, require a matching X-Device-Id."""
+        if self._session_repo is None or not isinstance(jti, str):
+            return None
+        session = await self._session_repo.get_by_jti(jti)
+        if session is None or session.device_id is None:
+            return None
+        if device_id is None or device_id != session.device_id:
+            await logger.awarning(
+                "refresh_failed",
+                reason="device_mismatch",
+                session_device_id=str(session.device_id),
+            )
+            raise RefreshError("Refresh token is bound to a different device")
+        return session.device_id
 
     async def _rotate_jti(self, jti_key: str, exp: object) -> None:
         """Blacklist the old JTI as rotated so any replay triggers theft detection."""

--- a/api/tests/v1/auth/unit/device_binding_session_test.py
+++ b/api/tests/v1/auth/unit/device_binding_session_test.py
@@ -1,0 +1,303 @@
+"""Tests for device-bound session creation and refresh validation."""
+
+import uuid
+from collections.abc import Iterator
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock
+
+import jwt
+import pytest
+from httpx import AsyncClient
+
+from com.qode.qrew.v1.service.core.security import (
+    create_access_token,
+    create_refresh_token,
+    extract_jti,
+)
+from com.qode.qrew.v1.service.main import app
+from com.qode.qrew.v1.service.models.session import Session
+from com.qode.qrew.v1.service.routers.auth import (
+    get_login_service,
+    get_refresh_service,
+)
+from com.qode.qrew.v1.service.schemas.auth import LoginResponse, RefreshResponse
+from com.qode.qrew.v1.service.services.login import LoginService
+from com.qode.qrew.v1.service.services.refresh import RefreshError, RefreshService
+from com.qode.qrew.v1.service.settings import settings
+
+_LOGIN_ENDPOINT = "/v1/auth/login"
+_REFRESH_ENDPOINT = "/v1/auth/refresh"
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def mock_login_service() -> AsyncMock:
+    service = AsyncMock()
+    service.login = AsyncMock(
+        return_value=LoginResponse(access_token="a.b.c", refresh_token="d.e.f")
+    )
+    return service
+
+
+@pytest.fixture
+def mock_refresh_service() -> AsyncMock:
+    service = AsyncMock()
+    service.refresh = AsyncMock(
+        return_value=RefreshResponse(access_token="x.y.z", refresh_token="r.s.t")
+    )
+    return service
+
+
+@pytest.fixture(autouse=True)
+def override_dependencies(
+    mock_login_service: AsyncMock, mock_refresh_service: AsyncMock
+) -> Iterator[None]:
+    app.dependency_overrides[get_login_service] = lambda: mock_login_service
+    app.dependency_overrides[get_refresh_service] = lambda: mock_refresh_service
+    yield
+    app.dependency_overrides.clear()
+
+
+# ── JWT device_id claim ───────────────────────────────────────────────────────
+
+
+def test_access_token_omits_device_id_when_not_provided() -> None:
+    token = create_access_token("user-123")
+    payload = jwt.decode(token, settings.secret_key, algorithms=["HS256"])
+    assert "device_id" not in payload
+
+
+def test_access_token_includes_device_id_when_provided() -> None:
+    device_id = str(uuid.uuid4())
+    token = create_access_token("user-123", device_id=device_id)
+    payload = jwt.decode(token, settings.secret_key, algorithms=["HS256"])
+    assert payload["device_id"] == device_id
+
+
+# ── Login route forwards X-Device-Id ──────────────────────────────────────────
+
+
+async def test_login_passes_device_id_from_header(
+    client: AsyncClient, mock_login_service: AsyncMock
+) -> None:
+    device_id = uuid.uuid4()
+    await client.post(
+        _LOGIN_ENDPOINT,
+        json={"email": "a@b.com", "password": "x"},
+        headers={"X-Device-Id": str(device_id)},
+    )
+    mock_login_service.login.assert_awaited_once()
+    args = mock_login_service.login.call_args.args
+    assert args[4] == device_id
+
+
+async def test_login_passes_none_when_header_missing(
+    client: AsyncClient, mock_login_service: AsyncMock
+) -> None:
+    await client.post(_LOGIN_ENDPOINT, json={"email": "a@b.com", "password": "x"})
+    args = mock_login_service.login.call_args.args
+    assert args[4] is None
+
+
+async def test_login_silently_ignores_malformed_device_id(
+    client: AsyncClient, mock_login_service: AsyncMock
+) -> None:
+    await client.post(
+        _LOGIN_ENDPOINT,
+        json={"email": "a@b.com", "password": "x"},
+        headers={"X-Device-Id": "not-a-uuid"},
+    )
+    args = mock_login_service.login.call_args.args
+    assert args[4] is None
+
+
+# ── Refresh route forwards X-Device-Id ────────────────────────────────────────
+
+
+async def test_refresh_passes_device_id_from_header(
+    client: AsyncClient, mock_refresh_service: AsyncMock
+) -> None:
+    device_id = uuid.uuid4()
+    await client.post(
+        _REFRESH_ENDPOINT,
+        json={"refresh_token": "tok"},
+        headers={"X-Device-Id": str(device_id)},
+    )
+    args = mock_refresh_service.refresh.call_args.args
+    assert args[1] == device_id
+
+
+async def test_refresh_returns_401_on_device_mismatch(
+    client: AsyncClient, mock_refresh_service: AsyncMock
+) -> None:
+    mock_refresh_service.refresh.side_effect = RefreshError(
+        "Refresh token is bound to a different device"
+    )
+    response = await client.post(
+        _REFRESH_ENDPOINT,
+        json={"refresh_token": "tok"},
+        headers={"X-Device-Id": str(uuid.uuid4())},
+    )
+    assert response.status_code == 401
+
+
+# ── LoginService bound-device resolution ──────────────────────────────────────
+
+
+async def test_login_service_resolves_valid_bound_device() -> None:
+
+    user_id = uuid.uuid4()
+    device_id = uuid.uuid4()
+    device = type("D", (), {"id": device_id, "user_id": user_id, "revoked_at": None})()
+    device_repo = AsyncMock()
+    device_repo.get_by_id = AsyncMock(return_value=device)
+
+    svc = LoginService(AsyncMock(), AsyncMock(), AsyncMock(), device_repo=device_repo)
+    result = await svc.resolve_bound_device(user_id, device_id)
+    assert result == device_id
+
+
+async def test_login_service_rejects_device_owned_by_other_user() -> None:
+
+    user_id = uuid.uuid4()
+    device_id = uuid.uuid4()
+    device = type(
+        "D",
+        (),
+        {"id": device_id, "user_id": uuid.uuid4(), "revoked_at": None},
+    )()
+    device_repo = AsyncMock()
+    device_repo.get_by_id = AsyncMock(return_value=device)
+
+    svc = LoginService(AsyncMock(), AsyncMock(), AsyncMock(), device_repo=device_repo)
+    result = await svc.resolve_bound_device(user_id, device_id)
+    assert result is None
+
+
+async def test_login_service_rejects_revoked_device() -> None:
+
+    user_id = uuid.uuid4()
+    device_id = uuid.uuid4()
+    device = type(
+        "D",
+        (),
+        {"id": device_id, "user_id": user_id, "revoked_at": datetime.now(UTC)},
+    )()
+    device_repo = AsyncMock()
+    device_repo.get_by_id = AsyncMock(return_value=device)
+
+    svc = LoginService(AsyncMock(), AsyncMock(), AsyncMock(), device_repo=device_repo)
+    result = await svc.resolve_bound_device(user_id, device_id)
+    assert result is None
+
+
+async def test_login_service_returns_none_when_device_id_missing() -> None:
+
+    device_repo = AsyncMock()
+    svc = LoginService(AsyncMock(), AsyncMock(), AsyncMock(), device_repo=device_repo)
+    result = await svc.resolve_bound_device(uuid.uuid4(), None)
+    assert result is None
+    device_repo.get_by_id.assert_not_called()
+
+
+# ── RefreshService device binding check ───────────────────────────────────────
+
+
+async def test_refresh_service_allows_match_on_device_id() -> None:
+
+    device_id = uuid.uuid4()
+    jti = str(uuid.uuid4())
+    session = Session(
+        id=uuid.uuid4(),
+        user_id=uuid.uuid4(),
+        jti=jti,
+        device_id=device_id,
+    )
+    session_repo = AsyncMock()
+    session_repo.get_by_jti = AsyncMock(return_value=session)
+
+    svc = RefreshService(
+        AsyncMock(), AsyncMock(), AsyncMock(), session_repo=session_repo
+    )
+    result = await svc.check_device_binding(jti, device_id)
+    assert result == device_id
+
+
+async def test_refresh_service_rejects_device_mismatch() -> None:
+
+    jti = str(uuid.uuid4())
+    session = Session(
+        id=uuid.uuid4(),
+        user_id=uuid.uuid4(),
+        jti=jti,
+        device_id=uuid.uuid4(),
+    )
+    session_repo = AsyncMock()
+    session_repo.get_by_jti = AsyncMock(return_value=session)
+
+    svc = RefreshService(
+        AsyncMock(), AsyncMock(), AsyncMock(), session_repo=session_repo
+    )
+    with pytest.raises(RefreshError, match="bound to a different device"):
+        await svc.check_device_binding(jti, uuid.uuid4())
+
+
+async def test_refresh_service_rejects_missing_header_on_bound_session() -> None:
+
+    jti = str(uuid.uuid4())
+    session = Session(
+        id=uuid.uuid4(),
+        user_id=uuid.uuid4(),
+        jti=jti,
+        device_id=uuid.uuid4(),
+    )
+    session_repo = AsyncMock()
+    session_repo.get_by_jti = AsyncMock(return_value=session)
+
+    svc = RefreshService(
+        AsyncMock(), AsyncMock(), AsyncMock(), session_repo=session_repo
+    )
+    with pytest.raises(RefreshError, match="bound to a different device"):
+        await svc.check_device_binding(jti, None)
+
+
+async def test_refresh_service_allows_unbound_session() -> None:
+
+    jti = str(uuid.uuid4())
+    session = Session(
+        id=uuid.uuid4(),
+        user_id=uuid.uuid4(),
+        jti=jti,
+        device_id=None,
+    )
+    session_repo = AsyncMock()
+    session_repo.get_by_jti = AsyncMock(return_value=session)
+
+    svc = RefreshService(
+        AsyncMock(), AsyncMock(), AsyncMock(), session_repo=session_repo
+    )
+    result = await svc.check_device_binding(jti, None)
+    assert result is None
+
+
+async def test_refresh_service_allows_when_session_missing() -> None:
+
+    session_repo = AsyncMock()
+    session_repo.get_by_jti = AsyncMock(return_value=None)
+
+    svc = RefreshService(
+        AsyncMock(), AsyncMock(), AsyncMock(), session_repo=session_repo
+    )
+    result = await svc.check_device_binding(str(uuid.uuid4()), uuid.uuid4())
+    assert result is None
+
+
+# ── Round-trip sanity ─────────────────────────────────────────────────────────
+
+
+def test_refresh_token_jti_extractable() -> None:
+    """Sanity: extract_jti still works after device_id was added to access tokens."""
+    token = create_refresh_token("user-1")
+    assert extract_jti(token) is not None

--- a/uv.lock
+++ b/uv.lock
@@ -171,7 +171,7 @@ wheels = [
 
 [[package]]
 name = "api"
-version = "1.5.0"
+version = "1.6.0"
 source = { editable = "api" }
 dependencies = [
     { name = "aiosmtplib" },


### PR DESCRIPTION
## Summary

Refresh tokens are now cryptographically tied to the bound device that created the session.

## Verification

`api/tests/v1/auth/unit/device_binding_session_test.py`

## Issue Reference

Closes [QRW-96](https://github.com/cristiangilsanz/qrew/issues/96)

## Checklist
- [x] I confirm that this PR follows the project's established coding standards.