### PR TITLE
feat: require per-refresh device-key signature on bound sessions

### DIFF
--- a/api/.env.example
+++ b/api/.env.example
@@ -1,49 +1,87 @@
-# Application
+# Production-style template. Copy to .env and fill in real secrets.
+# settings.py defaults are dev-friendly; this file documents the prod posture.
+
+# ── Application ──────────────────────────────────────────────────────────────
 APP_NAME=qrew-api
 VERSION=0.1.0
-DEBUG=true
-HOST=127.0.0.1
+DEBUG=false
+HOST=0.0.0.0
 PORT=8000
-BASE_URL=http://localhost:3000
-CORS_ORIGINS=["http://localhost:3000","http://localhost:5173"]
+BASE_URL=https://qrew.example.com
+CORS_ORIGINS=["https://qrew.example.com","https://app.qrew.example.com"]
 
-# Database
-DATABASE_URL=postgresql+asyncpg://postgres:sekret@localhost:5432/qrew
-REDIS_URL=redis://localhost:6379/0
+# ── Infrastructure ───────────────────────────────────────────────────────────
+DATABASE_URL=postgresql+asyncpg://qrew:CHANGE_ME@db.internal:5432/qrew
+REDIS_URL=redis://:CHANGE_ME@redis.internal:6379/0
 
-# Auth
-SECRET_KEY=sekret
+# ── Auth tokens ──────────────────────────────────────────────────────────────
+# Generate: python -c "import secrets; print(secrets.token_urlsafe(64))"
+SECRET_KEY=CHANGE_ME_TO_A_64_BYTE_RANDOM_VALUE
 ACCESS_TOKEN_EXPIRE_MINUTES=30
 SETUP_TOKEN_EXPIRE_MINUTES=15
 REFRESH_TOKEN_EXPIRE_DAYS=7
 EMAIL_VERIFICATION_TOKEN_EXPIRE_HOURS=24
 PHONE_NUMBER_OTP_EXPIRE_MINUTES=10
 
-# KYC
+# ── KYC ──────────────────────────────────────────────────────────────────────
 KYC_AUTO_APPROVE=false
+# Fernet key — generate: python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
+NATIONAL_ID_ENCRYPTION_KEY=CHANGE_ME_FERNET_KEY
 
-# Security
-HIBP_ENABLED=false
+# ── Device fingerprinting ────────────────────────────────────────────────────
+FINGERPRINT_MULTI_ACCOUNT_THRESHOLD=2
 
-# Cloudflare Turnstile
-CAPTCHA_ENABLED=false
-CAPTCHA_SECRET_KEY=
+# ── Login anomaly detection ──────────────────────────────────────────────────
+GEOIP_DB_PATH=/var/lib/qrew/GeoLite2-City.mmdb
+ANOMALY_IMPOSSIBLE_TRAVEL_KMH=1000.0
+ANOMALY_CONCURRENT_WINDOW_MINUTES=5
+# Threat #14: kill all sessions when an anomaly is detected
+ANOMALY_KILL_SESSIONS_ON_DETECTION=true
 
