### PR TITLE
feat: HIBP breach check at login to flag post-registration compromised passwords

### DIFF
--- a/api/src/com/qode/qrew/v1/service/models/audit.py
+++ b/api/src/com/qode/qrew/v1/service/models/audit.py
@@ -15,6 +15,7 @@ class AuditAction(enum.StrEnum):
     LOGIN_FAILED = "login_failed"
     LOGIN_LOCKED = "login_locked"
     LOGIN_UNLOCKED = "login_unlocked"
+    LOGIN_COMPROMISED_PASSWORD = "login_compromised_password"  # noqa: S105
     LOGOUT = "logout"
     VERIFY_EMAIL = "verify_email"
     VERIFY_PHONE = "verify_phone"

--- a/api/src/com/qode/qrew/v1/service/schemas/auth.py
+++ b/api/src/com/qode/qrew/v1/service/schemas/auth.py
@@ -103,6 +103,7 @@ class LoginResponse(BaseModel):
     refresh_token: str | None = None
     token_type: str = "bearer"  # noqa: S105
     setup_required: bool = False
+    password_compromised: bool = False
 
 
 class VerifyResponse(BaseModel):

--- a/api/src/com/qode/qrew/v1/service/services/login.py
+++ b/api/src/com/qode/qrew/v1/service/services/login.py
@@ -9,6 +9,7 @@ from com.qode.qrew.v1.service.core.security import (
     create_setup_token,
     extract_jti,
     hash_password,
+    is_password_pwned,
     verify_password,
 )
 from com.qode.qrew.v1.service.models.audit import AuditAction
@@ -104,6 +105,10 @@ class LoginService:
         if self._lockout is not None:
             await self._lockout.reset(user.id)
 
