### PR TITLE
feat: implement scanner credential management for venue entry

### DIFF
--- a/api/alembic/versions/9c0d1e2f3a4b_2026_05_26_add_scanners_table.py
+++ b/api/alembic/versions/9c0d1e2f3a4b_2026_05_26_add_scanners_table.py
@@ -1,0 +1,54 @@
+"""add scanners table
+
+Revision ID: 9c0d1e2f3a4b
+Revises: 8b9c0d1e2f3a
+Create Date: 2026-05-26 14:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "9c0d1e2f3a4b"
+down_revision: str | None = "8b9c0d1e2f3a"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "scanners",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("name", sa.String(length=128), nullable=False),
+        sa.Column("venue_id", sa.UUID(), nullable=False),
+        sa.Column("created_by", sa.UUID(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column("last_used_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "is_active",
+            sa.Boolean(),
+            server_default=sa.text("true"),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(["created_by"], ["users.id"], ondelete="RESTRICT"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        op.f("ix_scanners_venue_id"), "scanners", ["venue_id"], unique=False
+    )
+    op.create_index(
+        op.f("ix_scanners_created_by"), "scanners", ["created_by"], unique=False
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(op.f("ix_scanners_created_by"), table_name="scanners")
+    op.drop_index(op.f("ix_scanners_venue_id"), table_name="scanners")
+    op.drop_table("scanners")

--- a/api/src/com/qode/qrew/v1/service/core/auth.py
+++ b/api/src/com/qode/qrew/v1/service/core/auth.py
@@ -9,8 +9,11 @@ from jwt import ExpiredSignatureError, InvalidTokenError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from com.qode.qrew.v1.service.core.database import get_db
+from com.qode.qrew.v1.service.core.scanner_security import decode_scanner_token
+from com.qode.qrew.v1.service.models.scanner import Scanner
 from com.qode.qrew.v1.service.models.session import Session
 from com.qode.qrew.v1.service.models.user import User
+from com.qode.qrew.v1.service.repositories.scanner import ScannerRepository
 from com.qode.qrew.v1.service.repositories.session import SessionRepository
 from com.qode.qrew.v1.service.repositories.user import UserRepository
 from com.qode.qrew.v1.service.settings import settings
@@ -145,6 +148,37 @@ async def get_current_session(
         raise _CREDENTIALS_EXCEPTION
 
     return session
+
+
+async def get_scanner(
+    credentials: Annotated[HTTPAuthorizationCredentials, Depends(_bearer)],
+    db: AsyncSession = Depends(get_db),
+) -> Scanner:
+    """Validate a scanner Bearer JWT and return the active Scanner record."""
+    try:
+        payload = decode_scanner_token(credentials.credentials)
+    except (ExpiredSignatureError, InvalidTokenError) as exc:
+        raise _CREDENTIALS_EXCEPTION from exc
+
+    if payload.get("type") != "scanner":
+        raise _CREDENTIALS_EXCEPTION
+
+    scanner_id_raw = payload.get("scanner_id")
+    if not isinstance(scanner_id_raw, str):
+        raise _CREDENTIALS_EXCEPTION
+
+    try:
+        scanner_id = uuid.UUID(scanner_id_raw)
+    except ValueError as exc:
+        raise _CREDENTIALS_EXCEPTION from exc
+
+    repo = ScannerRepository(db)
+    scanner = await repo.get_by_id(scanner_id)
+    if scanner is None or not scanner.is_active:
+        raise _CREDENTIALS_EXCEPTION
+
+    await repo.touch_last_used(scanner)
+    return scanner
 
 
 async def get_admin_user(

--- a/api/src/com/qode/qrew/v1/service/core/scanner_security.py
+++ b/api/src/com/qode/qrew/v1/service/core/scanner_security.py
@@ -1,0 +1,73 @@
+"""RS256 signing helpers for scanner credentials.
+
+Scanner JWTs are asymmetric: the private key signs server-side, scanner
+devices verify offline with the public key. Keys come from settings; if
+unset (dev/test), an ephemeral RSA-2048 key pair is generated at import.
+"""
+
+import uuid
+from datetime import UTC, datetime, timedelta
+
+import jwt
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+
+from com.qode.qrew.v1.service.settings import settings
+
+
+def _generate_keypair() -> tuple[str, str]:
+    """Generate a fresh RSA-2048 PEM key pair (PKCS8 / SubjectPublicKeyInfo)."""
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    private_pem = key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    ).decode()
+    public_pem = (
+        key.public_key()
+        .public_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PublicFormat.SubjectPublicKeyInfo,
+        )
+        .decode()
+    )
+    return private_pem, public_pem
+
+
+def _resolve_keys() -> tuple[str, str]:
+    if settings.scanner_jwt_private_key and settings.scanner_jwt_public_key:
+        return settings.scanner_jwt_private_key, settings.scanner_jwt_public_key
+    return _generate_keypair()
+
+
+_PRIVATE_KEY, _PUBLIC_KEY = _resolve_keys()
+
+
+def scanner_public_key() -> str:
+    """Return the PEM-encoded public key used to verify scanner JWTs."""
+    return _PUBLIC_KEY
+
+
+def create_scanner_token(
+    scanner_id: uuid.UUID,
+    venue_id: uuid.UUID,
+    event_id: uuid.UUID,
+    date: str,
+) -> str:
+    """Return a short-lived RS256-signed JWT for a scanner device."""
+    now = datetime.now(UTC)
+    payload = {
+        "scanner_id": str(scanner_id),
+        "venue_id": str(venue_id),
+        "event_id": str(event_id),
+        "date": date,
+        "type": "scanner",
+        "iat": now,
+        "exp": now + timedelta(hours=settings.scanner_token_expire_hours),
+    }
+    return jwt.encode(payload, _PRIVATE_KEY, algorithm="RS256")
+
+
+def decode_scanner_token(token: str) -> dict[str, object]:
+    """Decode and validate a scanner JWT; raises jwt errors on failure."""
+    return jwt.decode(token, _PUBLIC_KEY, algorithms=["RS256"])  # type: ignore[no-any-return]

--- a/api/src/com/qode/qrew/v1/service/models/__init__.py
+++ b/api/src/com/qode/qrew/v1/service/models/__init__.py
@@ -3,6 +3,7 @@ from com.qode.qrew.v1.service.models.audit import AuditEvent
 from com.qode.qrew.v1.service.models.device import Device
 from com.qode.qrew.v1.service.models.fingerprint import DeviceFingerprint
 from com.qode.qrew.v1.service.models.passkey import PasskeyCredential
+from com.qode.qrew.v1.service.models.scanner import Scanner
 from com.qode.qrew.v1.service.models.session import Session
 from com.qode.qrew.v1.service.models.user import User
 
@@ -12,6 +13,7 @@ __all__ = [
     "Device",
     "DeviceFingerprint",
     "PasskeyCredential",
+    "Scanner",
     "Session",
     "User",
 ]

--- a/api/src/com/qode/qrew/v1/service/models/audit.py
+++ b/api/src/com/qode/qrew/v1/service/models/audit.py
@@ -40,6 +40,9 @@ class AuditAction(enum.StrEnum):
     DEVICE_REVOKE = "device_revoke"
     DEVICE_REVOKE_ALL = "device_revoke_all"
     PASSKEY_REASSERTED = "passkey_reasserted"
+    SCANNER_CREATED = "scanner_created"
+    SCANNER_ROTATED = "scanner_rotated"
+    SCANNER_DEACTIVATED = "scanner_deactivated"
     GENESIS = "genesis"
 
 

--- a/api/src/com/qode/qrew/v1/service/models/scanner.py
+++ b/api/src/com/qode/qrew/v1/service/models/scanner.py
@@ -1,0 +1,35 @@
+import uuid
+from datetime import datetime
+
+from sqlalchemy import Boolean, DateTime, ForeignKey, String, func
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from com.qode.qrew.v1.service.core.database import Base
+
+
+class Scanner(Base):
+    __tablename__ = "scanners"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    name: Mapped[str] = mapped_column(String(128), nullable=False)
+    venue_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), nullable=False, index=True
+    )
+    created_by: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="RESTRICT"),
+        nullable=False,
+        index=True,
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    last_used_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    is_active: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, server_default="true"
+    )

--- a/api/src/com/qode/qrew/v1/service/repositories/scanner.py
+++ b/api/src/com/qode/qrew/v1/service/repositories/scanner.py
@@ -1,0 +1,40 @@
+import uuid
+from datetime import UTC, datetime
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from com.qode.qrew.v1.service.models.scanner import Scanner
+
+
+class ScannerRepository:
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+
+    async def create(self, scanner: Scanner) -> Scanner:
+        self._session.add(scanner)
+        await self._session.flush()
+        await self._session.refresh(scanner)
+        return scanner
+
+    async def get_by_id(self, scanner_id: uuid.UUID) -> Scanner | None:
+        result = await self._session.execute(
+            select(Scanner).where(Scanner.id == scanner_id).limit(1)
+        )
+        return result.scalar_one_or_none()
+
+    async def list_all(self) -> list[Scanner]:
+        result = await self._session.execute(
+            select(Scanner).order_by(Scanner.created_at.desc())
+        )
+        return list(result.scalars().all())
+
+    async def deactivate(self, scanner: Scanner) -> Scanner:
+        scanner.is_active = False
+        await self._session.flush()
+        await self._session.refresh(scanner)
+        return scanner
+
+    async def touch_last_used(self, scanner: Scanner) -> None:
+        scanner.last_used_at = datetime.now(UTC)
+        await self._session.flush()

--- a/api/src/com/qode/qrew/v1/service/routers/admin.py
+++ b/api/src/com/qode/qrew/v1/service/routers/admin.py
@@ -10,6 +10,7 @@ from com.qode.qrew.v1.service.models.user import KycStatus, User
 from com.qode.qrew.v1.service.repositories.fingerprint import (
     DeviceFingerprintRepository,
 )
+from com.qode.qrew.v1.service.repositories.scanner import ScannerRepository
 from com.qode.qrew.v1.service.repositories.user import UserRepository
 from com.qode.qrew.v1.service.schemas.admin import (
     AuditVerifyResponse,
@@ -18,6 +19,14 @@ from com.qode.qrew.v1.service.schemas.admin import (
     KycReviewResponse,
     UserListResponse,
     UserSummaryResponse,
+)
+from com.qode.qrew.v1.service.schemas.scanner import (
+    ScannerCreateRequest,
+    ScannerDeactivateResponse,
+    ScannerListResponse,
+    ScannerRotateRequest,
+    ScannerSummaryResponse,
+    ScannerTokenResponse,
 )
 from com.qode.qrew.v1.service.services.audit import AuditService
 from com.qode.qrew.v1.service.services.fingerprint import FingerprintService
@@ -29,6 +38,7 @@ from com.qode.qrew.v1.service.services.notification import (
     NotificationDispatcher,
     build_notification_dispatcher,
 )
+from com.qode.qrew.v1.service.services.scanner import ScannerError, ScannerService
 
 router = APIRouter(prefix="/admin", tags=["admin"])
 
@@ -168,3 +178,113 @@ async def list_users(
         page=page,
         page_size=page_size,
     )
+
+
+def get_scanner_service(
+    db: AsyncSession = Depends(get_db),
+) -> ScannerService:
+    """Build and return the scanner service."""
+    return ScannerService(ScannerRepository(db), AuditService())
+
+
+def _scanner_summary(scanner: object) -> ScannerSummaryResponse:
+    return ScannerSummaryResponse.model_validate(scanner, from_attributes=True)
+
+
+# ── Scanner credentials ──────────────────────────────────────────────────────
+
+
+@router.post(
+    "/scanners",
+    response_model=ScannerTokenResponse,
+    status_code=status.HTTP_201_CREATED,
+    summary="Register a scanner and return a short-lived RS256 JWT",
+)
+@limiter.limit("30/minute")  # type: ignore[misc]
+async def create_scanner(
+    request: Request,
+    body: ScannerCreateRequest,
+    admin: User = Depends(get_admin_user),
+    service: ScannerService = Depends(get_scanner_service),
+) -> ScannerTokenResponse:
+    """Persist a new scanner and return its initial signed credential."""
+    scanner, token = await service.create(
+        admin.id, body.name, body.venue_id, body.event_id, body.date
+    )
+    return ScannerTokenResponse(
+        scanner_id=scanner.id,
+        token=token,
+        expires_in_hours=service.token_ttl_hours,
+    )
+
+
+@router.get(
+    "/scanners",
+    response_model=ScannerListResponse,
+    status_code=status.HTTP_200_OK,
+    summary="List all registered scanners",
+)
+@limiter.limit("60/minute")  # type: ignore[misc]
+async def list_scanners(
+    request: Request,
+    _admin: User = Depends(get_admin_user),
+    service: ScannerService = Depends(get_scanner_service),
+) -> ScannerListResponse:
+    """Return every scanner record (active and deactivated)."""
+    scanners = await service.list_all()
+    return ScannerListResponse(scanners=[_scanner_summary(s) for s in scanners])
+
+
+@router.post(
+    "/scanners/{scanner_id}/rotate",
+    response_model=ScannerTokenResponse,
+    status_code=status.HTTP_200_OK,
+    summary="Issue a fresh JWT for an existing scanner",
+)
+@limiter.limit("30/minute")  # type: ignore[misc]
+async def rotate_scanner(
+    request: Request,
+    scanner_id: uuid.UUID,
+    body: ScannerRotateRequest,
+    admin: User = Depends(get_admin_user),
+    service: ScannerService = Depends(get_scanner_service),
+) -> ScannerTokenResponse:
+    """Mint a new credential for a scanner that's already registered."""
+    try:
+        scanner, token = await service.rotate(
+            admin.id, scanner_id, body.venue_id, body.event_id, body.date
+        )
+    except ScannerError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={"message": exc.message, "field": exc.field},
+        ) from exc
+    return ScannerTokenResponse(
+        scanner_id=scanner.id,
+        token=token,
+        expires_in_hours=service.token_ttl_hours,
+    )
+
+
+@router.delete(
+    "/scanners/{scanner_id}",
+    response_model=ScannerDeactivateResponse,
+    status_code=status.HTTP_200_OK,
+    summary="Deactivate a scanner",
+)
+@limiter.limit("30/minute")  # type: ignore[misc]
+async def deactivate_scanner(
+    request: Request,
+    scanner_id: uuid.UUID,
+    admin: User = Depends(get_admin_user),
+    service: ScannerService = Depends(get_scanner_service),
+) -> ScannerDeactivateResponse:
+    """Mark the scanner as inactive; future JWTs and validations are refused."""
+    try:
+        await service.deactivate(admin.id, scanner_id)
+    except ScannerError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={"message": exc.message, "field": exc.field},
+        ) from exc
+    return ScannerDeactivateResponse(message="Scanner deactivated.")

