### PR TITLE
feat: enforce websocket heartbeat timeout and reap stale connections

### DIFF
--- a/api/src/com/qode/qrew/v1/service/core/ws/connection.py
+++ b/api/src/com/qode/qrew/v1/service/core/ws/connection.py
@@ -1,4 +1,5 @@
 import asyncio
+import time
 import uuid
 from dataclasses import dataclass, field
 from typing import Any
@@ -32,6 +33,7 @@ class Connection:
 
     def __post_init__(self) -> None:
         self._queue = asyncio.Queue(maxsize=self.queue_size)
+        self._last_pong = time.monotonic()
 
     @property
     def closed(self) -> bool:
@@ -74,3 +76,7 @@ class Connection:
     @property
     def last_pong(self) -> float:
         return self._last_pong
+
+    def is_stale(self, now: float, max_silence_seconds: float) -> bool:
+        """Return whether the connection has missed pongs beyond the grace window."""
+        return now - self._last_pong > max_silence_seconds

--- a/api/src/com/qode/qrew/v1/service/core/ws/hub.py
+++ b/api/src/com/qode/qrew/v1/service/core/ws/hub.py
@@ -1,6 +1,7 @@
 import asyncio
 import contextlib
 import json
+import time
 from typing import Any
 
 import redis.asyncio as aioredis
@@ -13,8 +14,12 @@ from com.qode.qrew.v1.service.core.observability import (
     take_carrier,
     tracer,
 )
-from com.qode.qrew.v1.service.core.ws.close_codes import WS_CLOSE_OVERLOAD
+from com.qode.qrew.v1.service.core.ws.close_codes import (
+    WS_CLOSE_INTERNAL,
+    WS_CLOSE_OVERLOAD,
+)
 from com.qode.qrew.v1.service.core.ws.connection import Connection
+from com.qode.qrew.v1.service.settings import settings
 
 logger = structlog.get_logger(__name__)
 
@@ -33,6 +38,7 @@ class Hub:
         self._local: dict[str, set[Connection]] = {}
         self._pubsub: Any = None
         self._task: asyncio.Task[None] | None = None
+        self._reaper_task: asyncio.Task[None] | None = None
         self._lock = asyncio.Lock()
         self._running = False
 
@@ -42,6 +48,7 @@ class Hub:
         self._pubsub = self._redis.pubsub()  # type: ignore[misc]
         self._running = True
         self._task = asyncio.create_task(self._dispatcher())
+        self._reaper_task = asyncio.create_task(self._reaper())
 
     async def stop(self) -> None:
         self._running = False
@@ -50,6 +57,11 @@ class Hub:
             with contextlib.suppress(asyncio.CancelledError, Exception):
                 await self._task
             self._task = None
+        if self._reaper_task is not None:
+            self._reaper_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError, Exception):
+                await self._reaper_task
+            self._reaper_task = None
         if self._pubsub is not None:
             with contextlib.suppress(Exception):
                 await self._pubsub.aclose()  # type: ignore[misc]
@@ -147,3 +159,53 @@ class Hub:
                     await self.deliver_local(channel_key, payload)
         except asyncio.CancelledError:
             raise
+
+    def _reaper_interval_seconds(self) -> float:
+        """Half the pong timeout, never below one second."""
+        return max(1.0, settings.ws_pong_timeout_seconds / 2)
+
+    def _max_silence_seconds(self) -> float:
+        return float(settings.ws_heartbeat_seconds + settings.ws_pong_timeout_seconds)
+
+    async def _reaper(self) -> None:
+        interval = self._reaper_interval_seconds()
+        try:
+            while self._running:
+                await asyncio.sleep(interval)
+                if not self._running:
+                    return
+                try:
+                    await self.reap_stale()
+                except Exception as exc:  # noqa: BLE001
+                    await logger.awarning("ws_reaper_error", error=repr(exc))
+        except asyncio.CancelledError:
+            raise
+
+    async def reap_stale(self) -> int:
+        """Close every connection whose last pong is older than the grace window."""
+        now = time.monotonic()
+        max_silence = self._max_silence_seconds()
+        stale: set[Connection] = set()
+        async with self._lock:
+            for subscribers in self._local.values():
+                for connection in subscribers:
+                    if connection.is_stale(now, max_silence):
+                        stale.add(connection)
+        for connection in stale:
+            await self._reap_one(connection)
+        return len(stale)
+
+    async def _reap_one(self, connection: Connection) -> None:
+        channel_keys: list[str] = []
+        async with self._lock:
+            for channel_key, subscribers in self._local.items():
+                if connection in subscribers:
+                    channel_keys.append(channel_key)
+        for channel_key in channel_keys:
+            await self.unsubscribe(channel_key, connection)
+        await connection.close(WS_CLOSE_INTERNAL, "heartbeat lost")
+        await logger.awarning(
+            "ws_connection_reaped",
+            connection_id=connection.id,
+            user_id=str(connection.user.id),
+        )

