### PR TITLE
feat: implement passkey re-assertion endpoint for QR display gate

### DIFF
--- a/api/alembic/versions/8b9c0d1e2f3a_2026_05_26_add_last_asserted_at_to_sessions.py
+++ b/api/alembic/versions/8b9c0d1e2f3a_2026_05_26_add_last_asserted_at_to_sessions.py
@@ -1,0 +1,28 @@
+"""add last_asserted_at to sessions
+
+Revision ID: 8b9c0d1e2f3a
+Revises: 7a8b9c0d1e2f
+Create Date: 2026-05-26 13:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "8b9c0d1e2f3a"
+down_revision: str | None = "7a8b9c0d1e2f"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "sessions",
+        sa.Column("last_asserted_at", sa.DateTime(timezone=True), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("sessions", "last_asserted_at")

--- a/api/src/com/qode/qrew/v1/service/core/auth.py
+++ b/api/src/com/qode/qrew/v1/service/core/auth.py
@@ -9,7 +9,9 @@ from jwt import ExpiredSignatureError, InvalidTokenError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from com.qode.qrew.v1.service.core.database import get_db
+from com.qode.qrew.v1.service.models.session import Session
 from com.qode.qrew.v1.service.models.user import User
+from com.qode.qrew.v1.service.repositories.session import SessionRepository
 from com.qode.qrew.v1.service.repositories.user import UserRepository
 from com.qode.qrew.v1.service.settings import settings
 
@@ -115,6 +117,34 @@ async def get_recovery_user(
         raise _CREDENTIALS_EXCEPTION
 
     return user
+
+
+async def get_current_session(
+    credentials: Annotated[HTTPAuthorizationCredentials, Depends(_bearer)],
+    db: AsyncSession = Depends(get_db),
+) -> Session:
+    """Resolve the Session row from the access token's session JTI claim."""
+    try:
+        payload = jwt.decode(
+            credentials.credentials,
+            settings.secret_key,
+            algorithms=["HS256"],
+        )
+    except (ExpiredSignatureError, InvalidTokenError) as exc:
+        raise _CREDENTIALS_EXCEPTION from exc
+
+    if payload.get("type") != "access" or payload.get("scope") != "access":
+        raise _CREDENTIALS_EXCEPTION
+
+    jti = payload.get("jti")
+    if not isinstance(jti, str):
+        raise _CREDENTIALS_EXCEPTION
+
+    session = await SessionRepository(db).get_by_jti(jti)
+    if session is None:
+        raise _CREDENTIALS_EXCEPTION
+
+    return session
 
 
 async def get_admin_user(

--- a/api/src/com/qode/qrew/v1/service/core/security.py
+++ b/api/src/com/qode/qrew/v1/service/core/security.py
@@ -74,7 +74,11 @@ def phone_number_otp_expiry() -> datetime:
     )
 
 
-def create_access_token(subject: str, device_id: str | None = None) -> str:
+def create_access_token(
+    subject: str,
+    device_id: str | None = None,
+    session_jti: str | None = None,
+) -> str:
     """Return a signed JWT access token for the given subject."""
     now = datetime.now(UTC)
     payload: dict[str, object] = {
@@ -86,6 +90,8 @@ def create_access_token(subject: str, device_id: str | None = None) -> str:
     }
     if device_id is not None:
         payload["device_id"] = device_id
+    if session_jti is not None:
+        payload["jti"] = session_jti
     return jwt.encode(payload, settings.secret_key, algorithm="HS256")
 
 

--- a/api/src/com/qode/qrew/v1/service/models/audit.py
+++ b/api/src/com/qode/qrew/v1/service/models/audit.py
@@ -39,6 +39,7 @@ class AuditAction(enum.StrEnum):
     DEVICE_BIND = "device_bind"
     DEVICE_REVOKE = "device_revoke"
     DEVICE_REVOKE_ALL = "device_revoke_all"
+    PASSKEY_REASSERTED = "passkey_reasserted"
     GENESIS = "genesis"
 
 

--- a/api/src/com/qode/qrew/v1/service/models/session.py
+++ b/api/src/com/qode/qrew/v1/service/models/session.py
@@ -38,3 +38,6 @@ class Session(Base):
     last_used_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False
     )