--- a/api/src/com/qode/qrew/v1/service/schemas/scanner.py
+++ b/api/src/com/qode/qrew/v1/service/schemas/scanner.py
@@ -1,0 +1,43 @@
+import uuid
+from datetime import date as date_type
+from datetime import datetime
+
+from pydantic import BaseModel, Field
+
+
+class ScannerCreateRequest(BaseModel):
+    name: str = Field(..., min_length=1, max_length=128)
+    venue_id: uuid.UUID
+    event_id: uuid.UUID
+    date: date_type
+
+
+class ScannerRotateRequest(BaseModel):
+    venue_id: uuid.UUID
+    event_id: uuid.UUID
+    date: date_type
+
+
+class ScannerTokenResponse(BaseModel):
+    scanner_id: uuid.UUID
+    token: str
+    token_type: str = "bearer"  # noqa: S105
+    expires_in_hours: int
+
+
+class ScannerSummaryResponse(BaseModel):
+    id: uuid.UUID
+    name: str
+    venue_id: uuid.UUID
+    created_by: uuid.UUID
+    created_at: datetime
+    last_used_at: datetime | None
+    is_active: bool
+
+
+class ScannerListResponse(BaseModel):
+    scanners: list[ScannerSummaryResponse]
+
+
+class ScannerDeactivateResponse(BaseModel):
+    message: str

