### PR TITLE
feat: implement per-account failed-login lockout with exponential backoff

### DIFF
--- a/api/src/com/qode/qrew/v1/service/models/audit.py
+++ b/api/src/com/qode/qrew/v1/service/models/audit.py
@@ -13,6 +13,8 @@ class AuditAction(enum.StrEnum):
     REGISTER = "register"
     LOGIN = "login"
     LOGIN_FAILED = "login_failed"
+    LOGIN_LOCKED = "login_locked"
+    LOGIN_UNLOCKED = "login_unlocked"
     LOGOUT = "logout"
     VERIFY_EMAIL = "verify_email"
     VERIFY_PHONE = "verify_phone"

--- a/api/src/com/qode/qrew/v1/service/routers/admin.py
+++ b/api/src/com/qode/qrew/v1/service/routers/admin.py
@@ -1,11 +1,14 @@
 import uuid
+from typing import Annotated
 
+import redis.asyncio as aioredis
 from fastapi import APIRouter, Depends, HTTPException, Request, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from com.qode.qrew.v1.service.core.auth import get_admin_user
 from com.qode.qrew.v1.service.core.database import get_db
 from com.qode.qrew.v1.service.core.limiter import limiter
+from com.qode.qrew.v1.service.core.redis import get_redis
 from com.qode.qrew.v1.service.models.user import KycStatus, User
 from com.qode.qrew.v1.service.repositories.fingerprint import (
     DeviceFingerprintRepository,
@@ -34,6 +37,7 @@ from com.qode.qrew.v1.service.services.kyc_review import (
     KycReviewError,
     KycReviewService,
 )
+from com.qode.qrew.v1.service.services.login_lockout import LoginLockoutService
 from com.qode.qrew.v1.service.services.notification import (
     NotificationDispatcher,
     build_notification_dispatcher,
@@ -178,6 +182,30 @@ async def list_users(
         page=page,
         page_size=page_size,
     )
+
+
+def get_login_lockout_service(
+    redis: Annotated[aioredis.Redis, Depends(get_redis)] = ...,  # type: ignore[type-arg, assignment]
+) -> LoginLockoutService:
+    """Build and return the login lockout service."""
+    return LoginLockoutService(redis, AuditService())
+
+
+@router.post(
+    "/users/{user_id}/unlock",
+    status_code=status.HTTP_200_OK,
+    summary="Clear a per-account login lockout",
+)
+@limiter.limit("30/minute")  # type: ignore[misc]
+async def unlock_user(
+    request: Request,
+    user_id: uuid.UUID,
+    admin: User = Depends(get_admin_user),
+    lockout: LoginLockoutService = Depends(get_login_lockout_service),
+) -> dict[str, str]:
+    """Clear the Redis lockout counter for the given user (support tool)."""
+    await lockout.admin_unlock(user_id, admin.id)
+    return {"message": "User account unlocked."}
 
 
 def get_scanner_service(

--- a/api/src/com/qode/qrew/v1/service/routers/auth.py
+++ b/api/src/com/qode/qrew/v1/service/routers/auth.py
@@ -113,6 +113,10 @@ from com.qode.qrew.v1.service.services.geoip import GeoIpService
 from com.qode.qrew.v1.service.services.kyc import KycError, KycService
 from com.qode.qrew.v1.service.services.login import LoginError, LoginService
 from com.qode.qrew.v1.service.services.login_anomaly import LoginAnomalyService
+from com.qode.qrew.v1.service.services.login_lockout import (
+    LoginLockoutError,
+    LoginLockoutService,
+)
 from com.qode.qrew.v1.service.services.logout import LogoutError, LogoutService
 from com.qode.qrew.v1.service.services.notification import (
     NotificationDispatcher,
@@ -203,6 +207,7 @@ def get_login_service(
         notifier=notifier,
         redis=redis,
     )
+    lockout = LoginLockoutService(redis, AuditService())
     return LoginService(
         UserRepository(db),
         PasskeyCredentialRepository(db),
@@ -210,6 +215,7 @@ def get_login_service(
         session_repo,
         anomaly,
         DeviceRepository(db),
+        lockout,
     )
 
 
@@ -494,6 +500,12 @@ async def login(
         return await service.login(
             body, ip_address, user_agent, device_fingerprint, device_id
         )
+    except LoginLockoutError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail={"message": "Invalid email or password", "field": None},
+            headers={"Retry-After": str(exc.retry_after_seconds)},
+        ) from exc
     except LoginError as exc:
         raise _domain_error(exc, status.HTTP_401_UNAUTHORIZED) from exc
 

--- a/api/src/com/qode/qrew/v1/service/services/login.py
+++ b/api/src/com/qode/qrew/v1/service/services/login.py
@@ -21,6 +21,7 @@ from com.qode.qrew.v1.service.repositories.user import UserRepository
 from com.qode.qrew.v1.service.schemas.auth import LoginRequest, LoginResponse
 from com.qode.qrew.v1.service.services.audit import AuditService
 from com.qode.qrew.v1.service.services.login_anomaly import LoginAnomalyService
+from com.qode.qrew.v1.service.services.login_lockout import LoginLockoutService
 
 logger = structlog.get_logger(__name__)
 
@@ -40,6 +41,7 @@ class LoginService:
         session_repo: SessionRepository | None = None,
         anomaly: LoginAnomalyService | None = None,
         device_repo: DeviceRepository | None = None,
+        lockout: LoginLockoutService | None = None,
     ) -> None:
         self._repo = repo
         self._passkey_repo = passkey_repo
@@ -47,8 +49,9 @@ class LoginService:
         self._session_repo = session_repo
         self._anomaly = anomaly
         self._device_repo = device_repo
+        self._lockout = lockout
 
-    async def login(
+    async def login(  # noqa: PLR0912, PLR0915
         self,
         request: LoginRequest,
         ip_address: str | None = None,
@@ -73,6 +76,9 @@ class LoginService:
                 )
             raise LoginError("Invalid email or password")
 
+        if self._lockout is not None:
+            await self._lockout.check_not_locked(user.id)
+
         if not verify_password(request.password, user.hashed_password):
             await logger.awarning(
                 "login_failed",
@@ -91,7 +97,12 @@ class LoginService:
                 await logger.awarning(
                     "audit_write_failed", action=AuditAction.LOGIN_FAILED
                 )
+            if self._lockout is not None:
+                await self._lockout.record_failure(user.id, ip_address)
             raise LoginError("Invalid email or password")
+
+        if self._lockout is not None:
+            await self._lockout.reset(user.id)
 
         if not user.email_verified:
             await logger.awarning(

--- a/api/src/com/qode/qrew/v1/service/services/login_lockout.py
+++ b/api/src/com/qode/qrew/v1/service/services/login_lockout.py
@@ -1,0 +1,132 @@
+"""Per-account failed-login lockout with exponential backoff.
+
+Distinct from slowapi (per-IP). Distributes across IPs don't help —
+the counter is keyed by user_id and the lockout is account-wide.
+"""
+
+import uuid
+
+import redis.asyncio as aioredis
+import structlog
+
+from com.qode.qrew.v1.service.core.errors import DomainError
+from com.qode.qrew.v1.service.models.audit import AuditAction
+from com.qode.qrew.v1.service.services.audit import AuditService
+from com.qode.qrew.v1.service.settings import settings
+
+logger = structlog.get_logger(__name__)
+
+_FAILED_PREFIX = "login:failed:"
+_LOCK_PREFIX = "login:lock:"
+
+
+# Backoff schedule: (threshold_attempts, lock_duration_seconds).
+# Defaults expand from login_lockout_base_seconds:
+#   5 attempts  -> 1x base   (5 min)
+#   10 attempts -> 6x base   (30 min)
+#   20 attempts -> 288x base (24 h)
+def _backoff_schedule() -> list[tuple[int, int]]:
+    base = settings.login_lockout_base_seconds
+    return [
+        (settings.login_max_attempts, base),
+        (settings.login_max_attempts * 2, base * 6),
+        (settings.login_max_attempts * 4, base * 288),
+    ]
+
+
+class LoginLockoutError(DomainError):
+    """Raised when an account is currently locked out."""
+
+    def __init__(self, message: str, retry_after_seconds: int) -> None:
+        super().__init__(message)
+        self.retry_after_seconds = retry_after_seconds
+
+
+def _failed_key(user_id: uuid.UUID) -> str:
+    return f"{_FAILED_PREFIX}{user_id}"
+
+
+def _lock_key(user_id: uuid.UUID) -> str:
+    return f"{_LOCK_PREFIX}{user_id}"
+
+
+class LoginLockoutService:
+    def __init__(
+        self,
+        redis: aioredis.Redis,  # type: ignore[type-arg]
+        audit: AuditService,
+    ) -> None:
+        self._redis = redis
+        self._audit = audit
+
+    async def check_not_locked(self, user_id: uuid.UUID) -> None:
+        """Raise LoginLockoutError if the account is currently locked."""
+        ttl: int = await self._redis.ttl(_lock_key(user_id))
+        if ttl > 0:
+            raise LoginLockoutError(
+                "Account temporarily locked due to too many failed login attempts",
+                retry_after_seconds=ttl,
+            )
+
+    async def record_failure(
+        self,
+        user_id: uuid.UUID,
+        ip_address: str | None = None,
+    ) -> None:
+        """Increment the failure counter and trigger a lockout if a threshold is hit."""
+        key = _failed_key(user_id)
+        attempts: int = await self._redis.incr(key)
+        if attempts == 1:
+            longest = _backoff_schedule()[-1][1]
+            await self._redis.expire(key, longest * 2)
+
+        duration = self._duration_for_attempts(attempts)
+        if duration is None:
+            return
+
+        await self._redis.setex(_lock_key(user_id), duration, "1")
+        await logger.awarning(
+            "login_locked",
+            user_id=str(user_id),
+            attempts=attempts,
+            duration_seconds=duration,
+        )
+        try:
+            await self._audit.record(
+                action=AuditAction.LOGIN_LOCKED,
+                actor_id=user_id,
+                entity_type="user",
+                entity_id=str(user_id),
+                ip_address=ip_address,
+                payload={"attempts": attempts, "duration_seconds": duration},
+            )
+        except Exception:
+            await logger.awarning("audit_write_failed", action=AuditAction.LOGIN_LOCKED)
+
+    async def reset(self, user_id: uuid.UUID) -> None:
+        """Clear the failure counter and any active lock."""
+        await self._redis.delete(_failed_key(user_id), _lock_key(user_id))
+
+    async def admin_unlock(self, user_id: uuid.UUID, admin_id: uuid.UUID) -> None:
+        """Admin-triggered unlock: clears the lock and records an audit event."""
+        await self.reset(user_id)
+        try:
+            await self._audit.record(
+                action=AuditAction.LOGIN_UNLOCKED,
+                actor_id=admin_id,
+                entity_type="user",
+                entity_id=str(user_id),
+            )
+        except Exception:
+            await logger.awarning(
+                "audit_write_failed", action=AuditAction.LOGIN_UNLOCKED
+            )
+
+    @staticmethod
+    def _duration_for_attempts(attempts: int) -> int | None:
+        """Return the lockout duration in seconds for this attempt count, or None."""
+        match: int | None = None
+        for threshold, duration in _backoff_schedule():
+            if attempts == threshold:
+                match = duration
+        return match

--- a/api/src/com/qode/qrew/v1/service/settings.py
+++ b/api/src/com/qode/qrew/v1/service/settings.py
@@ -46,6 +46,10 @@ class Settings(BaseSettings):
     # Security
     hibp_enabled: bool = False
 
+    # Login lockout (per-account)
+    login_max_attempts: int = 5
+    login_lockout_base_seconds: int = 300
+
     # Cloudflare Turnstile
     captcha_enabled: bool = False
     captcha_secret_key: str = "1x0000000000000000000000000000000AA"  # noqa: S105

--- a/api/tests/v1/auth/unit/login_lockout_test.py
+++ b/api/tests/v1/auth/unit/login_lockout_test.py
@@ -1,0 +1,304 @@
+"""Tests for per-account login lockout and admin unlock."""
+
+import uuid
+from collections.abc import Iterator
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from httpx import AsyncClient
+
+from com.qode.qrew.v1.service.core.auth import get_admin_user
+from com.qode.qrew.v1.service.main import app
+from com.qode.qrew.v1.service.models.user import KycStatus
+from com.qode.qrew.v1.service.routers.admin import get_login_lockout_service
+from com.qode.qrew.v1.service.routers.auth import get_login_service
+from com.qode.qrew.v1.service.schemas.auth import LoginRequest, LoginResponse
+from com.qode.qrew.v1.service.services import login as login_mod
+from com.qode.qrew.v1.service.services.login import LoginError, LoginService
+from com.qode.qrew.v1.service.services.login_lockout import (
+    LoginLockoutError,
+    LoginLockoutService,
+)
+from com.qode.qrew.v1.service.settings import settings
+
+_LOGIN_ENDPOINT = "/v1/auth/login"
+_LOGIN_PAYLOAD: dict[str, object] = {
+    "email": "alice@example.com",
+    "password": "Str0ng!P@ssw0rd",
+}
+
+
+def _mock_admin() -> MagicMock:
+    u = MagicMock()
+    u.id = uuid.uuid4()
+    u.is_admin = True
+    return u
+
+
+# ── Route layer: 429 with Retry-After ────────────────────────────────────────
+
+
+@pytest.fixture
+def mock_login_service() -> AsyncMock:
+    s = AsyncMock()
+    s.login = AsyncMock(return_value=LoginResponse(access_token="a.b.c"))
+    return s
+
+
+@pytest.fixture
+def override_login(mock_login_service: AsyncMock) -> Iterator[None]:
+    app.dependency_overrides[get_login_service] = lambda: mock_login_service
+    yield
+    app.dependency_overrides.clear()
+
+
+async def test_login_returns_429_with_retry_after_when_locked(
+    client: AsyncClient,
+    mock_login_service: AsyncMock,
+    override_login: None,
+) -> None:
+    mock_login_service.login.side_effect = LoginLockoutError(
+        "Account temporarily locked", retry_after_seconds=300
+    )
+    response = await client.post(_LOGIN_ENDPOINT, json=_LOGIN_PAYLOAD)
+    assert response.status_code == 429
+    assert response.headers["Retry-After"] == "300"
+    body = response.json()
+    # Must not reveal account existence — same wording as bad-password path
+    assert "Invalid email or password" in str(body)
+
+
+async def test_normal_login_failure_still_returns_401(
+    client: AsyncClient,
+    mock_login_service: AsyncMock,
+    override_login: None,
+) -> None:
+    mock_login_service.login.side_effect = LoginError("Invalid email or password")
+    response = await client.post(_LOGIN_ENDPOINT, json=_LOGIN_PAYLOAD)
+    assert response.status_code == 401
+
+
+# ── LoginLockoutService logic ────────────────────────────────────────────────
+
+
+def _service() -> tuple[LoginLockoutService, AsyncMock, AsyncMock]:
+    redis = AsyncMock()
+    redis.incr = AsyncMock()
+    redis.expire = AsyncMock()
+    redis.setex = AsyncMock()
+    redis.delete = AsyncMock()
+    redis.ttl = AsyncMock(return_value=0)
+    audit = AsyncMock()
+    audit.record = AsyncMock()
+    return LoginLockoutService(redis, audit), redis, audit
+
+
+async def test_check_not_locked_passes_when_no_lock() -> None:
+    svc, redis, _ = _service()
+    redis.ttl.return_value = 0
+    await svc.check_not_locked(uuid.uuid4())  # no raise
+
+
+async def test_check_not_locked_raises_with_remaining_ttl() -> None:
+    svc, redis, _ = _service()
+    redis.ttl.return_value = 137
+    with pytest.raises(LoginLockoutError) as exc:
+        await svc.check_not_locked(uuid.uuid4())
+    assert exc.value.retry_after_seconds == 137
+
+
+async def test_record_failure_below_threshold_does_not_lock() -> None:
+    svc, redis, audit = _service()
+    redis.incr.return_value = settings.login_max_attempts - 1
+    await svc.record_failure(uuid.uuid4(), "127.0.0.1")
+    redis.setex.assert_not_awaited()
+    audit.record.assert_not_awaited()
+
+
+async def test_record_failure_at_first_threshold_locks_for_base() -> None:
+    svc, redis, audit = _service()
+    redis.incr.return_value = settings.login_max_attempts
+    user_id = uuid.uuid4()
+    await svc.record_failure(user_id, "127.0.0.1")
+    redis.setex.assert_awaited_once()
+    args = redis.setex.call_args.args
+    assert args[0] == f"login:lock:{user_id}"
+    assert args[1] == settings.login_lockout_base_seconds
+    audit.record.assert_awaited_once()
+
+
+async def test_record_failure_at_second_threshold_escalates() -> None:
+    svc, redis, _ = _service()
+    redis.incr.return_value = settings.login_max_attempts * 2
+    await svc.record_failure(uuid.uuid4())
+    args = redis.setex.call_args.args
+    # 6x base
+    assert args[1] == settings.login_lockout_base_seconds * 6
+
+
+async def test_record_failure_at_third_threshold_locks_for_24h_equivalent() -> None:
+    svc, redis, _ = _service()
+    redis.incr.return_value = settings.login_max_attempts * 4
+    await svc.record_failure(uuid.uuid4())
+    args = redis.setex.call_args.args
+    # 288x base = 5min * 288 = 24h with defaults
+    assert args[1] == settings.login_lockout_base_seconds * 288
+
+
+async def test_record_failure_between_thresholds_does_not_relock() -> None:
+    svc, redis, _ = _service()
+    redis.incr.return_value = settings.login_max_attempts + 1
+    await svc.record_failure(uuid.uuid4())
+    redis.setex.assert_not_awaited()
+
+
+async def test_record_failure_first_attempt_sets_ttl_on_counter() -> None:
+    svc, redis, _ = _service()
+    redis.incr.return_value = 1
+    await svc.record_failure(uuid.uuid4())
+    redis.expire.assert_awaited_once()
+
+
+async def test_reset_clears_both_keys() -> None:
+    svc, redis, _ = _service()
+    user_id = uuid.uuid4()
+    await svc.reset(user_id)
+    redis.delete.assert_awaited_once_with(
+        f"login:failed:{user_id}", f"login:lock:{user_id}"
+    )
+
+
+async def test_admin_unlock_resets_and_audits() -> None:
+    svc, redis, audit = _service()
+    user_id = uuid.uuid4()
+    admin_id = uuid.uuid4()
+    await svc.admin_unlock(user_id, admin_id)
+    redis.delete.assert_awaited_once()
+    audit.record.assert_awaited_once()
+    kwargs = audit.record.call_args.kwargs
+    assert kwargs["actor_id"] == admin_id
+
+
+# ── Admin unlock route ───────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def mock_lockout() -> AsyncMock:
+    s = AsyncMock()
+    s.admin_unlock = AsyncMock()
+    return s
+
+
+@pytest.fixture
+def override_admin_lockout(mock_lockout: AsyncMock) -> Iterator[None]:
+    app.dependency_overrides[get_admin_user] = _mock_admin
+    app.dependency_overrides[get_login_lockout_service] = lambda: mock_lockout
+    yield
+    app.dependency_overrides.clear()
+
+
+async def test_admin_unlock_endpoint_returns_200(
+    client: AsyncClient,
+    mock_lockout: AsyncMock,
+    override_admin_lockout: None,
+) -> None:
+    user_id = uuid.uuid4()
+    response = await client.post(f"/v1/admin/users/{user_id}/unlock")
+    assert response.status_code == 200
+    body = response.json()
+    assert "unlocked" in body["message"].lower()
+    mock_lockout.admin_unlock.assert_awaited_once()
+
+
+async def test_admin_unlock_endpoint_rejects_invalid_uuid(
+    client: AsyncClient,
+    mock_lockout: AsyncMock,
+    override_admin_lockout: None,
+) -> None:
+    response = await client.post("/v1/admin/users/not-a-uuid/unlock")
+    assert response.status_code == 422
+
+
+# ── Integration: LoginService calls lockout in correct order ─────────────────
+
+
+async def test_login_service_resets_lockout_on_success() -> None:
+
+    user = MagicMock()
+    user.id = uuid.uuid4()
+    user.email = "alice@example.com"
+    user.email_verified = True
+    user.is_active = True
+    user.phone_number_verified = True
+    user.kyc_status = KycStatus.approved
+    # bcrypt hash for "x" — we'll bypass with a mocked verify
+    user.hashed_password = "hash"
+
+    repo = AsyncMock()
+    repo.get_by_email = AsyncMock(return_value=user)
+    passkey_repo = AsyncMock()
+    passkey_repo.has_passkey = AsyncMock(return_value=True)
+    lockout = AsyncMock()
+    lockout.check_not_locked = AsyncMock()
+    lockout.reset = AsyncMock()
+    lockout.record_failure = AsyncMock()
+
+    svc = LoginService(repo, passkey_repo, AsyncMock(), lockout=lockout)
+
+    with pytest.MonkeyPatch.context() as mp:
+
+        def _ok(_p: str, _h: str) -> bool:
+            return True
+
+        mp.setattr(login_mod, "verify_password", _ok)
+        await svc.login(LoginRequest(email="alice@example.com", password="x"))
+
+    lockout.check_not_locked.assert_awaited_once_with(user.id)
+    lockout.reset.assert_awaited_once_with(user.id)
+    lockout.record_failure.assert_not_awaited()
+
+
+async def test_login_service_records_failure_on_wrong_password() -> None:
+
+    user = MagicMock()
+    user.id = uuid.uuid4()
+    user.email = "alice@example.com"
+    user.email_verified = True
+    user.is_active = True
+    user.hashed_password = "hash"
+
+    repo = AsyncMock()
+    repo.get_by_email = AsyncMock(return_value=user)
+    lockout = AsyncMock()
+
+    svc = LoginService(repo, AsyncMock(), AsyncMock(), lockout=lockout)
+
+    with pytest.MonkeyPatch.context() as mp:
+
+        def _bad(_p: str, _h: str) -> bool:
+            return False
+
+        mp.setattr(login_mod, "verify_password", _bad)
+        with pytest.raises(LoginError):
+            await svc.login(LoginRequest(email="alice@example.com", password="x"))
+
+    lockout.record_failure.assert_awaited_once()
+
+
+async def test_login_service_check_not_locked_raises_before_password_verify() -> None:
+
+    user = MagicMock()
+    user.id = uuid.uuid4()
+    user.hashed_password = "hash"
+
+    repo = AsyncMock()
+    repo.get_by_email = AsyncMock(return_value=user)
+    lockout = AsyncMock()
+    lockout.check_not_locked = AsyncMock(
+        side_effect=LoginLockoutError("locked", retry_after_seconds=10)
+    )
+
+    svc = LoginService(repo, AsyncMock(), AsyncMock(), lockout=lockout)
+
+    with pytest.raises(LoginLockoutError):
+        await svc.login(LoginRequest(email="alice@example.com", password="x"))


### PR DESCRIPTION
## Summary

Adds a per-account lockout layer that prevents slow brute-force attacks distributed across many IPs. Distinct from slowapi (which is per-IP); this counter is keyed by `user_id`.

## Verification

`api/tests/v1/auth/unit/login_lockout_test.py`

## Issue Reference

Closes [QRW-100](https://github.com/cristiangilsanz/qrew/issues/100)

## Checklist
- [x] I confirm that this PR follows the project's established coding standards.