+        password_compromised = await self._check_password_pwned(
+            user.id, request.password, ip_address
+        )
+
         if not user.email_verified:
             await logger.awarning(
                 "login_failed",
@@ -162,7 +167,11 @@ class LoginService:
                     await self._anomaly.check(user, ip_address, device_fingerprint)
                 except Exception:
                     await logger.awarning("anomaly_check_error", user_id=str(user.id))
-            return LoginResponse(access_token=access_token, refresh_token=refresh_token)
+            return LoginResponse(
+                access_token=access_token,
+                refresh_token=refresh_token,
+                password_compromised=password_compromised,
+            )
 
         await logger.ainfo("user_logged_in_setup_required", user_id=str(user.id))
         try:
@@ -178,7 +187,38 @@ class LoginService:
         return LoginResponse(
             access_token=create_setup_token(str(user.id)),
             setup_required=True,
+            password_compromised=password_compromised,
         )
+
+    async def _check_password_pwned(
+        self,
+        user_id: uuid.UUID,
+        password: str,
+        ip_address: str | None,
+    ) -> bool:
+        """Return True if the password appears in HIBP; swallow any error."""
+        try:
+            compromised = await is_password_pwned(password)
+        except Exception:
+            await logger.awarning("hibp_check_error", user_id=str(user_id))
+            return False
+        if not compromised:
+            return False
+
+        await logger.awarning("login_compromised_password", user_id=str(user_id))
+        try:
+            await self._audit.record(
+                action=AuditAction.LOGIN_COMPROMISED_PASSWORD,
+                actor_id=user_id,
+                entity_type="user",
+                entity_id=str(user_id),
+                ip_address=ip_address,
+            )
+        except Exception:
+            await logger.awarning(
+                "audit_write_failed", action=AuditAction.LOGIN_COMPROMISED_PASSWORD
+            )
+        return True
 
     async def _persist_session(
         self,

--- a/api/tests/v1/auth/unit/login_hibp_test.py
+++ b/api/tests/v1/auth/unit/login_hibp_test.py
@@ -1,0 +1,143 @@
+"""Tests for HIBP breach check at login."""
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from com.qode.qrew.v1.service.models.audit import AuditAction
+from com.qode.qrew.v1.service.models.user import KycStatus
+from com.qode.qrew.v1.service.schemas.auth import LoginRequest
+from com.qode.qrew.v1.service.services import login as login_mod
+from com.qode.qrew.v1.service.services.login import LoginError, LoginService
+
+
+def _user(setup_complete: bool = True) -> MagicMock:
+    u = MagicMock()
+    u.id = uuid.uuid4()
+    u.email = "alice@example.com"
+    u.email_verified = True
+    u.is_active = True
+    u.phone_number_verified = setup_complete
+    u.kyc_status = KycStatus.approved if setup_complete else KycStatus.not_submitted
+    u.hashed_password = "hash"
+    return u
+
+
+def _build_service(passkey_present: bool = True) -> tuple[LoginService, AsyncMock]:
+    user = _user()
+    repo = AsyncMock()
+    repo.get_by_email = AsyncMock(return_value=user)
+    passkey_repo = AsyncMock()
+    passkey_repo.has_passkey = AsyncMock(return_value=passkey_present)
+    audit = AsyncMock()
+    audit.record = AsyncMock()
+    svc = LoginService(repo, passkey_repo, audit)
+    return svc, audit
+
+
+def _patch_password(mp: pytest.MonkeyPatch, ok: bool = True) -> None:
+    def _verify(_p: str, _h: str) -> bool:
+        return ok
+
+    mp.setattr(login_mod, "verify_password", _verify)
+
+
+def _patch_hibp(
+    mp: pytest.MonkeyPatch,
+    *,
+    compromised: bool = False,
+    raises: bool = False,
+) -> None:
+    async def _hibp(_password: str) -> bool:
+        if raises:
+            error_msg = "HIBP down"
+            raise RuntimeError(error_msg)
+        return compromised
+
+    mp.setattr(login_mod, "is_password_pwned", _hibp)
+
+
+async def test_login_sets_password_compromised_when_pwned(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    svc, audit = _build_service()
+    _patch_password(monkeypatch, ok=True)
+    _patch_hibp(monkeypatch, compromised=True)
+
+    result = await svc.login(LoginRequest(email="a@b.com", password="x"))
+
+    assert result.password_compromised is True
+    # Audit event written
+    actions = [call.kwargs.get("action") for call in audit.record.await_args_list]
+    assert AuditAction.LOGIN_COMPROMISED_PASSWORD in actions
+
+
+async def test_login_clean_password_keeps_flag_false(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    svc, audit = _build_service()
+    _patch_password(monkeypatch, ok=True)
+    _patch_hibp(monkeypatch, compromised=False)
+
+    result = await svc.login(LoginRequest(email="a@b.com", password="x"))
+
+    assert result.password_compromised is False
+    actions = [call.kwargs.get("action") for call in audit.record.await_args_list]
+    assert AuditAction.LOGIN_COMPROMISED_PASSWORD not in actions
+
+
+async def test_login_swallows_hibp_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A HIBP outage must NOT prevent login or set the flag."""
+    svc, _ = _build_service()
+    _patch_password(monkeypatch, ok=True)
+    _patch_hibp(monkeypatch, raises=True)
+
+    result = await svc.login(LoginRequest(email="a@b.com", password="x"))
+
+    assert result.password_compromised is False
+    assert result.access_token  # login succeeded
+
+
+async def test_setup_required_response_also_carries_flag(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Compromised flag must propagate to the setup-token response too."""
+    user = _user(setup_complete=False)
+    repo = AsyncMock()
+    repo.get_by_email = AsyncMock(return_value=user)
+    passkey_repo = AsyncMock()
+    passkey_repo.has_passkey = AsyncMock(return_value=False)
+    svc = LoginService(repo, passkey_repo, AsyncMock())
+
+    _patch_password(monkeypatch, ok=True)
+    _patch_hibp(monkeypatch, compromised=True)
+
+    result = await svc.login(LoginRequest(email="a@b.com", password="x"))
+
+    assert result.setup_required is True
+    assert result.password_compromised is True
+
+
+async def test_hibp_not_called_when_password_wrong(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """HIBP check should never run on a failed credential — would waste an API call."""
+    svc, _ = _build_service()
+    _patch_password(monkeypatch, ok=False)
+
+    called = False
+
+    async def _hibp(_password: str) -> bool:
+        nonlocal called
+        called = True
+        return False
+
+    monkeypatch.setattr(login_mod, "is_password_pwned", _hibp)
+
+    with pytest.raises(LoginError):
+        await svc.login(LoginRequest(email="a@b.com", password="x"))
+
+    assert called is False

--- a/uv.lock
+++ b/uv.lock
@@ -171,7 +171,7 @@ wheels = [
 
 [[package]]
 name = "api"
-version = "1.6.0"
+version = "1.7.0"
 source = { editable = "api" }
 dependencies = [
     { name = "aiosmtplib" },


### PR DESCRIPTION
## Summary

HIBP is checked at registration, but a password that enters a breach database afterwards stays valid forever.

This PR adds a login-time HIBP check so we can flag (not block) compromised credentials and prompt the user to rotate.

## Verification

`api/tests/v1/auth/unit/login_hibp_test.py` 

## Issue Reference

Closes [QRW-101](https://github.com/cristiangilsanz/qrew/issues/101)

## Checklist
- [x] I confirm that this PR follows the project's established coding standards.