--- a/api/src/com/qode/qrew/v1/service/services/scanner.py
+++ b/api/src/com/qode/qrew/v1/service/services/scanner.py
@@ -1,0 +1,123 @@
+import uuid
+from datetime import date as date_type
+
+import structlog
+
+from com.qode.qrew.v1.service.core.errors import DomainError
+from com.qode.qrew.v1.service.core.scanner_security import create_scanner_token
+from com.qode.qrew.v1.service.models.audit import AuditAction
+from com.qode.qrew.v1.service.models.scanner import Scanner
+from com.qode.qrew.v1.service.repositories.scanner import ScannerRepository
+from com.qode.qrew.v1.service.services.audit import AuditService
+from com.qode.qrew.v1.service.settings import settings
+
+logger = structlog.get_logger(__name__)
+
+
+class ScannerError(DomainError):
+    """Raised when a scanner operation cannot be completed."""
+
+
+class ScannerService:
+    def __init__(self, repo: ScannerRepository, audit: AuditService) -> None:
+        self._repo = repo
+        self._audit = audit
+
+    async def create(
+        self,
+        admin_id: uuid.UUID,
+        name: str,
+        venue_id: uuid.UUID,
+        event_id: uuid.UUID,
+        scan_date: date_type,
+    ) -> tuple[Scanner, str]:
+        """Register a scanner and return it alongside a signed RS256 JWT."""
+        scanner = await self._repo.create(
+            Scanner(
+                id=uuid.uuid4(),
+                name=name,
+                venue_id=venue_id,
+                created_by=admin_id,
+            )
+        )
+        token = create_scanner_token(
+            scanner.id, venue_id, event_id, scan_date.isoformat()
+        )
+        await logger.ainfo("scanner_created", scanner_id=str(scanner.id))
+        try:
+            await self._audit.record(
+                action=AuditAction.SCANNER_CREATED,
+                actor_id=admin_id,
+                entity_type="scanner",
+                entity_id=str(scanner.id),
+                payload={"venue_id": str(venue_id), "event_id": str(event_id)},
+            )
+        except Exception:
+            await logger.awarning(
+                "audit_write_failed", action=AuditAction.SCANNER_CREATED
+            )
+        return scanner, token
+
+    async def list_all(self) -> list[Scanner]:
+        return await self._repo.list_all()
+
+    async def rotate(
+        self,
+        admin_id: uuid.UUID,
+        scanner_id: uuid.UUID,
+        venue_id: uuid.UUID,
+        event_id: uuid.UUID,
+        scan_date: date_type,
+    ) -> tuple[Scanner, str]:
+        """Issue a fresh JWT for an existing active scanner."""
+        scanner = await self._repo.get_by_id(scanner_id)
+        if scanner is None:
+            raise ScannerError("Scanner not found", field="scanner_id")
+        if not scanner.is_active:
+            raise ScannerError("Scanner is deactivated", field="scanner_id")
+        if scanner.venue_id != venue_id:
+            raise ScannerError(
+                "Scanner is registered to a different venue", field="venue_id"
+            )
+
+        token = create_scanner_token(
+            scanner.id, venue_id, event_id, scan_date.isoformat()
+        )
+        try:
+            await self._audit.record(
+                action=AuditAction.SCANNER_ROTATED,
+                actor_id=admin_id,
+                entity_type="scanner",
+                entity_id=str(scanner.id),
+                payload={"event_id": str(event_id)},
+            )
+        except Exception:
+            await logger.awarning(
+                "audit_write_failed", action=AuditAction.SCANNER_ROTATED
+            )
+        return scanner, token
+
+    async def deactivate(self, admin_id: uuid.UUID, scanner_id: uuid.UUID) -> Scanner:
+        scanner = await self._repo.get_by_id(scanner_id)
+        if scanner is None:
+            raise ScannerError("Scanner not found", field="scanner_id")
+        if not scanner.is_active:
+            raise ScannerError("Scanner already deactivated", field="scanner_id")
+        scanner = await self._repo.deactivate(scanner)
+        await logger.ainfo("scanner_deactivated", scanner_id=str(scanner.id))
+        try:
+            await self._audit.record(
+                action=AuditAction.SCANNER_DEACTIVATED,
+                actor_id=admin_id,
+                entity_type="scanner",
+                entity_id=str(scanner.id),
+            )
+        except Exception:
+            await logger.awarning(
+                "audit_write_failed", action=AuditAction.SCANNER_DEACTIVATED
+            )
+        return scanner
+
+    @property
+    def token_ttl_hours(self) -> int:
+        return settings.scanner_token_expire_hours

