### PR TITLE
feat: implement user-facing audit log read endpoint

### DIFF
--- a/api/src/com/qode/qrew/v1/service/repositories/audit.py
+++ b/api/src/com/qode/qrew/v1/service/repositories/audit.py
@@ -97,6 +97,39 @@ class AuditRepository:
         )
         return list(result.scalars().all())
 
+    async def list_for_user(
+        self,
+        user_id: uuid.UUID,
+        limit: int,
+        action: str | None = None,
+        since: datetime | None = None,
+        cursor_created_at: datetime | None = None,
+        cursor_id: uuid.UUID | None = None,
+    ) -> list[AuditEvent]:
+        """User-facing query: reverse-chronological, with action/since filters.
+
+        Cursor pagination: pass the (created_at, id) of the last row from the
+        previous page to fetch the next page.
+        """
+        stmt = select(AuditEvent).where(AuditEvent.actor_id == user_id)
+        if action is not None:
+            stmt = stmt.where(AuditEvent.action == action)
+        if since is not None:
+            stmt = stmt.where(AuditEvent.created_at >= since)
+        if cursor_created_at is not None and cursor_id is not None:
+            stmt = stmt.where(
+                (AuditEvent.created_at < cursor_created_at)
+                | (
+                    (AuditEvent.created_at == cursor_created_at)
+                    & (AuditEvent.id < cursor_id)
+                )
+            )
+        stmt = stmt.order_by(AuditEvent.created_at.desc(), AuditEvent.id.desc()).limit(
+            limit
+        )
+        result = await self._session.execute(stmt)
+        return list(result.scalars().all())
+
     async def get_recent_login_events(
         self,
         user_id: uuid.UUID,

--- a/api/src/com/qode/qrew/v1/service/routers/auth.py
+++ b/api/src/com/qode/qrew/v1/service/routers/auth.py
@@ -1,5 +1,7 @@
+import base64
 import contextlib
 import uuid
+from datetime import datetime
 from typing import Annotated
 
 import redis.asyncio as aioredis
@@ -33,6 +35,7 @@ from com.qode.qrew.v1.service.core.limiter import limiter
 from com.qode.qrew.v1.service.core.redis import get_redis
 from com.qode.qrew.v1.service.models.session import Session
 from com.qode.qrew.v1.service.models.user import KycStatus, User
+from com.qode.qrew.v1.service.repositories.audit import AuditRepository
 from com.qode.qrew.v1.service.repositories.device import DeviceRepository
 from com.qode.qrew.v1.service.repositories.fingerprint import (
     DeviceFingerprintRepository,
@@ -40,6 +43,11 @@ from com.qode.qrew.v1.service.repositories.fingerprint import (
 from com.qode.qrew.v1.service.repositories.passkey import PasskeyCredentialRepository
 from com.qode.qrew.v1.service.repositories.session import SessionRepository
 from com.qode.qrew.v1.service.repositories.user import UserRepository
+from com.qode.qrew.v1.service.schemas.audit import (
+    UserAuditCursor,
+    UserAuditEventResponse,
+    UserAuditListResponse,
+)
 from com.qode.qrew.v1.service.schemas.auth import (
     AccountDeleteRequest,
     AccountDeleteResponse,
@@ -1373,4 +1381,68 @@ async def get_onboarding_status(
         kyc_submitted=kyc_submitted,
         passkey_registered=has_passkey,
         is_complete=is_complete,
+    )
+
+
+# ── User audit log ─────────────────────────────────────────────────────────────
+
+
+_AUDIT_PAGE_SIZE = 50
+
+
+def _decode_audit_cursor(raw: str | None) -> tuple[datetime, uuid.UUID] | None:
+    if raw is None:
+        return None
+    try:
+        decoded = base64.urlsafe_b64decode(raw + "=" * (-len(raw) % 4)).decode()
+        parsed = UserAuditCursor.model_validate_json(decoded)
+    except Exception as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={"message": "Invalid cursor", "field": "cursor"},
+        ) from exc
+    return parsed.created_at, parsed.id
+
+
+@router.get(
+    "/audit",
+    response_model=UserAuditListResponse,
+    status_code=status.HTTP_200_OK,
+    summary="Return the current user's own audit history",
+)
+@limiter.limit("60/minute")  # type: ignore[misc]
+async def list_user_audit(
+    request: Request,
+    action: str | None = None,
+    since: datetime | None = None,
+    cursor: str | None = None,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> UserAuditListResponse:
+    """Return the user's own audit events, reverse-chronological, paginated."""
+    cursor_pair = _decode_audit_cursor(cursor)
+    cursor_created_at = cursor_pair[0] if cursor_pair else None
+    cursor_id = cursor_pair[1] if cursor_pair else None
+
+    repo = AuditRepository(db)
+    events = await repo.list_for_user(
+        current_user.id,
+        limit=_AUDIT_PAGE_SIZE + 1,
+        action=action,
+        since=since,
+        cursor_created_at=cursor_created_at,
+        cursor_id=cursor_id,
+    )
+
+    next_cursor = None
+    if len(events) > _AUDIT_PAGE_SIZE:
+        last_visible = events[_AUDIT_PAGE_SIZE - 1]
+        events = events[:_AUDIT_PAGE_SIZE]
+        next_cursor = UserAuditCursor(
+            created_at=last_visible.created_at, id=last_visible.id
+        )
+
+    return UserAuditListResponse(
+        events=[UserAuditEventResponse.from_event(e) for e in events],
+        next_cursor=next_cursor,
     )

--- a/api/src/com/qode/qrew/v1/service/schemas/audit.py
+++ b/api/src/com/qode/qrew/v1/service/schemas/audit.py
@@ -1,0 +1,87 @@
+import uuid
+from datetime import datetime
+
+from pydantic import BaseModel
+
+from com.qode.qrew.v1.service.models.audit import AuditAction, AuditEvent
+
+_SUMMARIES: dict[str, str] = {
+    AuditAction.REGISTER: "Account registered",
+    AuditAction.LOGIN: "Signed in",
+    AuditAction.LOGIN_FAILED: "Failed sign-in attempt",
+    AuditAction.LOGIN_LOCKED: "Account temporarily locked",
+    AuditAction.LOGIN_UNLOCKED: "Account unlocked by support",
+    AuditAction.LOGIN_COMPROMISED_PASSWORD: (
+        "Sign-in with a password found in a breach database"
+    ),
+    AuditAction.SESSION_EVICTED: "Older session evicted (session cap)",
+    AuditAction.ACCOUNT_DELETED: "Account deleted",
+    AuditAction.LOGOUT: "Signed out",
+    AuditAction.VERIFY_EMAIL: "Email address verified",
+    AuditAction.VERIFY_PHONE: "Phone number verified",
+    AuditAction.KYC_UPLOADED: "KYC documents uploaded",
+    AuditAction.KYC_REVIEWED: "KYC reviewed",
+    AuditAction.PASSKEY_REGISTERED: "Passkey added",
+    AuditAction.PASSKEY_AUTHENTICATED: "Signed in with passkey",
+    AuditAction.PASSKEY_DELETED: "Passkey removed",
+    AuditAction.PASSKEY_RENAMED: "Passkey renamed",
+    AuditAction.PASSKEY_REASSERTED: "Identity re-verified",
+    AuditAction.TOKEN_REFRESHED: "Session refreshed",
+    AuditAction.TOKEN_THEFT_DETECTED: "Possible token theft detected",
+    AuditAction.SETUP_COMPLETED: "Onboarding complete",
+    AuditAction.PASSWORD_CHANGED: "Password changed",
+    AuditAction.EMAIL_CHANGE_REQUESTED: "Email change requested",
+    AuditAction.EMAIL_CHANGE_CONFIRMED: "Email address changed",
+    AuditAction.PHONE_CHANGE_REQUESTED: "Phone change requested",
+    AuditAction.PHONE_CHANGE_CONFIRMED: "Phone number changed",
+    AuditAction.RECOVERY_BEGIN: "Account recovery started",
+    AuditAction.RECOVERY_COMPLETED: "Account recovery completed",
+    AuditAction.RECOVERY_FAILED: "Account recovery failed",
+    AuditAction.LOGIN_ANOMALY_DETECTED: "Unusual sign-in flagged",
+    AuditAction.DEVICE_BIND: "Device bound",
+    AuditAction.DEVICE_REVOKE: "Device revoked",
+    AuditAction.DEVICE_REVOKE_ALL: "All devices revoked",
+    AuditAction.DEVICE_ATTESTED: "Device integrity verified",
+    AuditAction.DEVICE_ATTESTATION_FAILED: "Device integrity check failed",
+    AuditAction.SCANNER_CREATED: "Scanner registered",
+    AuditAction.SCANNER_ROTATED: "Scanner credential rotated",
+    AuditAction.SCANNER_DEACTIVATED: "Scanner deactivated",
+    AuditAction.FINGERPRINT_MULTI_ACCOUNT_FLAG: "Device flagged: multiple accounts",
+    AuditAction.FINGERPRINT_HEADLESS_FLAG: "Device flagged: automation detected",
+}
+
+
+def summarize(action: str) -> str:
+    return _SUMMARIES.get(action, action.replace("_", " ").capitalize())
+
+
+class UserAuditEventResponse(BaseModel):
+    id: uuid.UUID
+    action: str
+    entity_type: str | None
+    summary: str
+    ip_address: str | None
+    device_fingerprint_hash: str | None
+    created_at: datetime
+
+    @classmethod
+    def from_event(cls, event: AuditEvent) -> "UserAuditEventResponse":
+        return cls(
+            id=event.id,
+            action=event.action,
+            entity_type=event.entity_type,
+            summary=summarize(event.action),
+            ip_address=event.ip_address,
+            device_fingerprint_hash=event.device_fingerprint_hash,
+            created_at=event.created_at,
+        )
+
+
+class UserAuditCursor(BaseModel):
+    created_at: datetime
+    id: uuid.UUID
+
+
+class UserAuditListResponse(BaseModel):
+    events: list[UserAuditEventResponse]
+    next_cursor: UserAuditCursor | None = None

--- a/api/tests/v1/auth/unit/audit_test.py
+++ b/api/tests/v1/auth/unit/audit_test.py
@@ -1,0 +1,191 @@
+"""Tests for GET /v1/auth/audit (user-facing audit log)."""
+
+import base64
+import uuid
+from collections.abc import Iterator
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from httpx import AsyncClient
+
+from com.qode.qrew.v1.service.core.auth import get_current_user
+from com.qode.qrew.v1.service.main import app
+from com.qode.qrew.v1.service.models.audit import AuditAction
+from com.qode.qrew.v1.service.schemas.audit import (
+    UserAuditCursor,
+    summarize,
+)
+
+_ENDPOINT = "/v1/auth/audit"
+_AUDIT_REPO = "com.qode.qrew.v1.service.routers.auth.AuditRepository"
+
+
+def _mock_user() -> MagicMock:
+    u = MagicMock()
+    u.id = uuid.uuid4()
+    u.is_admin = False
+    return u
+
+
+def _mock_event(
+    action: str = AuditAction.LOGIN,
+    *,
+    created_at: datetime | None = None,
+    actor_id: uuid.UUID | None = None,
+    ip: str | None = "127.0.0.1",
+    payload: dict[str, object] | None = None,
+) -> MagicMock:
+    e = MagicMock()
+    e.id = uuid.uuid4()
+    e.actor_id = actor_id or uuid.uuid4()
+    e.action = action
+    e.entity_type = "user"
+    e.ip_address = ip
+    e.device_fingerprint_hash = "abc"
+    e.user_agent = "ua"
+    e.payload = payload or {"sensitive": "data"}
+    e.created_at = created_at or datetime.now(UTC)
+    return e
+
+
+@pytest.fixture(autouse=True)
+def override_user() -> Iterator[None]:
+    app.dependency_overrides[get_current_user] = _mock_user
+    yield
+    app.dependency_overrides.clear()
+
+
+# ── Happy paths ───────────────────────────────────────────────────────────────
+
+
+async def test_audit_returns_200_with_events(client: AsyncClient) -> None:
+    events = [
+        _mock_event(AuditAction.LOGIN),
+        _mock_event(AuditAction.PASSKEY_REGISTERED),
+    ]
+    with patch(_AUDIT_REPO) as repo_cls:
+        repo_cls.return_value.list_for_user = AsyncMock(return_value=events)
+        response = await client.get(_ENDPOINT)
+    assert response.status_code == 200
+    body = response.json()
+    assert len(body["events"]) == 2
+    assert body["next_cursor"] is None
+
+
+async def test_response_carries_server_curated_summary(client: AsyncClient) -> None:
+    events = [_mock_event(AuditAction.LOGIN)]
+    with patch(_AUDIT_REPO) as repo_cls:
+        repo_cls.return_value.list_for_user = AsyncMock(return_value=events)
+        response = await client.get(_ENDPOINT)
+    body = response.json()
+    assert body["events"][0]["summary"] == summarize(AuditAction.LOGIN)
+
+
+async def test_response_omits_raw_payload_and_chain_hashes(
+    client: AsyncClient,
+) -> None:
+    events = [_mock_event(payload={"reset_token": "secret"})]
+    with patch(_AUDIT_REPO) as repo_cls:
+        repo_cls.return_value.list_for_user = AsyncMock(return_value=events)
+        response = await client.get(_ENDPOINT)
+    body = response.json()
+    event = body["events"][0]
+    assert "payload" not in event
+    assert "hash" not in event
+    assert "prev_hash" not in event
+    assert "user_agent" not in event
+    assert "secret" not in str(body)
+
+
+# ── Filters ───────────────────────────────────────────────────────────────────
+
+
+async def test_action_filter_forwarded_to_repo(client: AsyncClient) -> None:
+    with patch(_AUDIT_REPO) as repo_cls:
+        repo_cls.return_value.list_for_user = AsyncMock(return_value=[])
+        await client.get(_ENDPOINT, params={"action": "login"})
+    kwargs = repo_cls.return_value.list_for_user.call_args.kwargs
+    assert kwargs["action"] == "login"
+
+
+async def test_since_filter_forwarded_to_repo(client: AsyncClient) -> None:
+    since = (datetime.now(UTC) - timedelta(days=7)).isoformat()
+    with patch(_AUDIT_REPO) as repo_cls:
+        repo_cls.return_value.list_for_user = AsyncMock(return_value=[])
+        await client.get(_ENDPOINT, params={"since": since})
+    kwargs = repo_cls.return_value.list_for_user.call_args.kwargs
+    assert isinstance(kwargs["since"], datetime)
+
+
+# ── Cursor pagination ─────────────────────────────────────────────────────────
+
+
+def _make_cursor(created_at: datetime, ident: uuid.UUID) -> str:
+    payload = UserAuditCursor(created_at=created_at, id=ident).model_dump_json()
+    return base64.urlsafe_b64encode(payload.encode()).decode().rstrip("=")
+
+
+async def test_next_cursor_returned_when_page_full(client: AsyncClient) -> None:
+    # 51 events = page size 50 + 1 lookahead
+    events = [_mock_event() for _ in range(51)]
+    with patch(_AUDIT_REPO) as repo_cls:
+        repo_cls.return_value.list_for_user = AsyncMock(return_value=events)
+        response = await client.get(_ENDPOINT)
+    body = response.json()
+    assert len(body["events"]) == 50
+    assert body["next_cursor"] is not None
+    assert "created_at" in body["next_cursor"]
+    assert "id" in body["next_cursor"]
+
+
+async def test_no_next_cursor_when_page_partial(client: AsyncClient) -> None:
+    events = [_mock_event() for _ in range(3)]
+    with patch(_AUDIT_REPO) as repo_cls:
+        repo_cls.return_value.list_for_user = AsyncMock(return_value=events)
+        response = await client.get(_ENDPOINT)
+    body = response.json()
+    assert body["next_cursor"] is None
+
+
+async def test_valid_cursor_forwarded_to_repo(client: AsyncClient) -> None:
+    cursor_dt = datetime.now(UTC) - timedelta(hours=1)
+    cursor_id = uuid.uuid4()
+    raw = _make_cursor(cursor_dt, cursor_id)
+    with patch(_AUDIT_REPO) as repo_cls:
+        repo_cls.return_value.list_for_user = AsyncMock(return_value=[])
+        await client.get(_ENDPOINT, params={"cursor": raw})
+    kwargs = repo_cls.return_value.list_for_user.call_args.kwargs
+    assert kwargs["cursor_id"] == cursor_id
+
+
+async def test_malformed_cursor_returns_400(client: AsyncClient) -> None:
+    response = await client.get(_ENDPOINT, params={"cursor": "not-base64-json"})
+    assert response.status_code == 400
+
+
+# ── Authorization scope ───────────────────────────────────────────────────────
+
+
+async def test_repo_called_with_current_user_id_only(client: AsyncClient) -> None:
+    """Authorization: the repo query is scoped to the authenticated user."""
+    with patch(_AUDIT_REPO) as repo_cls:
+        repo_cls.return_value.list_for_user = AsyncMock(return_value=[])
+        await client.get(_ENDPOINT)
+    args = repo_cls.return_value.list_for_user.call_args.args
+    # First positional arg is the user_id used to scope the query
+    assert isinstance(args[0], uuid.UUID)
+
+
+# ── summarize helper ──────────────────────────────────────────────────────────
+
+
+def test_summarize_known_action() -> None:
+    assert summarize(AuditAction.LOGIN) == "Signed in"
+    assert summarize(AuditAction.PASSKEY_REGISTERED) == "Passkey added"
+
+
+def test_summarize_unknown_action_falls_back() -> None:
+    # Unmapped action gets a human-readable fallback rather than the raw code
+    out = summarize("some_new_action")
+    assert "_" not in out


### PR DESCRIPTION
## Summary

Self-service detection for account compromise.

Users can now see their own audit history (logins, device additions, KYC actions, password/email/phone changes, recovery attempts, etc.) if a login from an unrecognised device shows up, they can revoke sessions and bind a new passkey.

## Verification

`api/tests/v1/auth/unit/audit_test.py`

## Issue Reference

Closes [QRW-72](https://github.com/cristiangilsanz/qrew/issues/72)

## Checklist
- [x] I confirm that this PR follows the project's established coding standards.