-# SMTP
-SMTP_ENABLED=false
-SMTP_HOST=smtp.gmail.com
+# ── Login lockout (per-account, distinct from per-IP slowapi) ────────────────
+LOGIN_MAX_ATTEMPTS=5
+LOGIN_LOCKOUT_BASE_SECONDS=300
+
+# ── Concurrent session cap ───────────────────────────────────────────────────
+MAX_SESSIONS_PER_USER=5
+
+# ── Have-I-Been-Pwned breach check (registration + login) ────────────────────
+HIBP_ENABLED=true
+
+# ── Cloudflare Turnstile (CAPTCHA on registration) ───────────────────────────
+CAPTCHA_ENABLED=true
+CAPTCHA_SECRET_KEY=CHANGE_ME_TURNSTILE_SECRET
+
+# ── Device integrity attestation (Play Integrity / App Attest) ───────────────
+ATTESTATION_ENABLED=true
+ATTESTATION_DEV_BYPASS=false
+ANDROID_PACKAGE_NAME=com.qrew.app
+ANDROID_APP_CERT_DIGEST_SHA256=CHANGE_ME_SHA256_DIGEST_OF_APP_SIGNING_CERT
+IOS_TEAM_ID=CHANGE_ME_APPLE_TEAM_ID
+IOS_BUNDLE_ID=com.qrew.app
+
+# ── Scanner credentials (RS256, scoped per venue+event+date) ─────────────────
+SCANNER_TOKEN_EXPIRE_HOURS=12
+# PEM-encoded; generate an RSA-2048 keypair and paste both. Private key stays
+# server-side; public key is distributed to scanner devices for offline verify.
+SCANNER_JWT_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----\n...CHANGE_ME...\n-----END PRIVATE KEY-----"
+SCANNER_JWT_PUBLIC_KEY="-----BEGIN PUBLIC KEY-----\n...CHANGE_ME...\n-----END PUBLIC KEY-----"
+
+# ── SMTP (email verification, recovery, change confirmations) ────────────────
+SMTP_ENABLED=true
+SMTP_HOST=smtp.example.com
 SMTP_PORT=587
-SMTP_USER=
-SMTP_PASSWORD=
-SMTP_FROM_ADDRESS=
+SMTP_USER=CHANGE_ME
+SMTP_PASSWORD=CHANGE_ME
+SMTP_FROM_ADDRESS=no-reply@qrew.example.com
 
-# Twilio
-TWILIO_ENABLED=false
-TWILIO_ACCOUNT_SID=
-TWILIO_AUTH_TOKEN=
-TWILIO_FROM_NUMBER=
+# ── Twilio (phone OTP) ───────────────────────────────────────────────────────
+TWILIO_ENABLED=true
+TWILIO_ACCOUNT_SID=CHANGE_ME
+TWILIO_AUTH_TOKEN=CHANGE_ME
+TWILIO_FROM_NUMBER=+10000000000
 
-# WebAuthn
-RP_ID=localhost
+# ── WebAuthn ─────────────────────────────────────────────────────────────────
+RP_ID=qrew.example.com
 RP_NAME=Qrew
-RP_EXPECTED_ORIGIN=http://localhost:3000
+RP_EXPECTED_ORIGIN=https://qrew.example.com

--- a/api/src/com/qode/qrew/v1/service/models/audit.py
+++ b/api/src/com/qode/qrew/v1/service/models/audit.py
@@ -31,6 +31,7 @@ class AuditAction(enum.StrEnum):
     PASSKEY_RENAMED = "passkey_renamed"
     TOKEN_REFRESHED = "token_refreshed"  # noqa: S105
     TOKEN_THEFT_DETECTED = "token_theft_detected"  # noqa: S105
+    REFRESH_SIGNATURE_INVALID = "refresh_signature_invalid"
     SETUP_COMPLETED = "setup_completed"
     PASSWORD_CHANGED = "password_changed"  # noqa: S105
     EMAIL_CHANGE_REQUESTED = "email_change_requested"

--- a/api/src/com/qode/qrew/v1/service/routers/auth.py
+++ b/api/src/com/qode/qrew/v1/service/routers/auth.py
@@ -154,7 +154,11 @@ from com.qode.qrew.v1.service.services.phone_change import (
     PhoneChangeService,
 )
 from com.qode.qrew.v1.service.services.recovery import RecoveryError, RecoveryService