--- a/api/src/com/qode/qrew/v1/service/settings.py
+++ b/api/src/com/qode/qrew/v1/service/settings.py
@@ -64,6 +64,11 @@ class Settings(BaseSettings):
     twilio_auth_token: str = ""
     twilio_from_number: str = ""
 
+    # Scanner credentials (RS256)
+    scanner_token_expire_hours: int = 12
+    scanner_jwt_private_key: str = ""
+    scanner_jwt_public_key: str = ""
+
     # WebAuthn
     rp_id: str = "localhost"
     rp_name: str = "Qrew"

--- a/api/tests/v1/admin/unit/scanner_test.py
+++ b/api/tests/v1/admin/unit/scanner_test.py
@@ -1,0 +1,301 @@
+"""Tests for admin scanner credential endpoints."""
+
+import uuid
+from collections.abc import Iterator
+from datetime import UTC, date, datetime
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import HTTPException
+from httpx import AsyncClient
+
+from com.qode.qrew.v1.service.core import auth as auth_module
+from com.qode.qrew.v1.service.core.auth import get_admin_user, get_scanner
+from com.qode.qrew.v1.service.core.scanner_security import (
+    create_scanner_token,
+    decode_scanner_token,
+    scanner_public_key,
+)
+from com.qode.qrew.v1.service.core.security import create_access_token
+from com.qode.qrew.v1.service.main import app
+from com.qode.qrew.v1.service.routers.admin import get_scanner_service
+from com.qode.qrew.v1.service.services.scanner import ScannerError, ScannerService
+
+_LIST_ENDPOINT = "/v1/admin/scanners"
+_CREATE_ENDPOINT = "/v1/admin/scanners"
+
+
+def _mock_admin() -> MagicMock:
+    user = MagicMock()
+    user.id = uuid.uuid4()
+    user.is_admin = True
+    return user
+
+
+def _mock_scanner(active: bool = True) -> MagicMock:
+    s = MagicMock()
+    s.id = uuid.uuid4()
+    s.name = "Gate A"
+    s.venue_id = uuid.uuid4()
+    s.created_by = uuid.uuid4()
+    s.created_at = datetime(2026, 1, 1, tzinfo=UTC)
+    s.last_used_at = None
+    s.is_active = active
+    return s
+
+
+@pytest.fixture
+def mock_service() -> AsyncMock:
+    service = AsyncMock()
+    service.create = AsyncMock(return_value=(_mock_scanner(), "signed.jwt.here"))
+    service.list_all = AsyncMock(return_value=[_mock_scanner(), _mock_scanner()])
+    service.rotate = AsyncMock(return_value=(_mock_scanner(), "rotated.jwt"))
+    service.deactivate = AsyncMock(return_value=_mock_scanner(active=False))
+    service.token_ttl_hours = 12
+    return service
+
+
+@pytest.fixture(autouse=True)
+def override_deps(mock_service: AsyncMock) -> Iterator[None]:
+    app.dependency_overrides[get_admin_user] = _mock_admin
+    app.dependency_overrides[get_scanner_service] = lambda: mock_service
+    yield
+    app.dependency_overrides.clear()
+
+
+_CREATE_PAYLOAD: dict[str, object] = {
+    "name": "Gate A",
+    "venue_id": str(uuid.uuid4()),
+    "event_id": str(uuid.uuid4()),
+    "date": "2026-06-01",
+}
+
+
+# ── POST /admin/scanners ──────────────────────────────────────────────────────
+
+
+async def test_create_scanner_returns_201_with_token(
+    client: AsyncClient, mock_service: AsyncMock
+) -> None:
+    response = await client.post(_CREATE_ENDPOINT, json=_CREATE_PAYLOAD)
+    assert response.status_code == 201
+    body = response.json()
+    assert body["token"] == "signed.jwt.here"
+    assert body["token_type"] == "bearer"
+    assert body["expires_in_hours"] == 12
+    mock_service.create.assert_awaited_once()
+
+
+async def test_create_rejects_missing_name(client: AsyncClient) -> None:
+    payload = dict(_CREATE_PAYLOAD)
+    payload.pop("name")
+    response = await client.post(_CREATE_ENDPOINT, json=payload)
+    assert response.status_code == 422
+
+
+async def test_create_rejects_invalid_uuid(client: AsyncClient) -> None:
+    payload = dict(_CREATE_PAYLOAD)
+    payload["venue_id"] = "not-a-uuid"
+    response = await client.post(_CREATE_ENDPOINT, json=payload)
+    assert response.status_code == 422
+
+
+# ── GET /admin/scanners ───────────────────────────────────────────────────────
+
+
+async def test_list_scanners_returns_200(client: AsyncClient) -> None:
+    response = await client.get(_LIST_ENDPOINT)
+    assert response.status_code == 200
+    body = response.json()
+    assert len(body["scanners"]) == 2
+
+
+# ── POST /admin/scanners/{id}/rotate ──────────────────────────────────────────
+
+
+async def test_rotate_returns_200_with_fresh_token(
+    client: AsyncClient, mock_service: AsyncMock
+) -> None:
+    scanner_id = uuid.uuid4()
+    response = await client.post(
+        f"/v1/admin/scanners/{scanner_id}/rotate",
+        json={
+            "venue_id": str(uuid.uuid4()),
+            "event_id": str(uuid.uuid4()),
+            "date": "2026-06-01",
+        },
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["token"] == "rotated.jwt"
+
+
+async def test_rotate_returns_400_when_scanner_inactive(
+    client: AsyncClient, mock_service: AsyncMock
+) -> None:
+    mock_service.rotate.side_effect = ScannerError("Scanner is deactivated")
+    response = await client.post(
+        f"/v1/admin/scanners/{uuid.uuid4()}/rotate",
+        json={
+            "venue_id": str(uuid.uuid4()),
+            "event_id": str(uuid.uuid4()),
+            "date": "2026-06-01",
+        },
+    )
+    assert response.status_code == 400
+
+
+# ── DELETE /admin/scanners/{id} ───────────────────────────────────────────────
+
+
+async def test_deactivate_returns_200(
+    client: AsyncClient, mock_service: AsyncMock
+) -> None:
+    response = await client.delete(f"/v1/admin/scanners/{uuid.uuid4()}")
+    assert response.status_code == 200
+    body = response.json()
+    assert "deactivated" in body["message"].lower()
+
+
+async def test_deactivate_returns_400_when_not_found(
+    client: AsyncClient, mock_service: AsyncMock
+) -> None:
+    mock_service.deactivate.side_effect = ScannerError("Scanner not found")
+    response = await client.delete(f"/v1/admin/scanners/{uuid.uuid4()}")
+    assert response.status_code == 400
+
+
+# ── RS256 signing helpers ─────────────────────────────────────────────────────
+
+
+def test_create_and_decode_scanner_token_roundtrip() -> None:
+    scanner_id = uuid.uuid4()
+    venue_id = uuid.uuid4()
+    event_id = uuid.uuid4()
+    token = create_scanner_token(scanner_id, venue_id, event_id, "2026-06-01")
+    payload = decode_scanner_token(token)
+    assert payload["type"] == "scanner"
+    assert payload["scanner_id"] == str(scanner_id)
+    assert payload["venue_id"] == str(venue_id)
+    assert payload["event_id"] == str(event_id)
+    assert payload["date"] == "2026-06-01"
+    assert "iat" in payload
+    assert "exp" in payload
+
+
+def test_scanner_public_key_is_pem() -> None:
+    pem = scanner_public_key()
+    assert pem.startswith("-----BEGIN PUBLIC KEY-----")
+    assert pem.strip().endswith("-----END PUBLIC KEY-----")
+
+
+# ── get_scanner dependency ────────────────────────────────────────────────────
+
+
+async def test_get_scanner_returns_active_scanner() -> None:
+    """get_scanner decodes the token, finds the scanner row, touches last_used."""
+    scanner = _mock_scanner()
+    repo_instance = MagicMock()
+    repo_instance.get_by_id = AsyncMock(return_value=scanner)
+    repo_instance.touch_last_used = AsyncMock()
+
+    # Build a real token
+    token = create_scanner_token(
+        scanner.id, scanner.venue_id, uuid.uuid4(), "2026-06-01"
+    )
+
+    creds = MagicMock()
+    creds.credentials = token
+
+    with pytest.MonkeyPatch.context() as mp:
+
+        def _build_repo(_db: object) -> MagicMock:
+            return repo_instance
+
+        mp.setattr(auth_module, "ScannerRepository", _build_repo)
+        result = await get_scanner(creds, db=MagicMock())
+
+    assert result is scanner
+    repo_instance.touch_last_used.assert_awaited_once_with(scanner)
+
+
+async def test_get_scanner_rejects_inactive_scanner() -> None:
+
+    scanner = _mock_scanner(active=False)
+    repo_instance = MagicMock()
+    repo_instance.get_by_id = AsyncMock(return_value=scanner)
+
+    token = create_scanner_token(scanner.id, uuid.uuid4(), uuid.uuid4(), "2026-06-01")
+    creds = MagicMock()
+    creds.credentials = token
+
+    with pytest.MonkeyPatch.context() as mp:
+
+        def _build_repo(_db: object) -> MagicMock:
+            return repo_instance
+
+        mp.setattr(auth_module, "ScannerRepository", _build_repo)
+        with pytest.raises(HTTPException) as exc:
+            await get_scanner(creds, db=MagicMock())
+        assert exc.value.status_code == 401
+
+
+async def test_get_scanner_rejects_unknown_scanner() -> None:
+
+    repo_instance = MagicMock()
+    repo_instance.get_by_id = AsyncMock(return_value=None)
+
+    token = create_scanner_token(uuid.uuid4(), uuid.uuid4(), uuid.uuid4(), "2026-06-01")
+    creds = MagicMock()
+    creds.credentials = token
+
+    with pytest.MonkeyPatch.context() as mp:
+
+        def _build_repo(_db: object) -> MagicMock:
+            return repo_instance
+
+        mp.setattr(auth_module, "ScannerRepository", _build_repo)
+        with pytest.raises(HTTPException) as exc:
+            await get_scanner(creds, db=MagicMock())
+        assert exc.value.status_code == 401
+
+
+async def test_get_scanner_rejects_user_access_token() -> None:
+    """An access token (HS256) must NOT validate as a scanner token (RS256)."""
+
+    user_token = create_access_token(str(uuid.uuid4()))
+    creds = MagicMock()
+    creds.credentials = user_token
+
+    with pytest.raises(HTTPException) as exc:
+        await get_scanner(creds, db=MagicMock())
+    assert exc.value.status_code == 401
+
+
+# ── Service-level rotation/deactivation guards ────────────────────────────────
+
+
+async def test_service_rotate_rejects_venue_mismatch() -> None:
+
+    scanner = _mock_scanner()
+    repo = MagicMock()
+    repo.get_by_id = AsyncMock(return_value=scanner)
+    svc = ScannerService(repo, AsyncMock())
+
+    with pytest.raises(ScannerError, match="different venue"):
+        await svc.rotate(uuid.uuid4(), scanner.id, uuid.uuid4(), uuid.uuid4(), _date())
+
+
+async def test_service_deactivate_rejects_double_deactivation() -> None:
+
+    scanner = _mock_scanner(active=False)
+    repo = MagicMock()
+    repo.get_by_id = AsyncMock(return_value=scanner)
+    svc = ScannerService(repo, AsyncMock())
+
+    with pytest.raises(ScannerError, match="already deactivated"):
+        await svc.deactivate(uuid.uuid4(), scanner.id)
+
+
+def _date() -> date:
+    return date(2026, 6, 1)


### PR DESCRIPTION
## Summary

Adds the scanner credential primitive needed by venue entry validation to defend from unauthenticated scanner probing of `/entry/validate`. Without this, the entire entry layer cannot be built.

Scanner JWTs are RS256 (asymmetric). The private key signs server-side and never leaves the API. Scanner devices verify offline with the public key.

Tokens are short-lived and scoped to `scanner_id`, `venue_id`, `event_id`, and `date`.

## Verification

`api/tests/v1/admin/unit/scanner_test.py` 

## Issue Reference

Closes [QRW-98](https://github.com/cristiangilsanz/qrew/issues/98)

## Checklist
- [x] I confirm that this PR follows the project's established coding standards.