+    last_asserted_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )

--- a/api/src/com/qode/qrew/v1/service/repositories/session.py
+++ b/api/src/com/qode/qrew/v1/service/repositories/session.py
@@ -46,6 +46,16 @@ class SessionRepository:
             session.last_used_at = datetime.now(UTC)
             await self._session.flush()
 
+    async def update_last_asserted_at(self, jti: str, asserted_at: datetime) -> None:
+        """Stamp the last passkey re-assertion timestamp on the given session."""
+        result = await self._session.execute(
+            select(Session).where(Session.jti == jti).limit(1)
+        )
+        session = result.scalar_one_or_none()
+        if session is not None:
+            session.last_asserted_at = asserted_at
+            await self._session.flush()
+
     async def delete_by_jti(self, jti: str) -> None:
         """Delete the session with the given JTI."""
         await self._session.execute(delete(Session).where(Session.jti == jti))

--- a/api/src/com/qode/qrew/v1/service/routers/auth.py
+++ b/api/src/com/qode/qrew/v1/service/routers/auth.py
@@ -17,6 +17,7 @@ from fastapi import (
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from com.qode.qrew.v1.service.core.auth import (
+    get_current_session,
     get_current_user,
     get_recovery_user,
     get_setup_or_full_user,
@@ -29,6 +30,7 @@ from com.qode.qrew.v1.service.core.captcha import (
 from com.qode.qrew.v1.service.core.database import get_db
 from com.qode.qrew.v1.service.core.limiter import limiter
 from com.qode.qrew.v1.service.core.redis import get_redis
+from com.qode.qrew.v1.service.models.session import Session
 from com.qode.qrew.v1.service.models.user import KycStatus, User
 from com.qode.qrew.v1.service.repositories.device import DeviceRepository
 from com.qode.qrew.v1.service.repositories.fingerprint import (
@@ -57,6 +59,8 @@ from com.qode.qrew.v1.service.schemas.auth import (
     LogoutRequest,
     LogoutResponse,
     OnboardingStatusResponse,
+    PasskeyAssertBeginResponse,
+    PasskeyAssertCompleteResponse,
     PasskeyAuthenticationBeginRequest,
     PasskeyAuthenticationCompleteRequest,
     PasskeyRegistrationCompleteRequest,
@@ -707,6 +711,51 @@ async def passkey_authenticate_complete(
         return await service.complete_authentication(
             body, ip_address, user_agent, device_fingerprint
         )
+    except PasskeyError as exc:
+        raise _domain_error(exc, status.HTTP_400_BAD_REQUEST) from exc
+
+
+@router.post(
+    "/passkey/assert/begin",
+    response_model=PasskeyAssertBeginResponse,
+    status_code=status.HTTP_200_OK,
+    summary="Begin a passkey re-assertion challenge for the current session",
+)
+@limiter.limit("30/minute")  # type: ignore[misc]
+async def passkey_assert_begin(
+    request: Request,
+    current_user: User = Depends(get_current_user),
+    current_session: Session = Depends(get_current_session),
+    service: PasskeyService = Depends(get_passkey_service),
+) -> PasskeyAssertBeginResponse:
+    """Generate a 30s WebAuthn challenge bound to the current session."""
+    try:
+        options = await service.begin_reassertion(current_user, current_session.jti)
+        return PasskeyAssertBeginResponse(options=options)
+    except PasskeyError as exc:
+        raise _domain_error(exc, status.HTTP_400_BAD_REQUEST) from exc
+
+
+@router.post(
+    "/passkey/assert/complete",
+    response_model=PasskeyAssertCompleteResponse,
+    status_code=status.HTTP_200_OK,
+    summary="Complete a passkey re-assertion and stamp the session",
+)
+@limiter.limit("30/minute")  # type: ignore[misc]
+async def passkey_assert_complete(
+    request: Request,
+    body: PasskeyAuthenticationCompleteRequest,
+    current_user: User = Depends(get_current_user),
+    current_session: Session = Depends(get_current_session),
+    service: PasskeyService = Depends(get_passkey_service),
+) -> PasskeyAssertCompleteResponse:
+    """Verify a re-assertion; updates session.last_asserted_at, issues no tokens."""
+    try:
+        asserted_at = await service.complete_reassertion(
+            current_user, current_session, body
+        )
+        return PasskeyAssertCompleteResponse(asserted_at=asserted_at)
     except PasskeyError as exc:
         raise _domain_error(exc, status.HTTP_400_BAD_REQUEST) from exc
 

--- a/api/src/com/qode/qrew/v1/service/schemas/auth.py
+++ b/api/src/com/qode/qrew/v1/service/schemas/auth.py
@@ -302,6 +302,14 @@ class PasskeyAuthenticationCompleteRequest(BaseModel):
     type: str = "public-key"
 
 
+class PasskeyAssertBeginResponse(BaseModel):
+    options: str
+
+
+class PasskeyAssertCompleteResponse(BaseModel):
+    asserted_at: datetime
+
+
 class UserProfileResponse(BaseModel):
     id: uuid.UUID
     email: str

--- a/api/src/com/qode/qrew/v1/service/services/login.py
+++ b/api/src/com/qode/qrew/v1/service/services/login.py
@@ -117,11 +117,13 @@ class LoginService:
 
         if setup_complete:
             bound_device_id = await self.resolve_bound_device(user.id, device_id)
+            refresh_token = create_refresh_token(str(user.id))
+            session_jti = extract_jti(refresh_token)
             access_token = create_access_token(
                 str(user.id),
                 device_id=str(bound_device_id) if bound_device_id else None,
+                session_jti=session_jti,
             )
-            refresh_token = create_refresh_token(str(user.id))
             await self._persist_session(
                 user.id,
                 refresh_token,

--- a/api/src/com/qode/qrew/v1/service/services/passkey.py
+++ b/api/src/com/qode/qrew/v1/service/services/passkey.py
@@ -45,8 +45,10 @@ from com.qode.qrew.v1.service.settings import settings
 logger = structlog.get_logger(__name__)
 
 _CHALLENGE_TTL_SECONDS = 300
+_ASSERT_CHALLENGE_TTL_SECONDS = 30
 _CHALLENGE_PREFIX = "webauthn:challenge:"
 _AUTH_CHALLENGE_PREFIX = "webauthn:auth:challenge:"
+_ASSERT_CHALLENGE_PREFIX = "webauthn:assert:challenge:"
 
 
 def _challenge_key(user_id: uuid.UUID) -> str:
@@ -55,6 +57,10 @@ def _challenge_key(user_id: uuid.UUID) -> str:
 
 def _auth_challenge_key(user_id: uuid.UUID) -> str:
     return f"{_AUTH_CHALLENGE_PREFIX}{user_id}"
+
+
+def _assert_challenge_key(session_jti: str) -> str:
+    return f"{_ASSERT_CHALLENGE_PREFIX}{session_jti}"
 
 
 class PasskeyError(DomainError):
@@ -289,8 +295,9 @@ class PasskeyService:
         )
 
         if setup_complete:
-            access_token = create_access_token(str(user.id))
             refresh_token = create_refresh_token(str(user.id))
+            session_jti = extract_jti(refresh_token)
+            access_token = create_access_token(str(user.id), session_jti=session_jti)
             await self._persist_session(
                 user.id, refresh_token, ip_address, user_agent, device_fingerprint
             )
@@ -326,6 +333,117 @@ class PasskeyService:
             access_token=create_setup_token(str(user.id)),
             setup_required=True,
         )
+
+    async def begin_reassertion(self, user: User, session_jti: str) -> str:
+        """Generate a short-lived WebAuthn assertion challenge bound to the session."""
+        credentials = await self._passkey_repo.get_all_by_user_id(user.id)
+        if not credentials:
+            raise PasskeyError("No passkey registered for this account")
+
+        allowed = [
+            PublicKeyCredentialDescriptor(
+                id=c.credential_id,
+                type=PublicKeyCredentialType.PUBLIC_KEY,
+            )
+            for c in credentials
+        ]
+        options = webauthn.generate_authentication_options(
+            rp_id=settings.rp_id,
+            allow_credentials=allowed,
+            user_verification=UserVerificationRequirement.REQUIRED,
+        )
+        await self._redis.set(
+            _assert_challenge_key(session_jti),
+            options.challenge,
+            ex=_ASSERT_CHALLENGE_TTL_SECONDS,
+        )
+        await logger.ainfo("passkey_reassertion_begin", user_id=str(user.id))
+        return webauthn.options_to_json(options)
+
+    async def complete_reassertion(
+        self,
+        user: User,
+        session: Session,
+        request: PasskeyAuthenticationCompleteRequest,
+    ) -> datetime:
+        """Verify a re-assertion and stamp the session's last_asserted_at."""
+        raw_id = base64url_to_bytes(request.raw_id)
+
+        stored_credential = await self._passkey_repo.get_by_credential_id(raw_id)
+        if stored_credential is None or stored_credential.user_id != user.id:
+            raise PasskeyError("Passkey not recognised")
+
+        challenge_key = _assert_challenge_key(session.jti)
+        raw_challenge: bytes | None = await self._redis.get(challenge_key)
+        if raw_challenge is None:
+            raise PasskeyError("Re-assertion challenge expired. Please start again.")
+
+        await self._redis.delete(challenge_key)
+
+        user_handle = (
+            base64url_to_bytes(request.response.user_handle)
+            if request.response.user_handle
+            else None
+        )
+        credential = AuthenticationCredential(
+            id=request.id,
+            raw_id=raw_id,
+            response=AuthenticatorAssertionResponse(
+                client_data_json=base64url_to_bytes(request.response.client_data_json),
+                authenticator_data=base64url_to_bytes(
+                    request.response.authenticator_data
+                ),
+                signature=base64url_to_bytes(request.response.signature),
+                user_handle=user_handle,
+            ),
+            type=PublicKeyCredentialType.PUBLIC_KEY,
+        )
+
+        try:
+            verification = webauthn.verify_authentication_response(
+                credential=credential,
+                expected_challenge=raw_challenge,
+                expected_rp_id=settings.rp_id,
+                expected_origin=settings.rp_expected_origin,
+                credential_current_sign_count=stored_credential.sign_count,
+                credential_public_key=stored_credential.public_key,
+                require_user_verification=True,
+            )
+        except Exception as exc:
+            await logger.awarning(
+                "passkey_reassertion_failed",
+                reason="verification_failed",
+                user_id=str(user.id),
+                detail=str(exc),
+            )
+            msg = (
+                f"Passkey re-assertion failed: {exc}"
+                if settings.debug
+                else "Passkey re-assertion failed. Please try again."
+            )
+            raise PasskeyError(msg) from exc
+
+        stored_credential.sign_count = verification.new_sign_count
+        stored_credential.last_used_at = datetime.now(UTC)
+        await self._passkey_repo.save(stored_credential)
+
+        asserted_at = datetime.now(UTC)
+        if self._session_repo is not None:
+            await self._session_repo.update_last_asserted_at(session.jti, asserted_at)
+
+        await logger.ainfo("passkey_reasserted", user_id=str(user.id))
+        try:
+            await self._audit.record(
+                action=AuditAction.PASSKEY_REASSERTED,
+                actor_id=user.id,
+                entity_type="session",
+                entity_id=str(session.id),
+            )
+        except Exception:
+            await logger.awarning(
+                "audit_write_failed", action=AuditAction.PASSKEY_REASSERTED
+            )
+        return asserted_at
 
     async def list_passkeys(self, user_id: uuid.UUID) -> PasskeyListResponse:
         """Return all passkeys registered by the given user."""

--- a/api/src/com/qode/qrew/v1/service/services/refresh.py
+++ b/api/src/com/qode/qrew/v1/service/services/refresh.py
@@ -97,16 +97,20 @@ class RefreshService:
         if jti_key:
             await self._rotate_jti(jti_key, payload.get("exp"))
 
+        new_refresh_token = create_refresh_token(str(user.id))
+        new_jti = extract_jti(new_refresh_token)
         access_token = create_access_token(
             str(user.id),
             device_id=str(bound_device_id) if bound_device_id else None,
+            session_jti=new_jti,
         )
-        new_refresh_token = create_refresh_token(str(user.id))
 
-        if self._session_repo is not None and isinstance(jti, str):
-            new_jti = extract_jti(new_refresh_token)
-            if new_jti is not None:
-                await self._session_repo.update_jti(jti, new_jti)
+        if (
+            self._session_repo is not None
+            and isinstance(jti, str)
+            and new_jti is not None
+        ):
+            await self._session_repo.update_jti(jti, new_jti)
 
         await logger.ainfo("token_refreshed", user_id=str(user.id))
         try:

--- a/api/tests/v1/auth/unit/passkey_reassertion_test.py
+++ b/api/tests/v1/auth/unit/passkey_reassertion_test.py
@@ -1,0 +1,308 @@
+"""Tests for POST /v1/auth/passkey/assert/begin and /complete."""
+
+import json
+import uuid
+from collections.abc import Iterator
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from httpx import AsyncClient
+
+from com.qode.qrew.v1.service.core.auth import (
+    get_current_session,
+    get_current_user,
+)
+from com.qode.qrew.v1.service.main import app
+from com.qode.qrew.v1.service.routers.auth import get_passkey_service
+from com.qode.qrew.v1.service.services import passkey as passkey_module
+from com.qode.qrew.v1.service.services.passkey import PasskeyError, PasskeyService
+
+_BEGIN_ENDPOINT = "/v1/auth/passkey/assert/begin"
+_COMPLETE_ENDPOINT = "/v1/auth/passkey/assert/complete"
+
+_COMPLETE_PAYLOAD: dict[str, object] = {
+    "id": "Y2hlY2tNZQ",
+    "rawId": "Y2hlY2tNZQ",
+    "response": {
+        "clientDataJSON": "eyJ0eXBlIjoid2ViYXV0aG4uZ2V0In0",
+        "authenticatorData": "SZYN5YgOjGh0NBcPZHZgW4_krrmihjLHmVzzuoMdl2MFAAAABA",
+        "signature": "MEYCIQDy0K2sGzrq7yGnxUBRyqvOBf5eRaKqMSuTvp6r1j8HqQ",
+    },
+    "type": "public-key",
+}
+
+_FAKE_OPTIONS = json.dumps(
+    {"challenge": "Y2hhbGxlbmdl", "rpId": "localhost", "userVerification": "required"}
+)
+
+
+def _mock_user() -> MagicMock:
+    u = MagicMock()
+    u.id = uuid.uuid4()
+    return u
+
+
+def _mock_session() -> MagicMock:
+    s = MagicMock()
+    s.id = uuid.uuid4()
+    s.jti = str(uuid.uuid4())
+    return s
+
+
+@pytest.fixture
+def mock_service() -> AsyncMock:
+    asserted_at = datetime.now(UTC)
+    service = AsyncMock()
+    service.begin_reassertion = AsyncMock(return_value=_FAKE_OPTIONS)
+    service.complete_reassertion = AsyncMock(return_value=asserted_at)
+    return service
+
+
+@pytest.fixture(autouse=True)
+def override_dependencies(mock_service: AsyncMock) -> Iterator[None]:
+    app.dependency_overrides[get_passkey_service] = lambda: mock_service
+    app.dependency_overrides[get_current_user] = _mock_user
+    app.dependency_overrides[get_current_session] = _mock_session
+    yield
+    app.dependency_overrides.clear()
+
+
+# ── Happy paths ───────────────────────────────────────────────────────────────
+
+
+async def test_begin_returns_200_with_options(
+    client: AsyncClient, mock_service: AsyncMock
+) -> None:
+    response = await client.post(_BEGIN_ENDPOINT)
+    assert response.status_code == 200
+    body = response.json()
+    assert body["options"] == _FAKE_OPTIONS
+    mock_service.begin_reassertion.assert_awaited_once()
+
+
+async def test_complete_returns_200_with_asserted_at(
+    client: AsyncClient, mock_service: AsyncMock
+) -> None:
+    response = await client.post(_COMPLETE_ENDPOINT, json=_COMPLETE_PAYLOAD)
+    assert response.status_code == 200
+    body = response.json()
+    assert "asserted_at" in body
+    assert "access_token" not in body
+    assert "refresh_token" not in body
+    mock_service.complete_reassertion.assert_awaited_once()
+
+
+async def test_begin_passes_session_jti_to_service(
+    client: AsyncClient, mock_service: AsyncMock
+) -> None:
+    await client.post(_BEGIN_ENDPOINT)
+    args = mock_service.begin_reassertion.call_args.args
+    # args: (user, session_jti)
+    assert isinstance(args[1], str)
+
+
+# ── Validation ────────────────────────────────────────────────────────────────
+
+
+async def test_complete_rejects_missing_payload(client: AsyncClient) -> None:
+    response = await client.post(_COMPLETE_ENDPOINT, json={})
+    assert response.status_code == 422
+
+
+# ── Error mapping ─────────────────────────────────────────────────────────────
+
+
+async def test_begin_returns_400_when_no_passkey_registered(
+    client: AsyncClient, mock_service: AsyncMock
+) -> None:
+    mock_service.begin_reassertion.side_effect = PasskeyError(
+        "No passkey registered for this account"
+    )
+    response = await client.post(_BEGIN_ENDPOINT)
+    assert response.status_code == 400
+
+
+async def test_complete_returns_400_when_challenge_expired(
+    client: AsyncClient, mock_service: AsyncMock
+) -> None:
+    mock_service.complete_reassertion.side_effect = PasskeyError(
+        "Re-assertion challenge expired. Please start again."
+    )
+    response = await client.post(_COMPLETE_ENDPOINT, json=_COMPLETE_PAYLOAD)
+    assert response.status_code == 400
+
+
+async def test_complete_returns_400_when_verification_fails(
+    client: AsyncClient, mock_service: AsyncMock
+) -> None:
+    mock_service.complete_reassertion.side_effect = PasskeyError(
+        "Passkey re-assertion failed. Please try again."
+    )
+    response = await client.post(_COMPLETE_ENDPOINT, json=_COMPLETE_PAYLOAD)
+    assert response.status_code == 400
+
+
+# ── Service-level: PasskeyService.complete_reassertion stamps the session ─────
+
+
+async def test_service_stamps_last_asserted_at(monkeypatch: pytest.MonkeyPatch) -> None:
+    """complete_reassertion calls session_repo.update_last_asserted_at on success."""
+
+    user = MagicMock()
+    user.id = uuid.uuid4()
+    session = MagicMock()
+    session.id = uuid.uuid4()
+    session.jti = str(uuid.uuid4())
+
+    credential = MagicMock()
+    credential.user_id = user.id
+    credential.sign_count = 0
+    credential.public_key = b"k"
+
+    passkey_repo = AsyncMock()
+    passkey_repo.get_by_credential_id = AsyncMock(return_value=credential)
+    passkey_repo.save = AsyncMock(return_value=credential)
+
+    session_repo = AsyncMock()
+    session_repo.update_last_asserted_at = AsyncMock()
+
+    redis = AsyncMock()
+    redis.get = AsyncMock(return_value=b"raw_challenge")
+    redis.delete = AsyncMock()
+
+    audit = AsyncMock()
+
+    verify_result = MagicMock()
+    verify_result.new_sign_count = 1
+
+    def _fake_verify(**_kwargs: object) -> MagicMock:
+        return verify_result
+
+    def _fake_decode(v: str | None) -> bytes:
+        return v.encode() if v else b""
+
+    monkeypatch.setattr(
+        passkey_module.webauthn, "verify_authentication_response", _fake_verify
+    )
+    monkeypatch.setattr(passkey_module, "base64url_to_bytes", _fake_decode)
+
+    svc = PasskeyService(passkey_repo, redis, AsyncMock(), audit, session_repo)
+    request = MagicMock()
+    request.raw_id = "Y2hlY2tNZQ"
+    request.id = "Y2hlY2tNZQ"
+    request.response.client_data_json = "eyJ0eXBlIjoid2ViYXV0aG4uZ2V0In0"
+    request.response.authenticator_data = "SZYN5YgOjGh0NBcPZHZgW4"
+    request.response.signature = "MEYCIQDy0K2sGzrq7yGnxUBRyqvOBf5eRaKqMSuTvp6r1j8HqQ"
+    request.response.user_handle = None
+
+    result = await svc.complete_reassertion(user, session, request)
+
+    assert isinstance(result, datetime)
+    session_repo.update_last_asserted_at.assert_awaited_once()
+    args = session_repo.update_last_asserted_at.call_args.args
+    assert args[0] == session.jti
+
+
+async def test_service_raises_when_credential_belongs_to_other_user() -> None:
+
+    user = MagicMock()
+    user.id = uuid.uuid4()
+    session = MagicMock()
+    session.jti = str(uuid.uuid4())
+
+    credential = MagicMock()
+    credential.user_id = uuid.uuid4()  # different user
+
+    passkey_repo = AsyncMock()
+    passkey_repo.get_by_credential_id = AsyncMock(return_value=credential)
+
+    svc = PasskeyService(
+        passkey_repo, AsyncMock(), AsyncMock(), AsyncMock(), AsyncMock()
+    )
+    request = MagicMock()
+    request.raw_id = "Y2hlY2tNZQ"
+
+    with pytest.raises(PasskeyError, match="not recognised"):
+        await svc.complete_reassertion(user, session, request)
+
+
+async def test_service_raises_when_challenge_missing() -> None:
+
+    user = MagicMock()
+    user.id = uuid.uuid4()
+    session = MagicMock()
+    session.jti = str(uuid.uuid4())
+
+    credential = MagicMock()
+    credential.user_id = user.id
+
+    passkey_repo = AsyncMock()
+    passkey_repo.get_by_credential_id = AsyncMock(return_value=credential)
+
+    redis = AsyncMock()
+    redis.get = AsyncMock(return_value=None)
+
+    svc = PasskeyService(passkey_repo, redis, AsyncMock(), AsyncMock(), AsyncMock())
+    request = MagicMock()
+    request.raw_id = "Y2hlY2tNZQ"
+
+    with pytest.raises(PasskeyError, match="challenge expired"):
+        await svc.complete_reassertion(user, session, request)
+
+
+# ── PasskeyService.begin_reassertion stores 30s challenge ─────────────────────
+
+
+async def test_begin_reassertion_stores_30s_challenge(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+
+    user = MagicMock()
+    user.id = uuid.uuid4()
+    session_jti = str(uuid.uuid4())
+
+    credential = MagicMock()
+    credential.credential_id = b"cred"
+
+    passkey_repo = AsyncMock()
+    passkey_repo.get_all_by_user_id = AsyncMock(return_value=[credential])
+
+    redis = AsyncMock()
+    redis.set = AsyncMock()
+
+    options = MagicMock()
+    options.challenge = b"challenge"
+
+    def _fake_gen(**_kwargs: object) -> MagicMock:
+        return options
+
+    def _fake_to_json(_opts: object) -> str:
+        return _FAKE_OPTIONS
+
+    monkeypatch.setattr(
+        passkey_module.webauthn, "generate_authentication_options", _fake_gen
+    )
+    monkeypatch.setattr(passkey_module.webauthn, "options_to_json", _fake_to_json)
+
+    svc = PasskeyService(passkey_repo, redis, AsyncMock(), AsyncMock(), AsyncMock())
+    result = await svc.begin_reassertion(user, session_jti)
+    assert result == _FAKE_OPTIONS
+    redis.set.assert_awaited_once()
+    kwargs = redis.set.call_args.kwargs
+    assert kwargs["ex"] == 30
+
+
+async def test_begin_reassertion_raises_when_no_passkey() -> None:
+
+    user = MagicMock()
+    user.id = uuid.uuid4()
+
+    passkey_repo = AsyncMock()
+    passkey_repo.get_all_by_user_id = AsyncMock(return_value=[])
+
+    svc = PasskeyService(
+        passkey_repo, AsyncMock(), AsyncMock(), AsyncMock(), AsyncMock()
+    )
+    with pytest.raises(PasskeyError, match="No passkey"):
+        await svc.begin_reassertion(user, str(uuid.uuid4()))


### PR DESCRIPTION
## Summary

Adds the lightweight passkey re-assertion flow needed byticket QR display to defend a ticket from being transferred to another person.

A user who is already logged in can prove their biometric without minting new tokens.

The result is a `last_asserted_at` timestamp stamped on the current session row.

## Verification

`api/tests/v1/auth/unit/passkey_reassertion_test.py`

## Issue Reference

Closes [QRW-97](https://github.com/cristiangilsanz/qrew/issues/97)

## Checklist
- [x] I confirm that this PR follows the project's established coding standards.