-from com.qode.qrew.v1.service.services.refresh import RefreshError, RefreshService
+from com.qode.qrew.v1.service.services.refresh import (
+    RefreshError,
+    RefreshService,
+    decode_signature_header,
+)
 from com.qode.qrew.v1.service.services.registration import (
     RegistrationError,
     RegistrationService,
@@ -247,7 +251,11 @@ def get_refresh_service(
 ) -> RefreshService:
     """Build and return the refresh service."""
     return RefreshService(
-        UserRepository(db), redis, AuditService(), SessionRepository(db)
+        UserRepository(db),
+        redis,
+        AuditService(),
+        SessionRepository(db),
+        DeviceRepository(db),
     )
 
 
@@ -568,13 +576,9 @@ async def refresh(
     service: RefreshService = Depends(get_refresh_service),
 ) -> RefreshResponse:
     """Issue a new access token from a valid refresh token."""
-    device_id: uuid.UUID | None = None
-    device_id_header = request.headers.get("X-Device-Id")
-    if device_id_header:
-        with contextlib.suppress(ValueError):
-            device_id = uuid.UUID(device_id_header)
+    signature = decode_signature_header(request.headers.get("X-Device-Signature"))
     try:
-        return await service.refresh(body, device_id)
+        return await service.refresh(body, signature)
     except RefreshError as exc:
         raise _domain_error(exc, status.HTTP_401_UNAUTHORIZED) from exc
 

--- a/api/src/com/qode/qrew/v1/service/services/device_binding.py
+++ b/api/src/com/qode/qrew/v1/service/services/device_binding.py
@@ -96,7 +96,7 @@ class DeviceBindingService:
                 "Invalid signature encoding.", field="signature"
             ) from exc
 
-        _verify_ecdsa(pub_key, sig_bytes, challenge_str.encode())
+        verify_ecdsa(pub_key, sig_bytes, challenge_str.encode())
 
         existing = await self._device_repo.get_by_public_key(public_key_bytes)
         if existing is not None:
@@ -146,7 +146,7 @@ def _pad_b64(value: str) -> str:
     return value + "=" * (-len(value) % 4)
 
 
