### PR TITLE
feat: enforce concurrent session cap per user with oldest-first eviction

### DIFF
--- a/api/src/com/qode/qrew/v1/service/models/audit.py
+++ b/api/src/com/qode/qrew/v1/service/models/audit.py
@@ -16,6 +16,7 @@ class AuditAction(enum.StrEnum):
     LOGIN_LOCKED = "login_locked"
     LOGIN_UNLOCKED = "login_unlocked"
     LOGIN_COMPROMISED_PASSWORD = "login_compromised_password"  # noqa: S105
+    SESSION_EVICTED = "session_evicted"
     LOGOUT = "logout"
     VERIFY_EMAIL = "verify_email"
     VERIFY_PHONE = "verify_phone"

--- a/api/src/com/qode/qrew/v1/service/repositories/session.py
+++ b/api/src/com/qode/qrew/v1/service/repositories/session.py
@@ -1,7 +1,7 @@
 import uuid
 from datetime import UTC, datetime
 
-from sqlalchemy import delete, select
+from sqlalchemy import delete, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from com.qode.qrew.v1.service.models.session import Session
@@ -31,6 +31,25 @@ class SessionRepository:
             select(Session)
             .where(Session.user_id == user_id)
             .order_by(Session.last_used_at.desc())
+        )
+        return list(result.scalars().all())
+
+    async def count_by_user_id(self, user_id: uuid.UUID) -> int:
+        """Return the number of sessions persisted for the given user."""
+        result = await self._session.execute(
+            select(func.count()).select_from(Session).where(Session.user_id == user_id)
+        )
+        return int(result.scalar_one())
+
+    async def get_oldest_by_user_id(
+        self, user_id: uuid.UUID, limit: int
+    ) -> list[Session]:
+        """Return the user's oldest sessions, ordered by created_at ASC."""
+        result = await self._session.execute(
+            select(Session)
+            .where(Session.user_id == user_id)
+            .order_by(Session.created_at.asc())
+            .limit(limit)
         )
         return list(result.scalars().all())
 

--- a/api/src/com/qode/qrew/v1/service/routers/auth.py
+++ b/api/src/com/qode/qrew/v1/service/routers/auth.py
@@ -216,6 +216,7 @@ def get_login_service(
         anomaly,
         DeviceRepository(db),
         lockout,
+        redis,
     )
 
 

--- a/api/src/com/qode/qrew/v1/service/services/login.py
+++ b/api/src/com/qode/qrew/v1/service/services/login.py
@@ -1,5 +1,6 @@
 import uuid
 
+import redis.asyncio as aioredis
 import structlog
 
 from com.qode.qrew.v1.service.core.errors import DomainError
@@ -23,6 +24,8 @@ from com.qode.qrew.v1.service.schemas.auth import LoginRequest, LoginResponse
 from com.qode.qrew.v1.service.services.audit import AuditService
 from com.qode.qrew.v1.service.services.login_anomaly import LoginAnomalyService
 from com.qode.qrew.v1.service.services.login_lockout import LoginLockoutService
+from com.qode.qrew.v1.service.services.logout import BLACKLIST_JTI_PREFIX
+from com.qode.qrew.v1.service.settings import settings
 
 logger = structlog.get_logger(__name__)
 
@@ -43,6 +46,7 @@ class LoginService:
         anomaly: LoginAnomalyService | None = None,
         device_repo: DeviceRepository | None = None,
         lockout: LoginLockoutService | None = None,
+        redis: aioredis.Redis | None = None,  # type: ignore[type-arg]
     ) -> None:
         self._repo = repo
         self._passkey_repo = passkey_repo
@@ -51,6 +55,7 @@ class LoginService:
         self._anomaly = anomaly
         self._device_repo = device_repo
         self._lockout = lockout
+        self._redis = redis
 
     async def login(  # noqa: PLR0912, PLR0915
         self,
@@ -148,6 +153,7 @@ class LoginService:
                 device_fingerprint,
                 bound_device_id,
             )