--- a/api/src/com/qode/qrew/v1/service/core/ws/router.py
+++ b/api/src/com/qode/qrew/v1/service/core/ws/router.py
@@ -144,17 +144,11 @@ async def _read_loop(connection: Connection) -> None:
 
 async def _heartbeat(connection: Connection) -> None:
     ping_interval = settings.ws_heartbeat_seconds
-    pong_timeout = settings.ws_pong_timeout_seconds
-    connection.record_pong(time.monotonic())
     try:
         while not connection.closed:
             await asyncio.sleep(ping_interval)
             if connection.closed:
                 return
             await connection.enqueue(_PING)
-            await asyncio.sleep(pong_timeout)
-            if time.monotonic() - connection.last_pong > ping_interval + pong_timeout:
-                await connection.close(WS_CLOSE_INTERNAL, "heartbeat timeout")
-                return
     except asyncio.CancelledError:
         raise

--- a/api/tests/v1/ws/reaper_test.py
+++ b/api/tests/v1/ws/reaper_test.py
@@ -1,0 +1,88 @@
+import time
+from collections.abc import AsyncGenerator
+from typing import Any
+from unittest.mock import MagicMock
+
+import fakeredis.aioredis
+import pytest_asyncio
+
+from com.qode.qrew.v1.service.core.ws import Hub
+from com.qode.qrew.v1.service.core.ws.connection import Connection
+from com.qode.qrew.v1.service.settings import settings
+
+
+class _StubSocket:
+    def __init__(self) -> None:
+        from starlette.websockets import WebSocketState
+
+        self.application_state = WebSocketState.CONNECTED
+        self.closed_with: tuple[int, str] | None = None
+
+    async def send_json(self, _message: dict[str, Any]) -> None:
+        return None
+
+    async def close(self, code: int = 1000, reason: str = "") -> None:
+        from starlette.websockets import WebSocketState
+
+        self.closed_with = (code, reason)
+        self.application_state = WebSocketState.DISCONNECTED
+
+
+def _make_connection(last_pong: float) -> Connection:
+    conn = Connection(
+        socket=_StubSocket(),  # type: ignore[arg-type]
+        user=MagicMock(id="u-1"),
+        session=MagicMock(),
+    )
+    conn.record_pong(last_pong)
+    return conn
+
+
+@pytest_asyncio.fixture
+async def hub() -> AsyncGenerator[Hub, None]:
+    redis = fakeredis.aioredis.FakeRedis()
+    h = Hub(redis)
+    await h.start()
+    yield h
+    await h.stop()
+
+
+async def test_reap_stale_closes_silent_connection(hub: Hub) -> None:
+    grace = settings.ws_heartbeat_seconds + settings.ws_pong_timeout_seconds
+    stale = _make_connection(time.monotonic() - grace - 5)
+    await hub.subscribe("me.u1", stale)
+
+    reaped = await hub.reap_stale()
+    assert reaped == 1
+    assert stale.closed
+    assert hub._local.get("me.u1") is None  # pyright: ignore[reportPrivateUsage]
+
+
+async def test_reap_stale_leaves_healthy_connection_alone(hub: Hub) -> None:
+    healthy = _make_connection(time.monotonic())
+    await hub.subscribe("me.u1", healthy)
+
+    reaped = await hub.reap_stale()
+    assert reaped == 0
+    assert not healthy.closed
+    subscribers = hub._local.get("me.u1")  # pyright: ignore[reportPrivateUsage]
+    assert subscribers is not None
+    assert healthy in subscribers
+
+
+async def test_reap_stale_unsubscribes_from_every_channel_held(hub: Hub) -> None:
+    grace = settings.ws_heartbeat_seconds + settings.ws_pong_timeout_seconds
+    stale = _make_connection(time.monotonic() - grace - 1)
+    await hub.subscribe("me.u1", stale)
+    await hub.subscribe("queue.event.42", stale)
+
+    await hub.reap_stale()
+
+    assert hub._local.get("me.u1") is None  # pyright: ignore[reportPrivateUsage]
+    assert hub._local.get("queue.event.42") is None  # pyright: ignore[reportPrivateUsage]
+
+
+async def test_connection_is_stale_uses_grace_window() -> None:
+    conn = _make_connection(time.monotonic() - 100)
+    assert conn.is_stale(time.monotonic(), max_silence_seconds=50)
+    assert not conn.is_stale(time.monotonic(), max_silence_seconds=200)


### PR DESCRIPTION
## Summary

The hub already tracked `last_pong` on every connection, but nothing acted on a missed pong: a mobile client that drops its TCP connection silently kept its slot until the process restarted.

This PR plugs the gap by giving the hub one process-wide reaper task that periodically scans every subscribed connection, closes the ones that have gone silent past the grace window, and unsubscribes them from every channel they held.

The reaper iterates the hub's existing `dict[channel → set[Connection]]` and rebuilds the connection→channels reverse view on the fly during reap (rare event, no need for a persistent index). Concurrent reaps cannot race because all hub state is guarded by `self._lock`.

## Verification

- `tests/v1/ws/reaper_test.py`

## Issue Reference

Closes [QRW-140](https://github.com/cristiangilsanz/qrew/issues/140)

## Checklist
- [x] I confirm that this PR follows the project's established coding standards.