### PR TITLE
feat: implement account deletion with PII anonymisation

### DIFF
--- a/api/alembic/versions/ad1e2f3a4b5c_2026_05_26_add_deleted_at_to_users.py
+++ b/api/alembic/versions/ad1e2f3a4b5c_2026_05_26_add_deleted_at_to_users.py
@@ -1,0 +1,28 @@
+"""add deleted_at to users
+
+Revision ID: ad1e2f3a4b5c
+Revises: 9c0d1e2f3a4b
+Create Date: 2026-05-26 15:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "ad1e2f3a4b5c"
+down_revision: str | None = "9c0d1e2f3a4b"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "users",
+        sa.Column("deleted_at", sa.DateTime(timezone=True), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("users", "deleted_at")

--- a/api/src/com/qode/qrew/v1/service/models/audit.py
+++ b/api/src/com/qode/qrew/v1/service/models/audit.py
@@ -17,6 +17,7 @@ class AuditAction(enum.StrEnum):
     LOGIN_UNLOCKED = "login_unlocked"
     LOGIN_COMPROMISED_PASSWORD = "login_compromised_password"  # noqa: S105
     SESSION_EVICTED = "session_evicted"
+    ACCOUNT_DELETED = "account_deleted"
     LOGOUT = "logout"
     VERIFY_EMAIL = "verify_email"
     VERIFY_PHONE = "verify_phone"

--- a/api/src/com/qode/qrew/v1/service/models/user.py
+++ b/api/src/com/qode/qrew/v1/service/models/user.py
@@ -84,3 +84,7 @@ class User(Base):
 
     is_active: Mapped[bool] = mapped_column(Boolean, default=True)
     is_admin: Mapped[bool] = mapped_column(Boolean, default=False)
+
+    deleted_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )

--- a/api/src/com/qode/qrew/v1/service/routers/auth.py
+++ b/api/src/com/qode/qrew/v1/service/routers/auth.py
@@ -40,6 +40,8 @@ from com.qode.qrew.v1.service.repositories.passkey import PasskeyCredentialRepos
 from com.qode.qrew.v1.service.repositories.session import SessionRepository
 from com.qode.qrew.v1.service.repositories.user import UserRepository
 from com.qode.qrew.v1.service.schemas.auth import (
+    AccountDeleteRequest,
+    AccountDeleteResponse,
     ChangeEmailRequest,
     ChangeEmailResponse,
     ChangePasswordRequest,
@@ -93,6 +95,10 @@ from com.qode.qrew.v1.service.schemas.passkey import (
 from com.qode.qrew.v1.service.schemas.session import (
     RevokeAllResponse,
     SessionListResponse,
+)
+from com.qode.qrew.v1.service.services.account_deletion import (
+    AccountDeletionError,
+    AccountDeletionService,
 )
 from com.qode.qrew.v1.service.services.audit import AuditService
 from com.qode.qrew.v1.service.services.complete_setup import (
@@ -374,6 +380,20 @@ def get_password_change_service(
     )
 
 
+def get_account_deletion_service(
+    db: AsyncSession = Depends(get_db),
+    redis: Annotated[aioredis.Redis, Depends(get_redis)] = ...,  # type: ignore[type-arg, assignment]
+) -> AccountDeletionService:
+    """Build and return the account deletion service."""
+    return AccountDeletionService(
+        UserRepository(db),
+        SessionRepository(db),
+        PasskeyCredentialRepository(db),
+        redis,
+        AuditService(),
+    )
+
+
 _DomainError = (
     RegistrationError
     | VerificationError
@@ -392,6 +412,7 @@ _DomainError = (
     | RecoveryError
     | DeviceBindingError
     | DeviceError
+    | AccountDeletionError
 )
 
 
@@ -930,6 +951,27 @@ async def change_password(
         )
         return ChangePasswordResponse(message="Password changed successfully.")
     except PasswordChangeError as exc:
+        raise _domain_error(exc, status.HTTP_400_BAD_REQUEST) from exc
+
+
+@router.post(
+    "/account/delete",
+    response_model=AccountDeleteResponse,
+    status_code=status.HTTP_200_OK,
+    summary="Delete the authenticated user's account (PII anonymised, soft delete)",
+)
+@limiter.limit("5/hour")  # type: ignore[misc]
+async def delete_account(
+    request: Request,
+    body: AccountDeleteRequest,
+    current_user: User = Depends(get_current_user),
+    service: AccountDeletionService = Depends(get_account_deletion_service),
+) -> AccountDeleteResponse:
+    """Anonymise PII, revoke sessions and passkeys, set deleted_at on the user."""
+    try:
+        await service.delete(current_user, body.current_password)
+        return AccountDeleteResponse(message="Account deleted.")
+    except AccountDeletionError as exc:
         raise _domain_error(exc, status.HTTP_400_BAD_REQUEST) from exc
 
 

--- a/api/src/com/qode/qrew/v1/service/schemas/auth.py
+++ b/api/src/com/qode/qrew/v1/service/schemas/auth.py
@@ -254,6 +254,14 @@ class ChangePasswordResponse(BaseModel):
     message: str
 
 
+class AccountDeleteRequest(BaseModel):
+    current_password: str = Field(..., min_length=1)
+
+
+class AccountDeleteResponse(BaseModel):
+    message: str
+
+
 class FingerprintReportRequest(BaseModel):
     fingerprint_hash: str = Field(..., min_length=1, max_length=255)
     user_agent: str | None = Field(default=None, max_length=1024)

--- a/api/src/com/qode/qrew/v1/service/services/account_deletion.py
+++ b/api/src/com/qode/qrew/v1/service/services/account_deletion.py
@@ -1,0 +1,105 @@
+"""Account deletion with PII anonymisation (GDPR right-to-erasure).
+
+Hard delete would break referential integrity for past tickets and audit
+logs, and would let users bypass KYC by deleting + re-registering. Instead
+we anonymise PII in place, soft-delete the row, kill all sessions/passkeys,
+and rely on `is_active = False` + `deleted_at` to lock the account.
+"""
+
+from datetime import UTC, datetime
+
+import redis.asyncio as aioredis
+import structlog
+
+from com.qode.qrew.v1.service.core.errors import DomainError
+from com.qode.qrew.v1.service.core.security import verify_password
+from com.qode.qrew.v1.service.models.audit import AuditAction
+from com.qode.qrew.v1.service.models.user import KycStatus, User
+from com.qode.qrew.v1.service.repositories.passkey import PasskeyCredentialRepository
+from com.qode.qrew.v1.service.repositories.session import SessionRepository
+from com.qode.qrew.v1.service.repositories.user import UserRepository
+from com.qode.qrew.v1.service.services.audit import AuditService
+from com.qode.qrew.v1.service.services.logout import BLACKLIST_JTI_PREFIX
+from com.qode.qrew.v1.service.settings import settings
+
+logger = structlog.get_logger(__name__)
+
+
+class AccountDeletionError(DomainError):
+    """Raised when an account deletion cannot be completed."""
+
+
+class AccountDeletionService:
+    def __init__(
+        self,
+        user_repo: UserRepository,
+        session_repo: SessionRepository,
+        passkey_repo: PasskeyCredentialRepository,
+        redis: aioredis.Redis,  # type: ignore[type-arg]
+        audit: AuditService,
+    ) -> None:
+        self._user_repo = user_repo
+        self._session_repo = session_repo
+        self._passkey_repo = passkey_repo
+        self._redis = redis
+        self._audit = audit
+
+    async def delete(self, user: User, current_password: str) -> None:
+        """Re-auth, anonymise PII, kill sessions + passkeys, mark soft-deleted."""
+        if user.deleted_at is not None:
+            raise AccountDeletionError("Account is already deleted")
+
+        if not verify_password(current_password, user.hashed_password):
+            raise AccountDeletionError(
+                "Current password is incorrect", field="current_password"
+            )
+
+        self._anonymise(user)
+        await self._user_repo.save(user)
+
+        await self._passkey_repo.delete_all_by_user_id(user.id)
+
+        jtis = await self._session_repo.delete_all_by_user_id(user.id)
+        ttl = settings.refresh_token_expire_days * 24 * 3600
+        for jti in jtis:
+            await self._redis.setex(BLACKLIST_JTI_PREFIX + jti, ttl, "revoked")
+
+        await logger.ainfo("account_deleted", user_id=str(user.id))
+        try:
+            await self._audit.record(
+                action=AuditAction.ACCOUNT_DELETED,
+                actor_id=user.id,
+                entity_type="user",
+                entity_id=str(user.id),
+            )
+        except Exception:
+            await logger.awarning(
+                "audit_write_failed", action=AuditAction.ACCOUNT_DELETED
+            )
+
+    @staticmethod
+    def _anonymise(user: User) -> None:
+        """Replace PII with tombstone values; preserve uniqueness on email/phone."""
+        tombstone = str(user.id)
+        user.full_name = "Deleted User"
+        user.email = f"deleted-{tombstone}@deleted.local"
+        user.phone_number = f"+0{tombstone.replace('-', '')[:14]}"
+        user.email_verified = False
+        user.phone_number_verified = False
+        user.email_verification_token = None
+        user.email_verification_token_expires_at = None
+        user.phone_number_otp = None
+        user.phone_number_otp_expires_at = None
+        user.pending_email = None
+        user.pending_email_verification_token = None
+        user.pending_email_token_expires_at = None
+        user.pending_phone_number = None
+        user.pending_phone_otp = None
+        user.pending_phone_otp_expires_at = None
+        user.national_id_hash = None
+        user.national_id_number = None
+        user.kyc_status = KycStatus.not_submitted
+        user.registration_ip = "0.0.0.0"  # noqa: S104
+        user.device_fingerprint = None
+        user.is_active = False
+        user.deleted_at = datetime.now(UTC)

--- a/api/tests/v1/auth/unit/account_deletion_test.py
+++ b/api/tests/v1/auth/unit/account_deletion_test.py
@@ -1,0 +1,235 @@
+"""Tests for POST /v1/auth/account/delete."""
+
+import uuid
+from collections.abc import Iterator
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from httpx import AsyncClient
+
+from com.qode.qrew.v1.service.core.auth import get_current_user
+from com.qode.qrew.v1.service.main import app
+from com.qode.qrew.v1.service.models.audit import AuditAction
+from com.qode.qrew.v1.service.models.user import KycStatus, User
+from com.qode.qrew.v1.service.routers.auth import get_account_deletion_service
+from com.qode.qrew.v1.service.services import account_deletion as deletion_mod
+from com.qode.qrew.v1.service.services.account_deletion import (
+    AccountDeletionError,
+    AccountDeletionService,
+)
+from com.qode.qrew.v1.service.services.logout import BLACKLIST_JTI_PREFIX
+
+_ENDPOINT = "/v1/auth/account/delete"
+_PAYLOAD: dict[str, object] = {"current_password": "Str0ng!P@ssw0rd"}
+
+
+def _ok_verify(_password: str, _hashed: str) -> bool:
+    return True
+
+
+def _bad_verify(_password: str, _hashed: str) -> bool:
+    return False
+
+
+def _mock_user() -> MagicMock:
+    u = MagicMock()
+    u.id = uuid.uuid4()
+    u.is_admin = False
+    return u
+
+
+# ── Route layer ───────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def mock_service() -> AsyncMock:
+    s = AsyncMock()
+    s.delete = AsyncMock()
+    return s
+
+
+@pytest.fixture(autouse=True)
+def override(mock_service: AsyncMock) -> Iterator[None]:
+    app.dependency_overrides[get_current_user] = _mock_user
+    app.dependency_overrides[get_account_deletion_service] = lambda: mock_service
+    yield
+    app.dependency_overrides.clear()
+
+
+async def test_delete_returns_200(client: AsyncClient, mock_service: AsyncMock) -> None:
+    response = await client.post(_ENDPOINT, json=_PAYLOAD)
+    assert response.status_code == 200
+    assert "deleted" in response.json()["message"].lower()
+    mock_service.delete.assert_awaited_once()
+
+
+async def test_delete_returns_400_on_wrong_password(
+    client: AsyncClient, mock_service: AsyncMock
+) -> None:
+    mock_service.delete.side_effect = AccountDeletionError(
+        "Current password is incorrect", field="current_password"
+    )
+    response = await client.post(_ENDPOINT, json=_PAYLOAD)
+    assert response.status_code == 400
+    assert response.json()["detail"]["field"] == "current_password"
+
+
+async def test_delete_rejects_missing_password(client: AsyncClient) -> None:
+    response = await client.post(_ENDPOINT, json={})
+    assert response.status_code == 422
+
+
+# ── Service layer ─────────────────────────────────────────────────────────────
+
+
+def _build_user() -> User:
+    user = User()
+    user.id = uuid.uuid4()
+    user.full_name = "Alice Smith"
+    user.email = "alice@example.com"
+    user.phone_number = "+34600111222"
+    user.hashed_password = "hash"
+    user.email_verified = True
+    user.phone_number_verified = True
+    user.email_verification_token = "tok"
+    user.email_verification_token_expires_at = None
+    user.phone_number_otp = "123456"
+    user.phone_number_otp_expires_at = None
+    user.pending_email = None
+    user.pending_email_verification_token = None
+    user.pending_email_token_expires_at = None
+    user.pending_phone_number = None
+    user.pending_phone_otp = None
+    user.pending_phone_otp_expires_at = None
+    user.national_id_hash = "deadbeef" * 8
+    user.national_id_number = "encrypted-blob"
+    user.kyc_status = KycStatus.approved
+    user.registration_ip = "1.2.3.4"
+    user.device_fingerprint = "fp"
+    user.is_active = True
+    user.is_admin = False
+    user.deleted_at = None
+    return user
+
+
+def _build_service() -> tuple[
+    AccountDeletionService, AsyncMock, AsyncMock, AsyncMock, AsyncMock
+]:
+    user_repo = AsyncMock()
+    user_repo.save = AsyncMock()
+    passkey_repo = AsyncMock()
+    passkey_repo.delete_all_by_user_id = AsyncMock()
+    session_repo = AsyncMock()
+    session_repo.delete_all_by_user_id = AsyncMock(return_value=["jti-1", "jti-2"])
+    redis = AsyncMock()
+    redis.setex = AsyncMock()
+    audit = AsyncMock()
+    audit.record = AsyncMock()
+    svc = AccountDeletionService(user_repo, session_repo, passkey_repo, redis, audit)
+    return svc, user_repo, session_repo, redis, audit
+
+
+async def test_service_rejects_wrong_password(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    svc, _, _, _, _ = _build_service()
+    monkeypatch.setattr(deletion_mod, "verify_password", _bad_verify)
+    with pytest.raises(AccountDeletionError, match="Current password is incorrect"):
+        await svc.delete(_build_user(), "wrong")
+
+
+async def test_service_rejects_double_delete(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    svc, _, _, _, _ = _build_service()
+    monkeypatch.setattr(deletion_mod, "verify_password", _ok_verify)
+    user = _build_user()
+    user.deleted_at = datetime.now(UTC)
+    with pytest.raises(AccountDeletionError, match="already deleted"):
+        await svc.delete(user, "x")
+
+
+async def test_service_anonymises_pii(monkeypatch: pytest.MonkeyPatch) -> None:
+    svc, user_repo, _, _, _ = _build_service()
+    monkeypatch.setattr(deletion_mod, "verify_password", _ok_verify)
+    user = _build_user()
+    original_id = user.id
+
+    await svc.delete(user, "x")
+
+    assert user.full_name == "Deleted User"
+    assert user.email.startswith("deleted-")
+    assert user.email.endswith("@deleted.local")
+    assert user.phone_number.startswith("+0")
+    assert user.email_verification_token is None
+    assert user.phone_number_otp is None
+    assert user.national_id_hash is None
+    assert user.national_id_number is None
+    assert user.kyc_status == KycStatus.not_submitted
+    assert user.registration_ip == "0.0.0.0"
+    assert user.device_fingerprint is None
+    assert user.is_active is False
+    assert user.deleted_at is not None
+    assert user.id == original_id  # primary key preserved
+    user_repo.save.assert_awaited_once_with(user)
+
+
+async def test_service_kills_sessions_and_blacklists_jtis(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    svc, _, session_repo, redis, _ = _build_service()
+    monkeypatch.setattr(deletion_mod, "verify_password", _ok_verify)
+    user = _build_user()
+
+    await svc.delete(user, "x")
+
+    session_repo.delete_all_by_user_id.assert_awaited_once_with(user.id)
+    assert redis.setex.await_count == 2
+    keys = [call.args[0] for call in redis.setex.await_args_list]
+    assert BLACKLIST_JTI_PREFIX + "jti-1" in keys
+    assert BLACKLIST_JTI_PREFIX + "jti-2" in keys
+
+
+async def test_service_deletes_all_passkeys(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    passkey_repo = AsyncMock()
+    passkey_repo.delete_all_by_user_id = AsyncMock()
+    svc = AccountDeletionService(
+        AsyncMock(),
+        AsyncMock(delete_all_by_user_id=AsyncMock(return_value=[])),
+        passkey_repo,
+        AsyncMock(),
+        AsyncMock(),
+    )
+    monkeypatch.setattr(deletion_mod, "verify_password", _ok_verify)
+    user = _build_user()
+
+    await svc.delete(user, "x")
+    passkey_repo.delete_all_by_user_id.assert_awaited_once_with(user.id)
+
+
+async def test_service_audits_deletion(monkeypatch: pytest.MonkeyPatch) -> None:
+    svc, _, _, _, audit = _build_service()
+    monkeypatch.setattr(deletion_mod, "verify_password", _ok_verify)
+    user = _build_user()
+
+    await svc.delete(user, "x")
+
+    audit.record.assert_awaited_once()
+    kwargs = audit.record.call_args.kwargs
+    assert kwargs["action"] == AuditAction.ACCOUNT_DELETED
+    assert kwargs["actor_id"] == user.id
+
+
+async def test_service_audit_failure_does_not_break_deletion(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    svc, _, _, _, audit = _build_service()
+    audit.record.side_effect = RuntimeError("audit down")
+    monkeypatch.setattr(deletion_mod, "verify_password", _ok_verify)
+    user = _build_user()
+
+    await svc.delete(user, "x")  # no raise
+    assert user.deleted_at is not None


### PR DESCRIPTION
## Summary

GDPR right-to-erasure. Hard delete is unsafe.

It would break referential integrity for past tickets/audit events and let users bypass KYC by deleting and re-registering. So we soft-delete. It means that we anonymise PII in place, lock the account, and kill all credentials

## Verification

`api/tests/v1/auth/unit/account_deletion_test.py`

## Issue Reference

Closes [QRW-60](https://github.com/cristiangilsanz/qrew/issues/60)

## Checklist
- [x] I confirm that this PR follows the project's established coding standards.