+            await self.enforce_session_cap(user.id)
             await logger.ainfo("user_logged_in", user_id=str(user.id))
             try:
                 await self._audit.record(
@@ -189,6 +195,38 @@ class LoginService:
             setup_required=True,
             password_compromised=password_compromised,
         )
+
+    async def enforce_session_cap(self, user_id: uuid.UUID) -> None:
+        """Evict the user's oldest sessions if the cap is exceeded."""
+        if self._session_repo is None:
+            return
+        cap = settings.max_sessions_per_user
+        if cap <= 0:
+            return
+        count = await self._session_repo.count_by_user_id(user_id)
+        if count <= cap:
+            return
+        overflow = count - cap
+        victims = await self._session_repo.get_oldest_by_user_id(user_id, overflow)
+        ttl = settings.refresh_token_expire_days * 86400
+        for victim in victims:
+            jti = victim.jti
+            await self._session_repo.delete_by_jti(jti)
+            if self._redis is not None:
+                await self._redis.setex(BLACKLIST_JTI_PREFIX + jti, ttl, "1")
+            await logger.ainfo("session_evicted", user_id=str(user_id), jti=jti)
+            try:
+                await self._audit.record(
+                    action=AuditAction.SESSION_EVICTED,
+                    actor_id=user_id,
+                    entity_type="session",
+                    entity_id=str(victim.id),
+                    payload={"reason": "session_cap", "jti": jti},
+                )
+            except Exception:
+                await logger.awarning(
+                    "audit_write_failed", action=AuditAction.SESSION_EVICTED
+                )
 
     async def _check_password_pwned(
         self,

--- a/api/src/com/qode/qrew/v1/service/settings.py
+++ b/api/src/com/qode/qrew/v1/service/settings.py
@@ -50,6 +50,9 @@ class Settings(BaseSettings):
     login_max_attempts: int = 5
     login_lockout_base_seconds: int = 300
 
+    # Concurrent session cap
+    max_sessions_per_user: int = 5
+
     # Cloudflare Turnstile
     captcha_enabled: bool = False
     captcha_secret_key: str = "1x0000000000000000000000000000000AA"  # noqa: S105

--- a/api/tests/v1/auth/unit/session_cap_test.py
+++ b/api/tests/v1/auth/unit/session_cap_test.py
@@ -1,0 +1,136 @@
+"""Tests for concurrent session cap enforcement on login."""
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from com.qode.qrew.v1.service.models.audit import AuditAction
+from com.qode.qrew.v1.service.services.login import LoginService
+from com.qode.qrew.v1.service.services.logout import BLACKLIST_JTI_PREFIX
+from com.qode.qrew.v1.service.settings import settings
+
+
+def _victim(jti: str) -> MagicMock:
+    v = MagicMock()
+    v.id = uuid.uuid4()
+    v.jti = jti
+    return v
+
+
+def _build_service(
+    *,
+    count: int,
+    victims: list[MagicMock] | None = None,
+) -> tuple[LoginService, AsyncMock, AsyncMock, AsyncMock]:
+    session_repo = AsyncMock()
+    session_repo.count_by_user_id = AsyncMock(return_value=count)
+    session_repo.get_oldest_by_user_id = AsyncMock(return_value=victims or [])
+    session_repo.delete_by_jti = AsyncMock()
+
+    redis = AsyncMock()
+    redis.setex = AsyncMock()
+
+    audit = AsyncMock()
+    audit.record = AsyncMock()
+
+    svc = LoginService(
+        AsyncMock(),
+        AsyncMock(),
+        audit,
+        session_repo=session_repo,
+        redis=redis,
+    )
+    return svc, session_repo, redis, audit
+
+
+async def test_no_eviction_when_under_cap() -> None:
+    svc, session_repo, redis, audit = _build_service(
+        count=settings.max_sessions_per_user
+    )
+    await svc.enforce_session_cap(uuid.uuid4())
+    session_repo.get_oldest_by_user_id.assert_not_awaited()
+    redis.setex.assert_not_awaited()
+    audit.record.assert_not_awaited()
+
+
+async def test_evicts_one_when_one_over_cap() -> None:
+    victim = _victim("old-jti")
+    svc, session_repo, redis, _audit = _build_service(
+        count=settings.max_sessions_per_user + 1, victims=[victim]
+    )
+    user_id = uuid.uuid4()
+    await svc.enforce_session_cap(user_id)
+
+    session_repo.get_oldest_by_user_id.assert_awaited_once_with(user_id, 1)
+    session_repo.delete_by_jti.assert_awaited_once_with("old-jti")
+    redis.setex.assert_awaited_once()
+    args = redis.setex.call_args.args
+    assert args[0] == BLACKLIST_JTI_PREFIX + "old-jti"
+    assert args[1] == settings.refresh_token_expire_days * 86400
+
+
+async def test_evicts_multiple_when_multiple_over_cap() -> None:
+    victims = [_victim("a"), _victim("b"), _victim("c")]
+    svc, session_repo, redis, _audit = _build_service(
+        count=settings.max_sessions_per_user + 3, victims=victims
+    )
+    await svc.enforce_session_cap(uuid.uuid4())
+
+    session_repo.get_oldest_by_user_id.assert_awaited_once()
+    args = session_repo.get_oldest_by_user_id.call_args.args
+    assert args[1] == 3
+    assert session_repo.delete_by_jti.await_count == 3
+    assert redis.setex.await_count == 3
+
+
+async def test_audit_logged_for_each_eviction() -> None:
+    victims = [_victim("j1"), _victim("j2")]
+    svc, _repo, _redis, audit = _build_service(
+        count=settings.max_sessions_per_user + 2, victims=victims
+    )
+    user_id = uuid.uuid4()
+    await svc.enforce_session_cap(user_id)
+
+    assert audit.record.await_count == 2
+    for call in audit.record.await_args_list:
+        assert call.kwargs["action"] == AuditAction.SESSION_EVICTED
+        assert call.kwargs["actor_id"] == user_id
+        assert call.kwargs["payload"]["reason"] == "session_cap"
+        assert call.kwargs["payload"]["jti"] in {"j1", "j2"}
+
+
+async def test_no_op_when_session_repo_missing() -> None:
+    svc = LoginService(AsyncMock(), AsyncMock(), AsyncMock())
+    await svc.enforce_session_cap(uuid.uuid4())  # no raise
+
+
+async def test_no_op_when_cap_is_zero(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "max_sessions_per_user", 0)
+    svc, session_repo, _redis, _audit = _build_service(count=99)
+    await svc.enforce_session_cap(uuid.uuid4())
+    session_repo.count_by_user_id.assert_not_awaited()
+
+
+async def test_eviction_skips_redis_when_redis_missing() -> None:
+    """Without redis, eviction still deletes the session row + audits."""
+    victim = _victim("solo")
+    session_repo = AsyncMock()
+    session_repo.count_by_user_id = AsyncMock(
+        return_value=settings.max_sessions_per_user + 1
+    )
+    session_repo.get_oldest_by_user_id = AsyncMock(return_value=[victim])
+    session_repo.delete_by_jti = AsyncMock()
+    audit = AsyncMock()
+    audit.record = AsyncMock()
+
+    svc = LoginService(
+        AsyncMock(),
+        AsyncMock(),
+        audit,
+        session_repo=session_repo,
+    )
+    await svc.enforce_session_cap(uuid.uuid4())
+
+    session_repo.delete_by_jti.assert_awaited_once_with("solo")
+    audit.record.assert_awaited_once()


### PR DESCRIPTION
## Summary

Caps the number of concurrent sessions per user (default 5) so a stolen refresh token can't quietly sit alongside the legitimate user's sessions forever.

When the user logs in again, the oldest sessions are evicted first, forcing the attacker's token out as soon as the legitimate user is active.

## Verification

`api/tests/v1/auth/unit/session_cap_test.py`

## Issue Reference

Closes [QRW-102](https://github.com/cristiangilsanz/qrew/issues/102)

## Checklist
- [x] I confirm that this PR follows the project's established coding standards.