### PR TITLE
feat: propagate opentelemetry context across arq jobs and websocket fan-out

### DIFF
--- a/api/src/com/qode/qrew/v1/service/core/jobs/context.py
+++ b/api/src/com/qode/qrew/v1/service/core/jobs/context.py
@@ -6,7 +6,11 @@ from arq.worker import Retry
 
 from com.qode.qrew.v1.service.core.jobs.dlq import push_to_dlq
 from com.qode.qrew.v1.service.core.jobs.registry import JobSpec
-from com.qode.qrew.v1.service.core.observability import tracer
+from com.qode.qrew.v1.service.core.observability import (
+    extract_context,
+    take_carrier,
+    tracer,
+)
 
 logger = structlog.get_logger(__name__)
 
@@ -19,6 +23,19 @@ def _payload_from_args(args: tuple[Any, ...], kwargs: dict[str, Any]) -> dict[st
     return {"args": list(args), "kwargs": kwargs}
 
 
+def _take_propagation_context(
+    args: tuple[Any, ...], kwargs: dict[str, Any]
+) -> tuple[tuple[Any, ...], dict[str, str] | None]:
+    """Strip and return the OTel carrier from the leading dict payload, if any."""
+    if not args:
+        return args, take_carrier(kwargs)
+    head = args[0]
+    if isinstance(head, dict):
+        carrier = take_carrier(head)  # type: ignore[arg-type]
+        return args, carrier
+    return args, take_carrier(kwargs)
+
+
 def wrap_handler(spec: JobSpec) -> JobRunner:
     """Wrap a job handler with structlog binding, OTel span, retry, and DLQ push."""
 
@@ -29,8 +46,12 @@ def wrap_handler(spec: JobSpec) -> JobRunner:
         structlog.contextvars.bind_contextvars(
             job_name=spec.name, job_id=job_id, attempt=attempt
         )
+        args, carrier = _take_propagation_context(args, kwargs)
+        parent_context = extract_context(carrier)
         try:
-            with tracer.start_as_current_span(f"job.{spec.name}") as span:
+            with tracer.start_as_current_span(
+                f"job.{spec.name}", context=parent_context
+            ) as span:
                 span.set_attribute("job.name", spec.name)
                 span.set_attribute("job.id", job_id)
                 span.set_attribute("job.attempt", attempt)

--- a/api/src/com/qode/qrew/v1/service/core/jobs/enqueue.py
+++ b/api/src/com/qode/qrew/v1/service/core/jobs/enqueue.py
@@ -4,6 +4,10 @@ from arq.jobs import Job
 
 from com.qode.qrew.v1.service.core.jobs.pool import get_pool
 from com.qode.qrew.v1.service.core.jobs.registry import get_spec
+from com.qode.qrew.v1.service.core.observability import (
+    CARRIER_KEY,
+    inject_current_context,
+)
 
 
 async def enqueue(
@@ -12,11 +16,15 @@ async def enqueue(
     *,
     defer_seconds: int | None = None,
 ) -> Job | None:
-    """Enqueue a registered job for asynchronous execution."""
+    """Enqueue a registered job, propagating the current trace context."""
     spec = get_spec(job_name)
     pool = await get_pool()
+    body = dict(payload or {})
+    carrier = inject_current_context()
+    if carrier and CARRIER_KEY not in body:
+        body[CARRIER_KEY] = carrier
     return await pool.enqueue_job(
         spec.name,
-        payload or {},
+        body,
         _defer_by=defer_seconds,
     )

--- a/api/src/com/qode/qrew/v1/service/core/observability/__init__.py
+++ b/api/src/com/qode/qrew/v1/service/core/observability/__init__.py
@@ -1,6 +1,12 @@
 from com.qode.qrew.v1.service.core.observability.log_correlation import (
     add_trace_context,
 )
+from com.qode.qrew.v1.service.core.observability.propagation import (
+    CARRIER_KEY,
+    extract_context,
+    inject_current_context,
+    take_carrier,
+)
 from com.qode.qrew.v1.service.core.observability.tracing import (
     setup_tracing,
     shutdown_tracing,
@@ -9,9 +15,13 @@ from com.qode.qrew.v1.service.core.observability.tracing import (
 )
 
 __all__ = [
+    "CARRIER_KEY",
     "add_trace_context",
+    "extract_context",
+    "inject_current_context",
     "setup_tracing",
     "shutdown_tracing",
+    "take_carrier",
     "traced",
     "tracer",
 ]

--- a/api/src/com/qode/qrew/v1/service/core/observability/propagation.py
+++ b/api/src/com/qode/qrew/v1/service/core/observability/propagation.py
@@ -1,0 +1,33 @@
+from typing import Any
+
+from opentelemetry import context as otel_context
+from opentelemetry import propagate, trace
+
+CARRIER_KEY = "_otel"
+
+
+def inject_current_context() -> dict[str, str]:
+    """Capture the current trace context into a carrier dict, when valid."""
+    span = trace.get_current_span()
+    if not span.get_span_context().is_valid:
+        return {}
+    carrier: dict[str, str] = {}
+    propagate.inject(carrier)
+    return carrier
+
+
+def extract_context(carrier: dict[str, str] | None) -> otel_context.Context | None:
+    """Build an OpenTelemetry context from a carrier dict, or return None."""
+    if not carrier:
+        return None
+    return propagate.extract(carrier)
+
+
+def take_carrier(payload: dict[str, Any] | None) -> dict[str, str] | None:
+    """Pop the reserved carrier key from a payload, leaving the rest untouched."""
+    if not payload:
+        return None
+    raw = payload.pop(CARRIER_KEY, None)
+    if isinstance(raw, dict):
+        return {str(k): str(v) for k, v in raw.items()}  # type: ignore[misc]
+    return None

--- a/api/src/com/qode/qrew/v1/service/core/ws/hub.py
+++ b/api/src/com/qode/qrew/v1/service/core/ws/hub.py
@@ -6,6 +6,13 @@ from typing import Any
 import redis.asyncio as aioredis
 import structlog
 
+from com.qode.qrew.v1.service.core.observability import (
+    CARRIER_KEY,
+    extract_context,
+    inject_current_context,
+    take_carrier,
+    tracer,
+)
 from com.qode.qrew.v1.service.core.ws.close_codes import WS_CLOSE_OVERLOAD
 from com.qode.qrew.v1.service.core.ws.connection import Connection
 
@@ -74,8 +81,12 @@ class Hub:
             await self._pubsub.unsubscribe(_redis_channel(channel_key))  # type: ignore[misc]
 
     async def publish(self, channel_key: str, payload: dict[str, Any]) -> None:
+        envelope = dict(payload)
+        carrier = inject_current_context()
+        if carrier and CARRIER_KEY not in envelope:
+            envelope[CARRIER_KEY] = carrier
         try:
-            await self._redis.publish(_redis_channel(channel_key), json.dumps(payload))  # type: ignore[misc]
+            await self._redis.publish(_redis_channel(channel_key), json.dumps(envelope))  # type: ignore[misc]
         except aioredis.RedisError as exc:
             await logger.awarning("ws_publish_failed", error=repr(exc))
 
@@ -129,6 +140,10 @@ class Hub:
                 if not isinstance(parsed, dict):
                     continue
                 payload: dict[str, Any] = dict(parsed)  # type: ignore[arg-type]
-                await self.deliver_local(channel_key, payload)
+                carrier = take_carrier(payload)
+                parent = extract_context(carrier)
+                with tracer.start_as_current_span("ws.deliver", context=parent) as span:
+                    span.set_attribute("ws.channel", channel_key)
+                    await self.deliver_local(channel_key, payload)
         except asyncio.CancelledError:
             raise

--- a/api/tests/v1/jobs/propagation_test.py
+++ b/api/tests/v1/jobs/propagation_test.py
@@ -1,0 +1,82 @@
+from collections.abc import Generator
+from typing import Any
+
+import pytest
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+from com.qode.qrew.v1.service.core.jobs.context import wrap_handler
+from com.qode.qrew.v1.service.core.jobs.registry import JobSpec
+from com.qode.qrew.v1.service.core.observability import (
+    inject_current_context,
+    setup_tracing,
+    tracer,
+)
+
+
+@pytest.fixture
+def memory_exporter() -> Generator[InMemorySpanExporter, None, None]:
+    exporter = InMemorySpanExporter()
+    processor = SimpleSpanProcessor(exporter)
+    setup_tracing(extra_processors=[processor])
+    yield exporter
+    processor.shutdown()
+    exporter.clear()
+
+
+async def _noop(_ctx: dict[str, Any], _payload: dict[str, Any]) -> None:
+    return None
+
+
+def _spec() -> JobSpec:
+    return JobSpec(
+        name="test.linked",
+        handler=_noop,
+        max_attempts=1,
+        retry_delays=(1, 5, 25, 125, 625),
+        cron_fields=None,
+    )
+
+
+async def test_worker_span_inherits_trace_from_carrier(
+    memory_exporter: InMemorySpanExporter,
+) -> None:
+    runner = wrap_handler(_spec())
+    with tracer.start_as_current_span("producer") as producer:
+        producer_trace_id = producer.get_span_context().trace_id
+        carrier = inject_current_context()
+    payload: dict[str, Any] = {"foo": "bar", "_otel": carrier}
+    await runner({"job_try": 1, "job_id": "j1", "redis": None}, payload)
+
+    job_span = next(
+        s for s in memory_exporter.get_finished_spans() if s.name == "job.test.linked"
+    )
+    span_context = job_span.context
+    assert span_context is not None
+    assert span_context.trace_id == producer_trace_id
+    assert job_span.parent is not None
+
+
+async def test_worker_payload_otel_key_is_stripped_before_handler(
+    memory_exporter: InMemorySpanExporter,
+) -> None:
+    del memory_exporter
+    seen_payload: dict[str, Any] = {}
+
+    async def _capture(_ctx: dict[str, Any], payload: dict[str, Any]) -> None:
+        seen_payload.update(payload)
+
+    spec = JobSpec(
+        name="test.strip",
+        handler=_capture,
+        max_attempts=1,
+        retry_delays=(1, 5, 25, 125, 625),
+        cron_fields=None,
+    )
+    runner = wrap_handler(spec)
+    with tracer.start_as_current_span("producer"):
+        carrier = inject_current_context()
+    payload: dict[str, Any] = {"hello": "world", "_otel": carrier}
+    await runner({"job_try": 1, "job_id": "j2", "redis": None}, payload)
+    assert "_otel" not in seen_payload
+    assert seen_payload["hello"] == "world"

--- a/api/tests/v1/observability/propagation_test.py
+++ b/api/tests/v1/observability/propagation_test.py
@@ -1,0 +1,77 @@
+from collections.abc import Generator
+from typing import Any
+
+import pytest
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+from com.qode.qrew.v1.service.core.observability import (
+    CARRIER_KEY,
+    extract_context,
+    inject_current_context,
+    setup_tracing,
+    take_carrier,
+    tracer,
+)
+
+
+@pytest.fixture
+def memory_exporter() -> Generator[InMemorySpanExporter, None, None]:
+    exporter = InMemorySpanExporter()
+    processor = SimpleSpanProcessor(exporter)
+    setup_tracing(extra_processors=[processor])
+    yield exporter
+    processor.shutdown()
+    exporter.clear()
+
+
+def test_inject_returns_empty_when_no_active_span() -> None:
+    assert inject_current_context() == {}
+
+
+def test_inject_returns_carrier_inside_active_span(
+    memory_exporter: InMemorySpanExporter,
+) -> None:
+    del memory_exporter
+    with tracer.start_as_current_span("producer"):
+        carrier = inject_current_context()
+    assert "traceparent" in carrier
+
+
+def test_extract_returns_none_for_empty_carrier() -> None:
+    assert extract_context({}) is None
+    assert extract_context(None) is None
+
+
+def test_take_carrier_removes_reserved_key_only() -> None:
+    payload: dict[str, Any] = {
+        "user_id": "u-1",
+        CARRIER_KEY: {"traceparent": "00-abc-def-01"},
+    }
+    carrier = take_carrier(payload)
+    assert carrier == {"traceparent": "00-abc-def-01"}
+    assert CARRIER_KEY not in payload
+    assert payload == {"user_id": "u-1"}
+
+
+def test_take_carrier_returns_none_for_payload_without_carrier() -> None:
+    payload: dict[str, Any] = {"user_id": "u-1"}
+    assert take_carrier(payload) is None
+    assert payload == {"user_id": "u-1"}
+
+
+def test_inject_then_extract_links_consumer_span_to_producer(
+    memory_exporter: InMemorySpanExporter,
+) -> None:
+    with tracer.start_as_current_span("producer") as producer:
+        producer_trace_id = producer.get_span_context().trace_id
+        carrier = inject_current_context()
+
+    parent = extract_context(carrier)
+    with tracer.start_as_current_span("consumer", context=parent) as consumer:
+        consumer_trace_id = consumer.get_span_context().trace_id
+
+    finished = memory_exporter.get_finished_spans()
+    names = {s.name for s in finished}
+    assert {"producer", "consumer"} <= names
+    assert producer_trace_id == consumer_trace_id


### PR DESCRIPTION
## Summary

Before this PR, one user action (REST → Audit row → Notification job → WS event) showed up in Jaeger as several disconnected traces.

After this PR, all of those spans share a single `trace_id` and the worker / dispatcher spans carry a non-null parent reference to the producer.

## Verification

- `tests/v1/observability/propagation_test.py`

## Issue Reference

Closes [QRW-139](https://github.com/cristiangilsanz/qrew/issues/139)

## Checklist
- [x] I confirm that this PR follows the project's established coding standards.