-def _verify_ecdsa(
+def verify_ecdsa(
     pub_key: EllipticCurvePublicKey,
     sig_bytes: bytes,
     data: bytes,

--- a/api/src/com/qode/qrew/v1/service/services/refresh.py
+++ b/api/src/com/qode/qrew/v1/service/services/refresh.py
@@ -1,9 +1,12 @@
+import base64
 import uuid
 from datetime import UTC, datetime
 
 import jwt
 import redis.asyncio as aioredis
 import structlog
+from cryptography.hazmat.primitives.asymmetric.ec import EllipticCurvePublicKey
+from cryptography.hazmat.primitives.serialization import load_der_public_key
 from jwt import ExpiredSignatureError, InvalidTokenError
 
 from com.qode.qrew.v1.service.core.errors import DomainError
@@ -13,10 +16,15 @@ from com.qode.qrew.v1.service.core.security import (
     extract_jti,
 )
 from com.qode.qrew.v1.service.models.audit import AuditAction
+from com.qode.qrew.v1.service.repositories.device import DeviceRepository
 from com.qode.qrew.v1.service.repositories.session import SessionRepository
 from com.qode.qrew.v1.service.repositories.user import UserRepository
 from com.qode.qrew.v1.service.schemas.auth import RefreshRequest, RefreshResponse
 from com.qode.qrew.v1.service.services.audit import AuditService
+from com.qode.qrew.v1.service.services.device_binding import (
+    DeviceBindingError,
+    verify_ecdsa,
+)
 from com.qode.qrew.v1.service.services.logout import (
     BLACKLIST_JTI_PREFIX,
     BLACKLIST_USER_PREFIX,
@@ -28,6 +36,26 @@ logger = structlog.get_logger(__name__)
 _ROTATED = b"rotated"
 
 
+def signature_payload(jti: str, iat: int) -> bytes:
+    """Return the bytes the client must ECDSA-sign for a device-bound refresh.
+
+    Format: ``<jti>|<iat>`` — a short challenge that rotates on every refresh
+    (jti is fresh on each issue; iat is the token's issue time).
+    """
+    return f"{jti}|{iat}".encode()
+
+
+def decode_signature_header(raw: str | None) -> bytes | None:
+    """Decode an ``X-Device-Signature`` header (base64url, padding optional)."""
+    if raw is None:
+        return None
+    padded = raw + "=" * (-len(raw) % 4)
+    try:
+        return base64.urlsafe_b64decode(padded)
+    except Exception:
+        return None
+
+
 class RefreshError(DomainError):
     """A business-rule violation raised when a token refresh cannot be completed."""
 
@@ -36,19 +64,21 @@ class RefreshService:
     def __init__(
         self,
         repo: UserRepository,
-        redis: aioredis.Redis,
-        audit: AuditService,  # type: ignore[type-arg]
+        redis: aioredis.Redis,  # type: ignore[type-arg]
+        audit: AuditService,
         session_repo: SessionRepository | None = None,
+        device_repo: DeviceRepository | None = None,
     ) -> None:
         self._repo = repo
         self._redis = redis
         self._audit = audit
         self._session_repo = session_repo
+        self._device_repo = device_repo
 
     async def refresh(
         self,
         request: RefreshRequest,
-        device_id: uuid.UUID | None = None,
+        device_signature: bytes | None = None,
     ) -> RefreshResponse:
         """Issue a new access + refresh token pair, invalidating the old one."""
         try:
@@ -92,7 +122,9 @@ class RefreshService:
             await logger.awarning("refresh_failed", reason="user_not_found_or_inactive")
             raise RefreshError("Invalid refresh token")
 
-        bound_device_id = await self.check_device_binding(jti, device_id)
+        bound_device_id = await self.check_device_binding(
+            jti, payload.get("iat"), device_signature, user_id
+        )
 
         if jti_key:
             await self._rotate_jti(jti_key, payload.get("exp"))
@@ -183,22 +215,71 @@ class RefreshService:
             raise RefreshError("Refresh token has been revoked")
 
     async def check_device_binding(
-        self, jti: object, device_id: uuid.UUID | None
+        self,
+        jti: object,
+        iat: object,
+        signature: bytes | None,
+        actor_id: uuid.UUID,
     ) -> uuid.UUID | None:
-        """If the session is device-bound, require a matching X-Device-Id."""
+        """If the session is device-bound, verify the ECDSA signature over jti||iat."""
         if self._session_repo is None or not isinstance(jti, str):
             return None
         session = await self._session_repo.get_by_jti(jti)
         if session is None or session.device_id is None:
             return None
-        if device_id is None or device_id != session.device_id:
+        if not isinstance(iat, (int, float)):
+            raise RefreshError("Invalid refresh token")
+
+        if signature is None:
+            await self._audit_signature_failure(actor_id, jti, "missing_signature")
             await logger.awarning(
-                "refresh_failed",
-                reason="device_mismatch",
-                session_device_id=str(session.device_id),
+                "refresh_failed", reason="missing_device_signature", jti=jti
             )
-            raise RefreshError("Refresh token is bound to a different device")
+            raise RefreshError("Refresh requires a device signature")
+
+        if self._device_repo is None:
+            return session.device_id
+        device = await self._device_repo.get_by_id(session.device_id)
+        if device is None or device.revoked_at is not None:
+            await self._audit_signature_failure(actor_id, jti, "device_missing")
+            raise RefreshError("Bound device is no longer valid")
+
+        signed_payload = signature_payload(jti, int(iat))
+        try:
+            pub_key = load_der_public_key(device.public_key)
+        except Exception as exc:
+            await self._audit_signature_failure(actor_id, jti, "bad_public_key")
+            raise RefreshError("Invalid bound device public key") from exc
+        if not isinstance(pub_key, EllipticCurvePublicKey):
+            await self._audit_signature_failure(actor_id, jti, "bad_public_key")
+            raise RefreshError("Invalid bound device public key")
+
+        try:
+            verify_ecdsa(pub_key, signature, signed_payload)
+        except DeviceBindingError as exc:
+            await self._audit_signature_failure(actor_id, jti, "bad_signature")
+            await logger.awarning(
+                "refresh_failed", reason="device_signature_invalid", jti=jti
+            )
+            raise RefreshError("Refresh device signature invalid") from exc
         return session.device_id
+
+    async def _audit_signature_failure(
+        self, actor_id: uuid.UUID, jti: str, reason: str
+    ) -> None:
+        try:
+            await self._audit.record(
+                action=AuditAction.REFRESH_SIGNATURE_INVALID,
+                actor_id=actor_id,
+                entity_type="user",
+                entity_id=str(actor_id),
+                payload={"jti": jti, "reason": reason},
+            )
+        except Exception:
+            await logger.awarning(
+                "audit_write_failed",
+                action=AuditAction.REFRESH_SIGNATURE_INVALID,
+            )
 
     async def _rotate_jti(self, jti_key: str, exp: object) -> None:
         """Blacklist the old JTI as rotated so any replay triggers theft detection."""

--- a/api/tests/v1/auth/unit/device_binding_session_test.py
+++ b/api/tests/v1/auth/unit/device_binding_session_test.py
@@ -15,14 +15,12 @@ from com.qode.qrew.v1.service.core.security import (
     extract_jti,
 )
 from com.qode.qrew.v1.service.main import app
-from com.qode.qrew.v1.service.models.session import Session
 from com.qode.qrew.v1.service.routers.auth import (
     get_login_service,
     get_refresh_service,
 )
 from com.qode.qrew.v1.service.schemas.auth import LoginResponse, RefreshResponse
 from com.qode.qrew.v1.service.services.login import LoginService
-from com.qode.qrew.v1.service.services.refresh import RefreshError, RefreshService
 from com.qode.qrew.v1.service.settings import settings
 
 _LOGIN_ENDPOINT = "/v1/auth/login"
@@ -113,36 +111,6 @@ async def test_login_silently_ignores_malformed_device_id(
     assert args[4] is None
 
 
-# ── Refresh route forwards X-Device-Id ────────────────────────────────────────
-
-
-async def test_refresh_passes_device_id_from_header(
-    client: AsyncClient, mock_refresh_service: AsyncMock
-) -> None:
-    device_id = uuid.uuid4()
-    await client.post(
-        _REFRESH_ENDPOINT,
-        json={"refresh_token": "tok"},
-        headers={"X-Device-Id": str(device_id)},
-    )
-    args = mock_refresh_service.refresh.call_args.args
-    assert args[1] == device_id
-
-
-async def test_refresh_returns_401_on_device_mismatch(
-    client: AsyncClient, mock_refresh_service: AsyncMock
-) -> None:
-    mock_refresh_service.refresh.side_effect = RefreshError(
-        "Refresh token is bound to a different device"
-    )
-    response = await client.post(
-        _REFRESH_ENDPOINT,
-        json={"refresh_token": "tok"},
-        headers={"X-Device-Id": str(uuid.uuid4())},
-    )
-    assert response.status_code == 401
-
-
 # ── LoginService bound-device resolution ──────────────────────────────────────
 
 
@@ -200,98 +168,6 @@ async def test_login_service_returns_none_when_device_id_missing() -> None:
     result = await svc.resolve_bound_device(uuid.uuid4(), None)
     assert result is None
     device_repo.get_by_id.assert_not_called()
-
-
-# ── RefreshService device binding check ───────────────────────────────────────
-
-
-async def test_refresh_service_allows_match_on_device_id() -> None:
-
-    device_id = uuid.uuid4()
-    jti = str(uuid.uuid4())
-    session = Session(
-        id=uuid.uuid4(),
-        user_id=uuid.uuid4(),
-        jti=jti,
-        device_id=device_id,
-    )
-    session_repo = AsyncMock()
-    session_repo.get_by_jti = AsyncMock(return_value=session)
-
-    svc = RefreshService(
-        AsyncMock(), AsyncMock(), AsyncMock(), session_repo=session_repo
-    )
-    result = await svc.check_device_binding(jti, device_id)
-    assert result == device_id
-
-
-async def test_refresh_service_rejects_device_mismatch() -> None:
-
-    jti = str(uuid.uuid4())
-    session = Session(
-        id=uuid.uuid4(),
-        user_id=uuid.uuid4(),
-        jti=jti,
-        device_id=uuid.uuid4(),
-    )
-    session_repo = AsyncMock()
-    session_repo.get_by_jti = AsyncMock(return_value=session)
-
-    svc = RefreshService(
-        AsyncMock(), AsyncMock(), AsyncMock(), session_repo=session_repo
-    )
-    with pytest.raises(RefreshError, match="bound to a different device"):
-        await svc.check_device_binding(jti, uuid.uuid4())
-
-
-async def test_refresh_service_rejects_missing_header_on_bound_session() -> None:
-
-    jti = str(uuid.uuid4())
-    session = Session(
-        id=uuid.uuid4(),
-        user_id=uuid.uuid4(),
-        jti=jti,
-        device_id=uuid.uuid4(),
-    )
-    session_repo = AsyncMock()
-    session_repo.get_by_jti = AsyncMock(return_value=session)
-
-    svc = RefreshService(
-        AsyncMock(), AsyncMock(), AsyncMock(), session_repo=session_repo
-    )
-    with pytest.raises(RefreshError, match="bound to a different device"):
-        await svc.check_device_binding(jti, None)
-
-
-async def test_refresh_service_allows_unbound_session() -> None:
-
-    jti = str(uuid.uuid4())
-    session = Session(
-        id=uuid.uuid4(),
-        user_id=uuid.uuid4(),
-        jti=jti,
-        device_id=None,
-    )
-    session_repo = AsyncMock()
-    session_repo.get_by_jti = AsyncMock(return_value=session)
-
-    svc = RefreshService(
-        AsyncMock(), AsyncMock(), AsyncMock(), session_repo=session_repo
-    )
-    result = await svc.check_device_binding(jti, None)
-    assert result is None
-
-
-async def test_refresh_service_allows_when_session_missing() -> None:
-
-    session_repo = AsyncMock()
-    session_repo.get_by_jti = AsyncMock(return_value=None)
-
-    svc = RefreshService(
-        AsyncMock(), AsyncMock(), AsyncMock(), session_repo=session_repo
-    )
-    result = await svc.check_device_binding(str(uuid.uuid4()), uuid.uuid4())
-    assert result is None
 
 
 # ── Round-trip sanity ─────────────────────────────────────────────────────────

--- a/api/tests/v1/auth/unit/refresh_signature_test.py
+++ b/api/tests/v1/auth/unit/refresh_signature_test.py
@@ -1,0 +1,252 @@
+"""Tests for per-refresh device-key signature on device-bound sessions."""
+
+import base64
+import time
+import uuid
+from collections.abc import Iterator
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.hazmat.primitives.hashes import SHA256
+from httpx import AsyncClient
+
+from com.qode.qrew.v1.service.main import app
+from com.qode.qrew.v1.service.models.audit import AuditAction
+from com.qode.qrew.v1.service.models.session import Session
+from com.qode.qrew.v1.service.routers.auth import get_refresh_service
+from com.qode.qrew.v1.service.schemas.auth import RefreshResponse
+from com.qode.qrew.v1.service.services.refresh import (
+    RefreshError,
+    RefreshService,
+    decode_signature_header,
+    signature_payload,
+)
+
+_REFRESH_ENDPOINT = "/v1/auth/refresh"
+
+
+# ── signature_payload format ─────────────────────────────────────────────────
+
+
+def test_signature_payload_format() -> None:
+    assert signature_payload("jti-x", 1700000000) == b"jti-x|1700000000"
+
+
+def test_decode_signature_header_handles_padding() -> None:
+    raw_sig = b"abc"
+    encoded = base64.urlsafe_b64encode(raw_sig).decode().rstrip("=")
+    assert decode_signature_header(encoded) == raw_sig
+
+
+def test_decode_signature_header_none() -> None:
+    assert decode_signature_header(None) is None
+
+
+def test_decode_signature_header_malformed_returns_none() -> None:
+    assert decode_signature_header("!!!not-base64!!!") is None
+
+
+# ── Route forwards X-Device-Signature ────────────────────────────────────────
+
+
+@pytest.fixture
+def mock_refresh_service() -> AsyncMock:
+    s = AsyncMock()
+    s.refresh = AsyncMock(
+        return_value=RefreshResponse(access_token="a.b.c", refresh_token="d.e.f")
+    )
+    return s
+
+
+@pytest.fixture(autouse=True)
+def override(mock_refresh_service: AsyncMock) -> Iterator[None]:
+    app.dependency_overrides[get_refresh_service] = lambda: mock_refresh_service
+    yield
+    app.dependency_overrides.clear()
+
+
+async def test_refresh_route_forwards_signature_bytes(
+    client: AsyncClient, mock_refresh_service: AsyncMock
+) -> None:
+    sig = base64.urlsafe_b64encode(b"raw-sig-bytes").decode().rstrip("=")
+    await client.post(
+        _REFRESH_ENDPOINT,
+        json={"refresh_token": "tok"},
+        headers={"X-Device-Signature": sig},
+    )
+    args = mock_refresh_service.refresh.call_args.args
+    assert args[1] == b"raw-sig-bytes"
+
+
+async def test_refresh_route_passes_none_when_header_missing(
+    client: AsyncClient, mock_refresh_service: AsyncMock
+) -> None:
+    await client.post(_REFRESH_ENDPOINT, json={"refresh_token": "tok"})
+    args = mock_refresh_service.refresh.call_args.args
+    assert args[1] is None
+
+
+async def test_refresh_returns_401_when_service_rejects_signature(
+    client: AsyncClient, mock_refresh_service: AsyncMock
+) -> None:
+    mock_refresh_service.refresh.side_effect = RefreshError(
+        "Refresh device signature invalid"
+    )
+    response = await client.post(
+        _REFRESH_ENDPOINT,
+        json={"refresh_token": "tok"},
+        headers={"X-Device-Signature": "AAAA"},
+    )
+    assert response.status_code == 401
+
+
+# ── Service-level check_device_binding ───────────────────────────────────────
+
+
+def _generate_keypair() -> tuple[ec.EllipticCurvePrivateKey, bytes]:
+    key = ec.generate_private_key(ec.SECP256R1())
+    pub_der = key.public_key().public_bytes(
+        encoding=serialization.Encoding.DER,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    return key, pub_der
+
+
+def _build_service(
+    *, session: Session | None, device: MagicMock | None = None
+) -> tuple[RefreshService, AsyncMock]:
+    session_repo = AsyncMock()
+    session_repo.get_by_jti = AsyncMock(return_value=session)
+    device_repo = AsyncMock()
+    device_repo.get_by_id = AsyncMock(return_value=device)
+    audit = AsyncMock()
+    audit.record = AsyncMock()
+    svc = RefreshService(
+        AsyncMock(),
+        AsyncMock(),
+        audit,
+        session_repo=session_repo,
+        device_repo=device_repo,
+    )
+    return svc, audit
+
+
+async def test_unbound_session_skips_signature_check() -> None:
+    jti = str(uuid.uuid4())
+    session = Session(id=uuid.uuid4(), user_id=uuid.uuid4(), jti=jti, device_id=None)
+    svc, _ = _build_service(session=session)
+    result = await svc.check_device_binding(jti, int(time.time()), None, uuid.uuid4())
+    assert result is None
+
+
+async def test_bound_session_with_valid_signature_succeeds() -> None:
+    key, pub_der = _generate_keypair()
+    device_id = uuid.uuid4()
+    jti = str(uuid.uuid4())
+    iat = int(time.time())
+
+    session = Session(
+        id=uuid.uuid4(), user_id=uuid.uuid4(), jti=jti, device_id=device_id
+    )
+    device = MagicMock()
+    device.public_key = pub_der
+    device.revoked_at = None
+
+    svc, _ = _build_service(session=session, device=device)
+
+    sig = key.sign(signature_payload(jti, iat), ec.ECDSA(SHA256()))
+    result = await svc.check_device_binding(jti, iat, sig, uuid.uuid4())
+    assert result == device_id
+
+
+async def test_bound_session_with_wrong_signature_raises_and_audits() -> None:
+    _key, pub_der = _generate_keypair()
+    other_key, _ = _generate_keypair()
+    jti = str(uuid.uuid4())
+    iat = int(time.time())
+
+    session = Session(
+        id=uuid.uuid4(), user_id=uuid.uuid4(), jti=jti, device_id=uuid.uuid4()
+    )
+    device = MagicMock()
+    device.public_key = pub_der
+    device.revoked_at = None
+
+    svc, audit = _build_service(session=session, device=device)
+
+    bad_sig = other_key.sign(signature_payload(jti, iat), ec.ECDSA(SHA256()))
+    with pytest.raises(RefreshError, match="device signature invalid"):
+        await svc.check_device_binding(jti, iat, bad_sig, uuid.uuid4())
+
+    audit.record.assert_awaited_once()
+    kwargs = audit.record.call_args.kwargs
+    assert kwargs["action"] == AuditAction.REFRESH_SIGNATURE_INVALID
+
+
+async def test_bound_session_with_missing_signature_raises_and_audits() -> None:
+    jti = str(uuid.uuid4())
+    iat = int(time.time())
+
+    session = Session(
+        id=uuid.uuid4(), user_id=uuid.uuid4(), jti=jti, device_id=uuid.uuid4()
+    )
+    svc, audit = _build_service(session=session)
+
+    with pytest.raises(RefreshError, match="requires a device signature"):
+        await svc.check_device_binding(jti, iat, None, uuid.uuid4())
+    audit.record.assert_awaited_once()
+
+
+async def test_bound_session_rejects_when_device_revoked() -> None:
+    key, pub_der = _generate_keypair()
+    jti = str(uuid.uuid4())
+    iat = int(time.time())
+
+    session = Session(
+        id=uuid.uuid4(), user_id=uuid.uuid4(), jti=jti, device_id=uuid.uuid4()
+    )
+    device = MagicMock()
+    device.public_key = pub_der
+    device.revoked_at = datetime.now(UTC)
+
+    svc, _ = _build_service(session=session, device=device)
+    sig = key.sign(signature_payload(jti, iat), ec.ECDSA(SHA256()))
+
+    with pytest.raises(RefreshError, match="no longer valid"):
+        await svc.check_device_binding(jti, iat, sig, uuid.uuid4())
+
+
+async def test_payload_includes_iat_so_signature_doesnt_replay_to_other_iat() -> None:
+    """A signature over (jti, iat=A) must not validate against (jti, iat=B)."""
+    key, pub_der = _generate_keypair()
+    jti = str(uuid.uuid4())
+    iat_a = int(time.time())
+    iat_b = iat_a + 1
+
+    session = Session(
+        id=uuid.uuid4(), user_id=uuid.uuid4(), jti=jti, device_id=uuid.uuid4()
+    )
+    device = MagicMock()
+    device.public_key = pub_der
+    device.revoked_at = None
+
+    svc, _ = _build_service(session=session, device=device)
+    sig_a = key.sign(signature_payload(jti, iat_a), ec.ECDSA(SHA256()))
+
+    # Same signature, different iat → must reject
+    with pytest.raises(RefreshError, match="device signature invalid"):
+        await svc.check_device_binding(jti, iat_b, sig_a, uuid.uuid4())
+
+
+async def test_unbound_session_ignores_signature_when_provided() -> None:
+    """Sessions without device_id ignore the signature header (backwards compat)."""
+    jti = str(uuid.uuid4())
+    session = Session(id=uuid.uuid4(), user_id=uuid.uuid4(), jti=jti, device_id=None)
+    svc, _ = _build_service(session=session)
+    result = await svc.check_device_binding(
+        jti, int(time.time()), b"any-bytes", uuid.uuid4()
+    )
+    assert result is None

--- a/uv.lock
+++ b/uv.lock
@@ -171,7 +171,7 @@ wheels = [
 
 [[package]]
 name = "api"
-version = "1.7.0"
+version = "1.8.0"
 source = { editable = "api" }
 dependencies = [
     { name = "aiosmtplib" },


### PR DESCRIPTION
## Summary

Refresh tokens are now bound to the device using Secure Enclave–backed ECDSA signatures instead of relying on a replayable device ID header.

## Verification

`api/tests/v1/auth/unit/refresh_signature_test.py`

## Issue Reference

Closes [QRW-114](https://github.com/cristiangilsanz/qrew/issues/114)

## Checklist
- [x] I confirm that this PR follows the project's established coding standards.