### PR TITLE
feat: add arq-based background job runner with retries and dlq

### DIFF
--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
     "mailchecker>=4.1",
     "zxcvbn>=4.4",
     "opentelemetry-sdk>=1.24",
+    "arq>=0.26",
     "webauthn>=2.0",
     "python-multipart>=0.0.9",
     "pytesseract>=0.3",
@@ -55,6 +56,7 @@ dev = [
     "pyright>=1.1",
     "ruff>=0.4",
     "pre-commit>=3.7",
+    "fakeredis>=2.20",
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/api/src/com/qode/qrew/v1/service/core/jobs/__init__.py
+++ b/api/src/com/qode/qrew/v1/service/core/jobs/__init__.py
@@ -1,0 +1,20 @@
+from com.qode.qrew.v1.service.core.jobs.dlq import dlq_key
+from com.qode.qrew.v1.service.core.jobs.enqueue import enqueue
+from com.qode.qrew.v1.service.core.jobs.pool import close_pool, get_pool
+from com.qode.qrew.v1.service.core.jobs.registry import (
+    DEFAULT_RETRY_DELAYS_SECONDS,
+    JobSpec,
+    all_specs,
+    job,
+)
+
+__all__ = [
+    "DEFAULT_RETRY_DELAYS_SECONDS",
+    "JobSpec",
+    "all_specs",
+    "close_pool",
+    "dlq_key",
+    "enqueue",
+    "get_pool",
+    "job",
+]

--- a/api/src/com/qode/qrew/v1/service/core/jobs/context.py
+++ b/api/src/com/qode/qrew/v1/service/core/jobs/context.py
@@ -1,0 +1,62 @@
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+import structlog
+from arq.worker import Retry
+from opentelemetry import trace
+
+from com.qode.qrew.v1.service.core.jobs.dlq import push_to_dlq
+from com.qode.qrew.v1.service.core.jobs.registry import JobSpec
+
+logger = structlog.get_logger(__name__)
+_tracer = trace.get_tracer(__name__)
+
+JobRunner = Callable[..., Awaitable[Any]]
+
+
+def _payload_from_args(args: tuple[Any, ...], kwargs: dict[str, Any]) -> dict[str, Any]:
+    if len(args) == 1 and isinstance(args[0], dict):
+        return dict(args[0])  # type: ignore[arg-type]
+    return {"args": list(args), "kwargs": kwargs}
+
+
+def wrap_handler(spec: JobSpec) -> JobRunner:
+    """Wrap a job handler with structlog binding, OTel span, retry, and DLQ push."""
+
+    async def runner(ctx: dict[str, Any], *args: Any, **kwargs: Any) -> Any:
+        attempt = int(ctx.get("job_try", 1))
+        job_id = str(ctx.get("job_id", "unknown"))
+        structlog.contextvars.clear_contextvars()
+        structlog.contextvars.bind_contextvars(
+            job_name=spec.name, job_id=job_id, attempt=attempt
+        )
+        try:
+            with _tracer.start_as_current_span(f"job.{spec.name}") as span:
+                span.set_attribute("job.name", spec.name)
+                span.set_attribute("job.id", job_id)
+                span.set_attribute("job.attempt", attempt)
+                await logger.ainfo("job_started")
+                result = await spec.handler(ctx, *args, **kwargs)
+                await logger.ainfo("job_completed")
+                return result
+        except Retry:
+            raise
+        except BaseException as exc:
+            await logger.aexception("job_failed", error=repr(exc))
+            if attempt >= spec.max_attempts:
+                await push_to_dlq(
+                    ctx["redis"],
+                    job_name=spec.name,
+                    job_id=job_id,
+                    payload=_payload_from_args(args, kwargs),
+                    error=exc,
+                )
+                await logger.aerror("job_dead_lettered")
+                return None
+            delay = spec.retry_delays[attempt - 1]
+            raise Retry(defer=delay) from exc
+        finally:
+            structlog.contextvars.clear_contextvars()
+
+    runner.__name__ = spec.name.replace(".", "_")
+    return runner

--- a/api/src/com/qode/qrew/v1/service/core/jobs/cron.py
+++ b/api/src/com/qode/qrew/v1/service/core/jobs/cron.py
@@ -1,0 +1,59 @@
+from dataclasses import dataclass
+
+_CRONTAB_FIELDS = 5
+
+
+@dataclass(frozen=True)
+class CronFields:
+    minute: set[int] | None
+    hour: set[int] | None
+    day: set[int] | None
+    month: set[int] | None
+    weekday: set[int] | None
+
+
+_RANGES = {
+    "minute": (0, 59),
+    "hour": (0, 23),
+    "day": (1, 31),
+    "month": (1, 12),
+    "weekday": (0, 6),
+}
+
+
+def _parse_field(raw: str, name: str) -> set[int] | None:
+    low, high = _RANGES[name]
+    if raw == "*":
+        return None
+    out: set[int] = set()
+    for part in raw.split(","):
+        step = 1
+        body = part
+        if "/" in part:
+            body, step_raw = part.split("/", 1)
+            step = int(step_raw)
+        if body == "*":
+            start, end = low, high
+        elif "-" in body:
+            start_raw, end_raw = body.split("-", 1)
+            start, end = int(start_raw), int(end_raw)
+        else:
+            start = end = int(body)
+        if start < low or end > high or start > end or step < 1:
+            raise ValueError(f"invalid cron field for {name}: {raw}")
+        out.update(range(start, end + 1, step))
+    return out
+
+
+def parse_crontab(expr: str) -> CronFields:
+    parts = expr.split()
+    if len(parts) != _CRONTAB_FIELDS:
+        raise ValueError(f"crontab must have 5 fields, got {len(parts)}: {expr!r}")
+    minute, hour, day, month, weekday = parts
+    return CronFields(
+        minute=_parse_field(minute, "minute"),
+        hour=_parse_field(hour, "hour"),
+        day=_parse_field(day, "day"),
+        month=_parse_field(month, "month"),
+        weekday=_parse_field(weekday, "weekday"),
+    )

--- a/api/src/com/qode/qrew/v1/service/core/jobs/dlq.py
+++ b/api/src/com/qode/qrew/v1/service/core/jobs/dlq.py
@@ -1,0 +1,30 @@
+import json
+import traceback
+from datetime import UTC, datetime
+from typing import Any
+
+import redis.asyncio as aioredis
+
+
+def dlq_key(job_name: str) -> str:
+    return f"dlq:{job_name}"
+
+
+async def push_to_dlq(
+    redis_client: aioredis.Redis,  # type: ignore[type-arg]
+    *,
+    job_name: str,
+    job_id: str,
+    payload: dict[str, Any],
+    error: BaseException,
+) -> None:
+    """Record a job that exhausted its retry budget."""
+    entry = {
+        "job_id": job_id,
+        "job_name": job_name,
+        "payload": payload,
+        "error": repr(error),
+        "traceback": "".join(traceback.format_exception(error)),
+        "failed_at": datetime.now(UTC).isoformat(),
+    }
+    await redis_client.lpush(dlq_key(job_name), json.dumps(entry))  # type: ignore[misc]

--- a/api/src/com/qode/qrew/v1/service/core/jobs/enqueue.py
+++ b/api/src/com/qode/qrew/v1/service/core/jobs/enqueue.py
@@ -1,0 +1,22 @@
+from typing import Any
+
+from arq.jobs import Job
+
+from com.qode.qrew.v1.service.core.jobs.pool import get_pool
+from com.qode.qrew.v1.service.core.jobs.registry import get_spec
+
+
+async def enqueue(
+    job_name: str,
+    payload: dict[str, Any] | None = None,
+    *,
+    defer_seconds: int | None = None,
+) -> Job | None:
+    """Enqueue a registered job for asynchronous execution."""
+    spec = get_spec(job_name)
+    pool = await get_pool()
+    return await pool.enqueue_job(
+        spec.name,
+        payload or {},
+        _defer_by=defer_seconds,
+    )

--- a/api/src/com/qode/qrew/v1/service/core/jobs/pool.py
+++ b/api/src/com/qode/qrew/v1/service/core/jobs/pool.py
@@ -1,0 +1,39 @@
+from urllib.parse import urlparse
+
+from arq import create_pool
+from arq.connections import ArqRedis, RedisSettings
+
+from com.qode.qrew.v1.service.settings import settings
+
+
+def redis_settings_from_url(url: str | None = None) -> RedisSettings:
+    """Build an arq RedisSettings from settings.redis_url (or an override)."""
+    parsed = urlparse(url or settings.redis_url)
+    database = 0
+    if parsed.path and parsed.path != "/":
+        database = int(parsed.path.lstrip("/"))
+    return RedisSettings(
+        host=parsed.hostname or "localhost",
+        port=parsed.port or 6379,
+        database=database,
+        username=parsed.username,
+        password=parsed.password,
+        ssl=parsed.scheme == "rediss",
+    )
+
+
+class _PoolState:
+    pool: ArqRedis | None = None
+
+
+async def get_pool() -> ArqRedis:
+    """Return a process-wide ArqRedis pool, creating it lazily."""
+    if _PoolState.pool is None:
+        _PoolState.pool = await create_pool(redis_settings_from_url())
+    return _PoolState.pool
+
+
+async def close_pool() -> None:
+    if _PoolState.pool is not None:
+        await _PoolState.pool.aclose()
+        _PoolState.pool = None

--- a/api/src/com/qode/qrew/v1/service/core/jobs/registry.py
+++ b/api/src/com/qode/qrew/v1/service/core/jobs/registry.py
@@ -1,0 +1,61 @@
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from typing import Any
+
+from com.qode.qrew.v1.service.core.jobs.cron import CronFields, parse_crontab
+
+JobHandler = Callable[..., Awaitable[Any]]
+
+DEFAULT_RETRY_DELAYS_SECONDS: tuple[int, ...] = (1, 5, 25, 125, 625)
+
+
+@dataclass
+class JobSpec:
+    name: str
+    handler: JobHandler
+    max_attempts: int
+    retry_delays: tuple[int, ...]
+    cron_fields: CronFields | None
+
+
+_REGISTRY: dict[str, JobSpec] = {}
+
+
+def job(
+    *,
+    name: str,
+    cron: str | None = None,
+    max_attempts: int = 5,
+    retry_delays: tuple[int, ...] = DEFAULT_RETRY_DELAYS_SECONDS,
+) -> Callable[[JobHandler], JobHandler]:
+    """Register a coroutine as a background job."""
+
+    def decorator(handler: JobHandler) -> JobHandler:
+        if name in _REGISTRY:
+            raise ValueError(f"duplicate job name: {name}")
+        if max_attempts < 1:
+            raise ValueError("max_attempts must be >= 1")
+        if len(retry_delays) < max_attempts - 1:
+            raise ValueError("retry_delays must cover max_attempts - 1 entries")
+        _REGISTRY[name] = JobSpec(
+            name=name,
+            handler=handler,
+            max_attempts=max_attempts,
+            retry_delays=retry_delays,
+            cron_fields=parse_crontab(cron) if cron else None,
+        )
+        return handler
+
+    return decorator
+
+
+def all_specs() -> list[JobSpec]:
+    return list(_REGISTRY.values())
+
+
+def get_spec(name: str) -> JobSpec:
+    return _REGISTRY[name]
+
+
+def reset_registry_for_tests() -> None:
+    _REGISTRY.clear()

--- a/api/src/com/qode/qrew/v1/service/core/jobs/worker.py
+++ b/api/src/com/qode/qrew/v1/service/core/jobs/worker.py
@@ -1,0 +1,53 @@
+from typing import Any
+
+from arq.cron import CronJob, cron
+from arq.worker import func
+
+import com.qode.qrew.v1.service.jobs as _job_handlers
+from com.qode.qrew.v1.service.core.jobs.context import wrap_handler
+from com.qode.qrew.v1.service.core.jobs.pool import redis_settings_from_url
+from com.qode.qrew.v1.service.core.jobs.registry import JobSpec, all_specs
+
+_ = _job_handlers  # ensure @job decorators register at import time
+
+
+def _functions_and_crons() -> tuple[list[Any], list[CronJob]]:
+    functions: list[Any] = []
+    cron_jobs: list[CronJob] = []
+    for spec in all_specs():
+        runner = wrap_handler(spec)
+        functions.append(_arq_function(spec, runner))
+        if spec.cron_fields is not None:
+            cron_jobs.append(_build_cron(spec, runner))
+    return functions, cron_jobs
+
+
+def _arq_function(spec: JobSpec, runner: Any) -> Any:
+    return func(runner, name=spec.name, max_tries=spec.max_attempts + 1)
+
+
+def _build_cron(spec: JobSpec, runner: Any) -> CronJob:
+    f = spec.cron_fields
+    assert f is not None
+    return cron(
+        runner,
+        name=f"cron:{spec.name}",
+        minute=f.minute,
+        hour=f.hour,
+        day=f.day,
+        month=f.month,
+        weekday=f.weekday,
+        max_tries=spec.max_attempts + 1,
+    )
+
+
+_functions, _crons = _functions_and_crons()
+
+
+class WorkerSettings:
+    functions = _functions
+    cron_jobs = _crons
+    redis_settings = redis_settings_from_url()
+    max_jobs = 10
+    job_timeout = 300
+    keep_result = 60

--- a/api/src/com/qode/qrew/v1/service/jobs/__init__.py
+++ b/api/src/com/qode/qrew/v1/service/jobs/__init__.py
@@ -1,0 +1,3 @@
+from com.qode.qrew.v1.service.jobs import audit_verify, auth_cleanup
+
+__all__ = ["audit_verify", "auth_cleanup"]

--- a/api/src/com/qode/qrew/v1/service/jobs/audit_verify.py
+++ b/api/src/com/qode/qrew/v1/service/jobs/audit_verify.py
@@ -1,0 +1,42 @@
+from typing import Any
+
+import structlog
+
+from com.qode.qrew.v1.service.core.jobs import job
+from com.qode.qrew.v1.service.models.audit.audit import AuditAction
+from com.qode.qrew.v1.service.services.audit import AuditChainVerifier, AuditService
+
+logger = structlog.get_logger(__name__)
+
+
+@job(name="audit.verify_chain", cron="0 3 * * *", max_attempts=1)
+async def verify_chain(ctx: dict[str, Any]) -> dict[str, Any]:
+    """Recompute the audit hash chain nightly and record the outcome."""
+    del ctx
+    result = await AuditChainVerifier().verify()
+    if result.valid:
+        await logger.ainfo("audit_chain_verified", event_count=result.event_count)
+        await AuditService().record(
+            action=AuditAction.AUDIT_CHAIN_VERIFIED,
+            entity_type="system",
+            payload={"event_count": result.event_count},
+        )
+    else:
+        await logger.aerror(
+            "audit_chain_tampered",
+            event_count=result.event_count,
+            tampered_ids=result.tampered_ids,
+        )
+        await AuditService().record(
+            action=AuditAction.AUDIT_CHAIN_TAMPERED,
+            entity_type="system",
+            payload={
+                "event_count": result.event_count,
+                "tampered_ids": result.tampered_ids,
+            },
+        )
+    return {
+        "valid": result.valid,
+        "event_count": result.event_count,
+        "tampered_ids": result.tampered_ids,
+    }

--- a/api/src/com/qode/qrew/v1/service/jobs/auth_cleanup.py
+++ b/api/src/com/qode/qrew/v1/service/jobs/auth_cleanup.py
@@ -1,0 +1,78 @@
+from datetime import UTC, datetime
+from typing import Any
+
+import structlog
+from sqlalchemy import update
+
+from com.qode.qrew.v1.service.core.infra.database import AsyncSessionLocal
+from com.qode.qrew.v1.service.core.jobs import job
+from com.qode.qrew.v1.service.models.audit.audit import AuditAction
+from com.qode.qrew.v1.service.models.auth.user import User
+from com.qode.qrew.v1.service.services.audit import AuditService
+
+logger = structlog.get_logger(__name__)
+
+
+@job(name="auth.cleanup_expired_tokens", cron="*/15 * * * *", max_attempts=3)
+async def cleanup_expired_tokens(ctx: dict[str, Any]) -> dict[str, int]:
+    """Null out expired verification tokens and OTPs to keep the users table tidy."""
+    del ctx
+    now = datetime.now(UTC)
+    cleared = 0
+    async with AsyncSessionLocal() as session, session.begin():
+        result = await session.execute(
+            update(User)
+            .where(User.email_verification_token_expires_at < now)
+            .where(User.email_verification_token.is_not(None))
+            .values(
+                email_verification_token=None,
+                email_verification_token_expires_at=None,
+            )
+        )
+        cleared += int(getattr(result, "rowcount", 0) or 0)
+
+        result = await session.execute(
+            update(User)
+            .where(User.phone_number_otp_expires_at < now)
+            .where(User.phone_number_otp.is_not(None))
+            .values(
+                phone_number_otp=None,
+                phone_number_otp_expires_at=None,
+            )
+        )
+        cleared += int(getattr(result, "rowcount", 0) or 0)
+
+        result = await session.execute(
+            update(User)
+            .where(User.pending_phone_otp_expires_at < now)
+            .where(User.pending_phone_otp.is_not(None))
+            .values(
+                pending_phone_otp=None,
+                pending_phone_otp_expires_at=None,
+                pending_phone_number_ciphertext=None,
+                pending_phone_number_hash=None,
+            )
+        )
+        cleared += int(getattr(result, "rowcount", 0) or 0)
+
+        result = await session.execute(
+            update(User)
+            .where(User.pending_email_token_expires_at < now)
+            .where(User.pending_email_verification_token.is_not(None))
+            .values(
+                pending_email_verification_token=None,
+                pending_email_token_expires_at=None,
+                pending_email_ciphertext=None,
+                pending_email_hash=None,
+            )
+        )
+        cleared += int(getattr(result, "rowcount", 0) or 0)
+
+    await logger.ainfo("auth_tokens_cleaned", cleared=cleared)
+    if cleared > 0:
+        await AuditService().record(
+            action=AuditAction.EXPIRED_TOKENS_CLEANED,
+            entity_type="system",
+            payload={"cleared_rows": cleared},
+        )
+    return {"cleared": cleared}

--- a/api/src/com/qode/qrew/v1/service/lifespan.py
+++ b/api/src/com/qode/qrew/v1/service/lifespan.py
@@ -4,6 +4,7 @@ from contextlib import asynccontextmanager
 import structlog
 from fastapi import FastAPI
 
+from com.qode.qrew.v1.service.core.jobs.pool import close_pool
 from com.qode.qrew.v1.service.services.audit import AuditService
 
 logger = structlog.get_logger(__name__)
@@ -14,4 +15,5 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     await logger.ainfo("startup")
     await AuditService().ensure_genesis()
     yield
+    await close_pool()
     await logger.ainfo("shutdown")

--- a/api/src/com/qode/qrew/v1/service/models/audit/audit.py
+++ b/api/src/com/qode/qrew/v1/service/models/audit/audit.py
@@ -52,6 +52,9 @@ class AuditAction(enum.StrEnum):
     SCANNER_ROTATED = "scanner_rotated"
     SCANNER_DEACTIVATED = "scanner_deactivated"
     GENESIS = "genesis"
+    AUDIT_CHAIN_VERIFIED = "audit_chain_verified"
+    AUDIT_CHAIN_TAMPERED = "audit_chain_tampered"
+    EXPIRED_TOKENS_CLEANED = "expired_tokens_cleaned"
 
 
 class AuditEvent(Base):

--- a/api/tests/v1/jobs/context_test.py
+++ b/api/tests/v1/jobs/context_test.py
@@ -1,0 +1,61 @@
+import json
+from typing import Any
+
+import fakeredis.aioredis
+import pytest
+from arq.worker import Retry
+
+from com.qode.qrew.v1.service.core.jobs.context import wrap_handler
+from com.qode.qrew.v1.service.core.jobs.dlq import dlq_key
+from com.qode.qrew.v1.service.core.jobs.registry import JobSpec
+
+
+def _spec(handler: Any, max_attempts: int = 3) -> JobSpec:
+    return JobSpec(
+        name="test.unit",
+        handler=handler,
+        max_attempts=max_attempts,
+        retry_delays=(1, 2, 4, 8, 16),
+        cron_fields=None,
+    )
+
+
+async def test_runs_handler_on_first_attempt() -> None:
+    calls: list[int] = []
+
+    async def handler(ctx: dict[str, Any]) -> str:
+        calls.append(int(ctx["job_try"]))
+        return "ok"
+
+    runner = wrap_handler(_spec(handler))
+    redis = fakeredis.aioredis.FakeRedis()
+    result = await runner({"job_try": 1, "job_id": "j1", "redis": redis})
+    assert result == "ok"
+    assert calls == [1]
+
+
+async def test_raises_retry_on_failure_below_max() -> None:
+    async def handler(ctx: dict[str, Any]) -> None:
+        raise RuntimeError("boom")
+
+    runner = wrap_handler(_spec(handler, max_attempts=3))
+    redis = fakeredis.aioredis.FakeRedis()
+    with pytest.raises(Retry) as info:
+        await runner({"job_try": 1, "job_id": "j1", "redis": redis})
+    assert info.value.defer_score is not None
+
+
+async def test_dead_letters_on_final_attempt() -> None:
+    async def handler(ctx: dict[str, Any]) -> None:
+        raise RuntimeError("boom")
+
+    runner = wrap_handler(_spec(handler, max_attempts=3))
+    redis = fakeredis.aioredis.FakeRedis()
+    result = await runner({"job_try": 3, "job_id": "j1", "redis": redis})
+    assert result is None
+    entries_raw: Any = await redis.lrange(dlq_key("test.unit"), 0, -1)  # type: ignore[misc]
+    entries: list[bytes] = list(entries_raw)  # pyright: ignore[reportUnknownArgumentType]
+    assert len(entries) == 1
+    parsed = json.loads(entries[0])
+    assert parsed["job_id"] == "j1"
+    assert "boom" in parsed["error"]

--- a/api/tests/v1/jobs/cron_test.py
+++ b/api/tests/v1/jobs/cron_test.py
@@ -1,0 +1,32 @@
+import pytest
+
+from com.qode.qrew.v1.service.core.jobs.cron import parse_crontab
+
+
+def test_parse_every_15_minutes() -> None:
+    fields = parse_crontab("*/15 * * * *")
+    assert fields.minute == {0, 15, 30, 45}
+    assert fields.hour is None
+    assert fields.day is None
+
+
+def test_parse_daily_at_3am() -> None:
+    fields = parse_crontab("0 3 * * *")
+    assert fields.minute == {0}
+    assert fields.hour == {3}
+
+
+def test_parse_range_and_list() -> None:
+    fields = parse_crontab("0 9-11,15 * * 1-5")
+    assert fields.hour == {9, 10, 11, 15}
+    assert fields.weekday == {1, 2, 3, 4, 5}
+
+
+def test_rejects_wrong_arity() -> None:
+    with pytest.raises(ValueError, match="5 fields"):
+        parse_crontab("0 3 * *")
+
+
+def test_rejects_out_of_range() -> None:
+    with pytest.raises(ValueError, match="invalid cron field"):
+        parse_crontab("0 25 * * *")

--- a/api/tests/v1/jobs/integration/auth_cleanup_test.py
+++ b/api/tests/v1/jobs/integration/auth_cleanup_test.py
@@ -1,0 +1,40 @@
+import uuid
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from sqlalchemy import select
+
+from com.qode.qrew.v1.service.core.infra.database import AsyncSessionLocal
+from com.qode.qrew.v1.service.jobs.auth_cleanup import cleanup_expired_tokens
+from com.qode.qrew.v1.service.models.auth.user import KycStatus, User
+
+
+@pytest.mark.integration
+async def test_cleanup_clears_expired_tokens() -> None:
+    suffix = uuid.uuid4().hex[:8]
+    async with AsyncSessionLocal() as session, session.begin():
+        user = User(
+            hashed_password="x",
+            email_verification_token="expired-token",
+            email_verification_token_expires_at=datetime.now(UTC) - timedelta(hours=1),
+            phone_number_otp="999999",
+            phone_number_otp_expires_at=datetime.now(UTC) - timedelta(minutes=5),
+            terms_accepted_at=datetime.now(UTC),
+            registration_ip="127.0.0.1",
+            kyc_status=KycStatus.not_submitted,
+        )
+        user.email = f"cleanup-{suffix}@example.com"
+        user.phone_number = "+34600000000"
+        user.full_name = "Cleanup Test"
+        session.add(user)
+
+    result = await cleanup_expired_tokens({})
+    assert result["cleared"] >= 2
+
+    async with AsyncSessionLocal() as session:
+        rows = await session.execute(
+            select(User).where(User.email_hash == user.email_hash)
+        )
+        refreshed = rows.scalar_one()
+        assert refreshed.email_verification_token is None
+        assert refreshed.phone_number_otp is None

--- a/api/tests/v1/jobs/integration/conftest.py
+++ b/api/tests/v1/jobs/integration/conftest.py
@@ -1,0 +1,23 @@
+import pytest_asyncio
+from sqlalchemy import text
+
+from com.qode.qrew.v1.service.core.infra.database import engine
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def clean_db() -> None:
+    """Dispose stale pool connections then truncate all tables.
+
+    pytest-asyncio creates a new event loop per test. The module-level engine
+    holds connections from the previous loop, which causes "attached to a
+    different loop" errors. Disposing before each test forces the pool to open
+    fresh connections on the current loop.
+    """
+    await engine.dispose()
+    async with engine.begin() as conn:
+        await conn.execute(
+            text(
+                "TRUNCATE audit_events, passkey_credentials, users"
+                " RESTART IDENTITY CASCADE"
+            )
+        )

--- a/api/tests/v1/jobs/integration/conftest.py
+++ b/api/tests/v1/jobs/integration/conftest.py
@@ -6,13 +6,7 @@ from com.qode.qrew.v1.service.core.infra.database import engine
 
 @pytest_asyncio.fixture(autouse=True)
 async def clean_db() -> None:
-    """Dispose stale pool connections then truncate all tables.
-
-    pytest-asyncio creates a new event loop per test. The module-level engine
-    holds connections from the previous loop, which causes "attached to a
-    different loop" errors. Disposing before each test forces the pool to open
-    fresh connections on the current loop.
-    """
+    """Dispose stale pool connections"""
     await engine.dispose()
     async with engine.begin() as conn:
         await conn.execute(

--- a/api/tests/v1/jobs/registry_test.py
+++ b/api/tests/v1/jobs/registry_test.py
@@ -1,0 +1,61 @@
+from typing import Any
+
+import pytest
+
+from com.qode.qrew.v1.service.core.jobs import registry
+from com.qode.qrew.v1.service.core.jobs.registry import (
+    DEFAULT_RETRY_DELAYS_SECONDS,
+    all_specs,
+    get_spec,
+    job,
+    reset_registry_for_tests,
+)
+
+
+async def _noop(ctx: dict[str, Any]) -> None:
+    del ctx
+
+
+@pytest.fixture
+def isolated_registry() -> Any:
+    snapshot = {spec.name: spec for spec in all_specs()}
+    reset_registry_for_tests()
+    yield
+    reset_registry_for_tests()
+    for name, spec in snapshot.items():
+        registry._REGISTRY[name] = spec  # pyright: ignore[reportPrivateUsage]
+
+
+def test_decorator_registers_handler(isolated_registry: Any) -> None:
+    del isolated_registry
+    job(name="test.simple")(_noop)
+    spec = get_spec("test.simple")
+    assert spec.handler is _noop
+    assert spec.max_attempts == 5
+    assert spec.cron_fields is None
+
+
+def test_decorator_parses_cron(isolated_registry: Any) -> None:
+    del isolated_registry
+    job(name="test.cron", cron="0 3 * * *")(_noop)
+    spec = get_spec("test.cron")
+    assert spec.cron_fields is not None
+    assert spec.cron_fields.hour == {3}
+    assert spec.cron_fields.minute == {0}
+
+
+def test_duplicate_name_rejected(isolated_registry: Any) -> None:
+    del isolated_registry
+    job(name="test.dup")(_noop)
+    with pytest.raises(ValueError, match="duplicate"):
+        job(name="test.dup")(_noop)
+
+
+def test_retry_delays_must_cover_attempts(isolated_registry: Any) -> None:
+    del isolated_registry
+    with pytest.raises(ValueError, match="retry_delays"):
+        job(name="test.bad_retry", max_attempts=5, retry_delays=(1, 2))(_noop)
+
+
+def test_default_retry_delays_cover_five_attempts() -> None:
+    assert len(DEFAULT_RETRY_DELAYS_SECONDS) >= 4

--- a/api/tests/v1/jobs/worker_loads_test.py
+++ b/api/tests/v1/jobs/worker_loads_test.py
@@ -1,0 +1,13 @@
+from com.qode.qrew.v1.service.core.jobs.worker import WorkerSettings
+
+
+def test_domain_jobs_registered() -> None:
+    names = {f.name for f in WorkerSettings.functions}
+    assert "auth.cleanup_expired_tokens" in names
+    assert "audit.verify_chain" in names
+
+
+def test_cron_schedules_present() -> None:
+    cron_names = {c.name for c in WorkerSettings.cron_jobs}
+    assert "cron:auth.cleanup_expired_tokens" in cron_names
+    assert "cron:audit.verify_chain" in cron_names

--- a/justfile
+++ b/justfile
@@ -37,6 +37,10 @@ dev:
     just db-upgrade
     cd api && uv run dev
 
+# Run background job worker
+worker:
+    cd api && uv run arq com.qode.qrew.v1.service.core.jobs.worker.WorkerSettings
+
 # Verify linter
 lint-check:
     cd api && uv run ruff check .

--- a/uv.lock
+++ b/uv.lock
@@ -175,12 +175,13 @@ wheels = [
 
 [[package]]
 name = "api"
-version = "1.8.0"
+version = "1.9.0"
 source = { editable = "api" }
 dependencies = [
     { name = "aiosmtplib" },
     { name = "alembic" },
     { name = "argon2-cffi" },
+    { name = "arq" },
     { name = "asyncpg" },
     { name = "bcrypt" },
     { name = "cryptography" },
@@ -211,6 +212,7 @@ dependencies = [
 dev = [
     { name = "coverage" },
     { name = "factory-boy" },
+    { name = "fakeredis" },
     { name = "httpx" },
     { name = "pre-commit" },
     { name = "pyright" },
@@ -225,6 +227,7 @@ requires-dist = [
     { name = "aiosmtplib", specifier = ">=3.0" },
     { name = "alembic", specifier = ">=1.13" },
     { name = "argon2-cffi", specifier = ">=23.1" },
+    { name = "arq", specifier = ">=0.26" },
     { name = "asyncpg", specifier = ">=0.29" },
     { name = "bcrypt", specifier = ">=3.2,<4.0" },
     { name = "cryptography", specifier = ">=42.0" },
@@ -255,6 +258,7 @@ requires-dist = [
 dev = [
     { name = "coverage", extras = ["toml"], specifier = ">=7" },
     { name = "factory-boy", specifier = ">=3.3" },
+    { name = "fakeredis", specifier = ">=2.20" },
     { name = "httpx", specifier = ">=0.27" },
     { name = "pre-commit", specifier = ">=3.7" },
     { name = "pyright", specifier = ">=1.1" },
@@ -305,6 +309,19 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/74/cd/15777dfde1c29d96de7f18edf4cc94c385646852e7c7b0320aa91ccca583/argon2_cffi_bindings-25.1.0-cp39-abi3-win32.whl", hash = "sha256:473bcb5f82924b1becbb637b63303ec8d10e84c8d241119419897a26116515d2", size = 27180, upload-time = "2025-07-30T10:01:57.759Z" },
     { url = "https://files.pythonhosted.org/packages/e2/c6/a759ece8f1829d1f162261226fbfd2c6832b3ff7657384045286d2afa384/argon2_cffi_bindings-25.1.0-cp39-abi3-win_amd64.whl", hash = "sha256:a98cd7d17e9f7ce244c0803cad3c23a7d379c301ba618a5fa76a67d116618b98", size = 31715, upload-time = "2025-07-30T10:01:58.56Z" },
     { url = "https://files.pythonhosted.org/packages/42/b9/f8d6fa329ab25128b7e98fd83a3cb34d9db5b059a9847eddb840a0af45dd/argon2_cffi_bindings-25.1.0-cp39-abi3-win_arm64.whl", hash = "sha256:b0fdbcf513833809c882823f98dc2f931cf659d9a1429616ac3adebb49f5db94", size = 27149, upload-time = "2025-07-30T10:01:59.329Z" },
+]
+
+[[package]]
+name = "arq"
+version = "0.28.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "redis", extra = ["hiredis"] },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a4/81/7f9db65a89c29ba374000309b9dd95509500045df5c7e22f26c3731b7380/arq-0.28.0.tar.gz", hash = "sha256:a458188aefc2d7ee17d136f80d8fa8df1d6eba4ceebdead87e9f172d027dc311", size = 416141, upload-time = "2026-04-16T10:50:23.893Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/48/32/66b616976c5058d434ca2017979bfffd784888177b16b5038abcec93954a/arq-0.28.0-py3-none-any.whl", hash = "sha256:b1696bf5614d60f4172a2c0cbdc177e23ba03a5eb9acc29bd8181f4ea71fff94", size = 26061, upload-time = "2026-04-16T10:50:22.321Z" },
 ]
 
 [[package]]
@@ -784,6 +801,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/fa/e5/b16bf568a2f20fe7423282db4a4059dbcadef70e9029c1c106836f8edd84/faker-40.11.1.tar.gz", hash = "sha256:61965046e79e8cfde4337d243eac04c0d31481a7c010033141103b43f603100c", size = 1957415, upload-time = "2026-03-23T14:05:50.233Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fc/ec/3c4b78eb0d2f6a81fb8cc9286745845bff661e6815741eff7a6ac5fcc9ea/faker-40.11.1-py3-none-any.whl", hash = "sha256:3af3a213ba8fb33ce6ba2af7aef2ac91363dae35d0cec0b2b0337d189e5bee2a", size = 1989484, upload-time = "2026-03-23T14:05:48.793Z" },
+]
+
+[[package]]
+name = "fakeredis"
+version = "2.36.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "redis" },
+    { name = "sortedcontainers" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/40/26/9cf5174d2e42c24761f87d76160f959e7dbea1cf35b2c81c9cfcd7c74ad9/fakeredis-2.36.0.tar.gz", hash = "sha256:66d00953c9bfd3e345266ded342a2e54c611417344f43ad1467cb68f30bc8354", size = 209484, upload-time = "2026-05-29T19:14:27.316Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/66/5a/6ea14103f9254f0bef31d323e8fe1f57bc0151f7a4b287889217752e9879/fakeredis-2.36.0-py3-none-any.whl", hash = "sha256:43536ed9eb7af34a31226ee4e52c8471d1c3cc522ba2852a9985d3291e71287b", size = 138102, upload-time = "2026-05-29T19:14:25.974Z" },
 ]
 
 [[package]]
@@ -2064,11 +2094,14 @@ dev = [{ name = "ruff", specifier = ">=0.4" }]
 
 [[package]]
 name = "redis"
-version = "7.3.0"
+version = "5.3.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/da/82/4d1a5279f6c1251d3d2a603a798a1137c657de9b12cfc1fba4858232c4d2/redis-7.3.0.tar.gz", hash = "sha256:4d1b768aafcf41b01022410b3cc4f15a07d9b3d6fe0c66fc967da2c88e551034", size = 4928081, upload-time = "2026-03-06T18:18:16.287Z" }
+dependencies = [
+    { name = "pyjwt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6a/cf/128b1b6d7086200c9f387bd4be9b2572a30b90745ef078bd8b235042dc9f/redis-5.3.1.tar.gz", hash = "sha256:ca49577a531ea64039b5a36db3d6cd1a0c7a60c34124d46924a45b956e8cf14c", size = 4626200, upload-time = "2025-07-25T08:06:27.778Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f0/28/84e57fce7819e81ec5aa1bd31c42b89607241f4fb1a3ea5b0d2dbeaea26c/redis-7.3.0-py3-none-any.whl", hash = "sha256:9d4fcb002a12a5e3c3fbe005d59c48a2cc231f87fbb2f6b70c2d89bb64fec364", size = 404379, upload-time = "2026-03-06T18:18:14.583Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/26/5c5fa0e83c3621db835cfc1f1d789b37e7fa99ed54423b5f519beb931aa7/redis-5.3.1-py3-none-any.whl", hash = "sha256:dc1909bd24669cc31b5f67a039700b16ec30571096c5f1f0d9d2324bff31af97", size = 272833, upload-time = "2025-07-25T08:06:26.317Z" },
 ]
 
 [package.optional-dependencies]
@@ -2126,6 +2159,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a0/99/adfc7f94ca024736f061257d39118e1542bade7a52e86415a4c4ae92d8ff/slowapi-0.1.9.tar.gz", hash = "sha256:639192d0f1ca01b1c6d95bf6c71d794c3a9ee189855337b4821f7f457dddad77", size = 14028, upload-time = "2024-02-05T12:11:52.13Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2b/bb/f71c4b7d7e7eb3fc1e8c0458a8979b912f40b58002b9fbf37729b8cb464b/slowapi-0.1.9-py3-none-any.whl", hash = "sha256:cfad116cfb84ad9d763ee155c1e5c5cbf00b0d47399a769b227865f5df576e36", size = 14670, upload-time = "2024-02-05T12:11:50.898Z" },
+]
+
+[[package]]
+name = "sortedcontainers"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/c4/ba2f8066cceb6f23394729afe52f3bf7adec04bf9ed2c820b39e19299111/sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88", size = 30594, upload-time = "2021-05-16T22:03:42.897Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0", size = 29575, upload-time = "2021-05-16T22:03:41.177Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Introduces a process-wide Arq worker so cleanup, verification, and future async flows run off the request path.

## Verification

- `tests/v1/jobs/cron_test.py`
- `tests/v1/jobs/registry_test.py`
- `tests/v1/jobs/context_test.py`
- `tests/v1/jobs/auth_cleanup_test.py`

## Issue Reference

Closes [QRW-119](https://github.com/cristiangilsanz/qrew/issues/119)

## Checklist
- [x] I confirm that this PR follows the project's established coding standards.