### PR TITLE
feat: add organisations, organisation members and role-based acl dependency

### DIFF
--- a/api/alembic/versions/b9c0d1e2f3a4_2026_06_08_add_organisations_and_members.py
+++ b/api/alembic/versions/b9c0d1e2f3a4_2026_06_08_add_organisations_and_members.py
@@ -1,0 +1,88 @@
+"""2026_06_08_add_organisations_and_members
+
+Revision ID: b9c0d1e2f3a4
+Revises: a8b9c0d1e2f3
+Create Date: 2026-06-08 00:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision: str = "b9c0d1e2f3a4"
+down_revision: str | None = "a8b9c0d1e2f3"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "organisations",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column("slug", sa.String(length=64), nullable=False),
+        sa.Column("name", sa.String(length=128), nullable=False),
+        sa.Column("description", sa.Text, nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column("deleted_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.create_index("ix_organisations_slug", "organisations", ["slug"], unique=True)
+
+    op.create_table(
+        "organisation_members",
+        sa.Column(
+            "organisation_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("organisations.id", ondelete="CASCADE"),
+            primary_key=True,
+        ),
+        sa.Column(
+            "user_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            primary_key=True,
+        ),
+        sa.Column(
+            "role",
+            sa.Enum("member", "manager", "owner", name="organisation_role"),
+            nullable=False,
+        ),
+        sa.Column(
+            "joined_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.UniqueConstraint(
+            "organisation_id", "user_id", name="uq_organisation_members_org_user"
+        ),
+    )
+    op.create_index(
+        "ix_organisation_members_user_id", "organisation_members", ["user_id"]
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_organisation_members_user_id", table_name="organisation_members")
+    op.drop_table("organisation_members")
+    op.execute("DROP TYPE organisation_role")
+    op.drop_index("ix_organisations_slug", table_name="organisations")
+    op.drop_table("organisations")

--- a/api/src/com/qode/qrew/v1/service/core/auth/organisation_acl.py
+++ b/api/src/com/qode/qrew/v1/service/core/auth/organisation_acl.py
@@ -1,0 +1,52 @@
+import uuid
+from collections.abc import Awaitable, Callable
+
+from fastapi import Depends, HTTPException, Path, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from com.qode.qrew.v1.service.core.auth.auth import get_current_user
+from com.qode.qrew.v1.service.core.infra.database import get_db
+from com.qode.qrew.v1.service.models.auth.user import User
+from com.qode.qrew.v1.service.models.organisation import (
+    OrganisationMember,
+    OrganisationRole,
+    role_rank,
+)
+from com.qode.qrew.v1.service.repositories.organisation import (
+    OrganisationMemberRepository,
+    OrganisationRepository,
+)
+
+_FORBIDDEN_EXCEPTION = HTTPException(
+    status_code=status.HTTP_403_FORBIDDEN,
+    detail={"message": "Not a member of this organisation", "field": None},
+)
+_NOT_FOUND_EXCEPTION = HTTPException(
+    status_code=status.HTTP_404_NOT_FOUND,
+    detail={"message": "Organisation not found", "field": "organisation_id"},
+)
+
+
+def get_org_member(
+    minimum_role: OrganisationRole = OrganisationRole.member,
+) -> Callable[..., Awaitable[OrganisationMember]]:
+    """Build a FastAPI dependency that gates a route on org membership and role."""
+
+    async def _dependency(
+        organisation_id: uuid.UUID = Path(...),
+        current_user: User = Depends(get_current_user),
+        db: AsyncSession = Depends(get_db),
+    ) -> OrganisationMember:
+        org = await OrganisationRepository(db).get_by_id(organisation_id)
+        if org is None:
+            raise _NOT_FOUND_EXCEPTION
+        member = await OrganisationMemberRepository(db).get(
+            organisation_id, current_user.id
+        )
+        if member is None:
+            raise _FORBIDDEN_EXCEPTION
+        if role_rank(member.role) < role_rank(minimum_role):
+            raise _FORBIDDEN_EXCEPTION
+        return member
+
+    return _dependency

--- a/api/src/com/qode/qrew/v1/service/models/audit/audit.py
+++ b/api/src/com/qode/qrew/v1/service/models/audit/audit.py
@@ -57,6 +57,9 @@ class AuditAction(enum.StrEnum):
     EXPIRED_TOKENS_CLEANED = "expired_tokens_cleaned"
     RATE_LIMIT_HIT = "rate_limit_hit"
     NOTIFICATION_FAILED = "notification_failed"
+    ORGANISATION_CREATED = "organisation_created"
+    ORGANISATION_MEMBER_ADDED = "organisation_member_added"
+    ORGANISATION_MEMBER_REMOVED = "organisation_member_removed"
 
 
 class AuditEvent(Base):

--- a/api/src/com/qode/qrew/v1/service/models/organisation/__init__.py
+++ b/api/src/com/qode/qrew/v1/service/models/organisation/__init__.py
@@ -1,0 +1,8 @@
+from com.qode.qrew.v1.service.models.organisation.organisation import (
+    Organisation,
+    OrganisationMember,
+    OrganisationRole,
+    role_rank,
+)
+
+__all__ = ["Organisation", "OrganisationMember", "OrganisationRole", "role_rank"]

--- a/api/src/com/qode/qrew/v1/service/models/organisation/organisation.py
+++ b/api/src/com/qode/qrew/v1/service/models/organisation/organisation.py
@@ -1,0 +1,80 @@
+import enum
+import uuid
+from datetime import datetime
+
+from sqlalchemy import DateTime, Enum, ForeignKey, String, Text, UniqueConstraint, func
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from com.qode.qrew.v1.service.core.infra.database import Base
+
+
+class OrganisationRole(enum.StrEnum):
+    """Membership role within an organisation, in ascending privilege order."""
+
+    member = "member"
+    manager = "manager"
+    owner = "owner"
+
+
+_ROLE_RANK = {
+    OrganisationRole.member: 0,
+    OrganisationRole.manager: 1,
+    OrganisationRole.owner: 2,
+}
+
+
+def role_rank(role: OrganisationRole) -> int:
+    """Return the privilege rank of a role for comparison."""
+    return _ROLE_RANK[role]
+
+
+class Organisation(Base):
+    __tablename__ = "organisations"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    slug: Mapped[str] = mapped_column(
+        String(64), nullable=False, unique=True, index=True
+    )
+    name: Mapped[str] = mapped_column(String(128), nullable=False)
+    description: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
+    )
+    deleted_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+
+
+class OrganisationMember(Base):
+    __tablename__ = "organisation_members"
+    __table_args__ = (
+        UniqueConstraint(
+            "organisation_id", "user_id", name="uq_organisation_members_org_user"
+        ),
+    )
+
+    organisation_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("organisations.id", ondelete="CASCADE"),
+        primary_key=True,
+    )
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="CASCADE"),
+        primary_key=True,
+    )
+    role: Mapped[OrganisationRole] = mapped_column(
+        Enum(OrganisationRole, name="organisation_role"), nullable=False
+    )
+    joined_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )

--- a/api/src/com/qode/qrew/v1/service/repositories/organisation/__init__.py
+++ b/api/src/com/qode/qrew/v1/service/repositories/organisation/__init__.py
@@ -1,0 +1,6 @@
+from com.qode.qrew.v1.service.repositories.organisation.organisation import (
+    OrganisationMemberRepository,
+    OrganisationRepository,
+)
+
+__all__ = ["OrganisationMemberRepository", "OrganisationRepository"]

--- a/api/src/com/qode/qrew/v1/service/repositories/organisation/organisation.py
+++ b/api/src/com/qode/qrew/v1/service/repositories/organisation/organisation.py
@@ -1,0 +1,105 @@
+import uuid
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from com.qode.qrew.v1.service.models.organisation import (
+    Organisation,
+    OrganisationMember,
+    OrganisationRole,
+)
+
+
+class OrganisationRepository:
+    """Data access for the organisations table."""
+
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+
+    async def get_by_id(self, organisation_id: uuid.UUID) -> Organisation | None:
+        result = await self._session.execute(
+            select(Organisation).where(
+                Organisation.id == organisation_id,
+                Organisation.deleted_at.is_(None),
+            )
+        )
+        return result.scalar_one_or_none()
+
+    async def get_by_slug(self, slug: str) -> Organisation | None:
+        result = await self._session.execute(
+            select(Organisation).where(
+                Organisation.slug == slug,
+                Organisation.deleted_at.is_(None),
+            )
+        )
+        return result.scalar_one_or_none()
+
+    async def insert(self, organisation: Organisation) -> Organisation:
+        self._session.add(organisation)
+        await self._session.flush()
+        await self._session.refresh(organisation)
+        return organisation
+
+    def list_for_user_query(self, user_id: uuid.UUID):
+        """Build a query of non-deleted orgs the user belongs to."""
+        return (
+            select(Organisation)
+            .join(
+                OrganisationMember,
+                OrganisationMember.organisation_id == Organisation.id,
+            )
+            .where(
+                OrganisationMember.user_id == user_id,
+                Organisation.deleted_at.is_(None),
+            )
+        )
+
+
+class OrganisationMemberRepository:
+    """Data access for the organisation_members join table."""
+
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+
+    async def get(
+        self, organisation_id: uuid.UUID, user_id: uuid.UUID
+    ) -> OrganisationMember | None:
+        result = await self._session.execute(
+            select(OrganisationMember).where(
+                OrganisationMember.organisation_id == organisation_id,
+                OrganisationMember.user_id == user_id,
+            )
+        )
+        return result.scalar_one_or_none()
+
+    async def insert(
+        self,
+        *,
+        organisation_id: uuid.UUID,
+        user_id: uuid.UUID,
+        role: OrganisationRole,
+    ) -> OrganisationMember:
+        member = OrganisationMember(
+            organisation_id=organisation_id, user_id=user_id, role=role
+        )
+        self._session.add(member)
+        await self._session.flush()
+        await self._session.refresh(member)
+        return member
+
+    async def delete(self, organisation_id: uuid.UUID, user_id: uuid.UUID) -> bool:
+        member = await self.get(organisation_id, user_id)
+        if member is None:
+            return False
+        await self._session.delete(member)
+        await self._session.flush()
+        return True
+
+    async def count_owners(self, organisation_id: uuid.UUID) -> int:
+        result = await self._session.execute(
+            select(OrganisationMember).where(
+                OrganisationMember.organisation_id == organisation_id,
+                OrganisationMember.role == OrganisationRole.owner,
+            )
+        )
+        return len(list(result.scalars().all()))

--- a/api/src/com/qode/qrew/v1/service/routers/__init__.py
+++ b/api/src/com/qode/qrew/v1/service/routers/__init__.py
@@ -3,6 +3,7 @@ from fastapi import APIRouter
 from com.qode.qrew.v1.service.routers.admin import router as admin_router
 from com.qode.qrew.v1.service.routers.auth import router as auth_router
 from com.qode.qrew.v1.service.routers.health import router as health_router
+from com.qode.qrew.v1.service.routers.organisation import router as organisation_router
 from com.qode.qrew.v1.service.routers.search import router as search_router
 from com.qode.qrew.v1.service.routers.uploads import router as uploads_router
 from com.qode.qrew.v1.service.settings import settings
@@ -13,6 +14,7 @@ router.include_router(auth_router)
 router.include_router(admin_router)
 router.include_router(uploads_router)
 router.include_router(search_router)
+router.include_router(organisation_router)
 
 if settings.debug:
     from com.qode.qrew.v1.service.routers.dev import router as dev_router

--- a/api/src/com/qode/qrew/v1/service/routers/organisation.py
+++ b/api/src/com/qode/qrew/v1/service/routers/organisation.py
@@ -1,0 +1,221 @@
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException, Request, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from com.qode.qrew.v1.service.core.api import Page, clamp_limit, cursor_paginate
+from com.qode.qrew.v1.service.core.auth.auth import get_current_user
+from com.qode.qrew.v1.service.core.auth.organisation_acl import get_org_member
+from com.qode.qrew.v1.service.core.idempotency import idempotent
+from com.qode.qrew.v1.service.core.infra.database import get_db
+from com.qode.qrew.v1.service.core.infra.limiter import limiter
+from com.qode.qrew.v1.service.core.ratelimit import rate_limit
+from com.qode.qrew.v1.service.core.ratelimit.dependencies import (
+    audit_on_rejection,
+    limiter_for,
+)
+from com.qode.qrew.v1.service.models.auth.user import User
+from com.qode.qrew.v1.service.models.organisation import (
+    Organisation,
+    OrganisationMember,
+    OrganisationRole,
+)
+from com.qode.qrew.v1.service.repositories.auth.user import UserRepository
+from com.qode.qrew.v1.service.repositories.organisation import (
+    OrganisationMemberRepository,
+    OrganisationRepository,
+)
+from com.qode.qrew.v1.service.schemas.organisation import (
+    OrganisationCreateRequest,
+    OrganisationMemberInviteRequest,
+    OrganisationMemberResponse,
+    OrganisationPublicResponse,
+    OrganisationResponse,
+)
+from com.qode.qrew.v1.service.services.audit import AuditService
+from com.qode.qrew.v1.service.services.organisation import (
+    OrganisationError,
+    OrganisationService,
+)
+
+router = APIRouter(prefix="/organisations", tags=["organisations"])
+
+
+def _service(db: AsyncSession) -> OrganisationService:
+    return OrganisationService(
+        OrganisationRepository(db),
+        OrganisationMemberRepository(db),
+        UserRepository(db),
+        AuditService(),
+    )
+
+
+def _bad_request(error: OrganisationError) -> HTTPException:
+    code = (
+        status.HTTP_409_CONFLICT
+        if error.field == "slug"
+        else status.HTTP_400_BAD_REQUEST
+    )
+    return HTTPException(
+        status_code=code,
+        detail={"message": error.message, "field": error.field},
+    )
+
+
+def _to_response(org: Organisation) -> OrganisationResponse:
+    return OrganisationResponse(
+        id=org.id,
+        slug=org.slug,
+        name=org.name,
+        description=org.description,
+        created_at=org.created_at,
+    )
+
+
+@router.post(
+    "",
+    response_model=OrganisationResponse,
+    status_code=status.HTTP_201_CREATED,
+    summary="Create a new organisation",
+)
+@limiter.limit("30/hour")  # type: ignore[misc]
+@idempotent(scope="user", ttl_seconds=300)
+@rate_limit(
+    [("user", 20, 3600)],
+    limiter_factory=limiter_for,
+    on_rejection=audit_on_rejection,
+)
+async def create_organisation(
+    request: Request,
+    body: OrganisationCreateRequest,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> OrganisationResponse:
+    """Create a new organisation with the caller as its sole owner."""
+    del request
+    try:
+        org = await _service(db).create_organisation(
+            owner_id=current_user.id,
+            slug=body.slug,
+            name=body.name,
+            description=body.description,
+        )
+    except OrganisationError as exc:
+        raise _bad_request(exc) from exc
+    return _to_response(org)
+
+
+@router.get(
+    "",
+    response_model=Page[OrganisationResponse],
+    status_code=status.HTTP_200_OK,
+    summary="List organisations the caller belongs to",
+)
+@limiter.limit("60/minute")  # type: ignore[misc]
+async def list_my_organisations(
+    request: Request,
+    cursor: str | None = None,
+    limit: int = 20,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> Page[OrganisationResponse]:
+    """List the non-deleted organisations the caller is a member of."""
+    del request
+    page_limit = clamp_limit(limit, default=20)
+    stmt = OrganisationRepository(db).list_for_user_query(current_user.id)
+    rows, next_cursor = await cursor_paginate(
+        db,
+        stmt,
+        sort_column=Organisation.created_at,
+        id_column=Organisation.id,
+        limit=page_limit,
+        cursor=cursor,
+    )
+    return Page[OrganisationResponse](
+        items=[_to_response(org) for org in rows],
+        next_cursor=next_cursor,
+    )
+
+
+@router.get(
+    "/{organisation_id}",
+    response_model=OrganisationPublicResponse,
+    status_code=status.HTTP_200_OK,
+    summary="Read the public profile of an organisation",
+)
+@limiter.limit("120/minute")  # type: ignore[misc]
+async def get_public_organisation(
+    request: Request,
+    organisation_id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
+) -> OrganisationPublicResponse:
+    """Return the public profile of an organisation."""
+    del request
+    org = await OrganisationRepository(db).get_by_id(organisation_id)
+    if org is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={"message": "Organisation not found", "field": "organisation_id"},
+        )
+    return OrganisationPublicResponse(
+        id=org.id, slug=org.slug, name=org.name, description=org.description
+    )
+
+
+@router.post(
+    "/{organisation_id}/members",
+    response_model=OrganisationMemberResponse,
+    status_code=status.HTTP_201_CREATED,
+    summary="Invite an existing user to an organisation",
+)
+@limiter.limit("30/hour")  # type: ignore[misc]
+@idempotent(scope="user", ttl_seconds=300)
+async def invite_member(
+    request: Request,
+    organisation_id: uuid.UUID,
+    body: OrganisationMemberInviteRequest,
+    actor: OrganisationMember = Depends(get_org_member(OrganisationRole.manager)),
+    db: AsyncSession = Depends(get_db),
+) -> OrganisationMemberResponse:
+    """Add an existing user to an organisation with the requested role."""
+    del request
+    try:
+        member = await _service(db).invite_member(
+            actor_id=actor.user_id,
+            organisation_id=organisation_id,
+            invitee_email=body.email,
+            role=body.role,
+        )
+    except OrganisationError as exc:
+        raise _bad_request(exc) from exc
+    return OrganisationMemberResponse(
+        organisation_id=member.organisation_id,
+        user_id=member.user_id,
+        role=member.role,
+        joined_at=member.joined_at,
+    )
+
+
+@router.delete(
+    "/{organisation_id}/members/{user_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    summary="Remove a member from an organisation",
+)
+@limiter.limit("30/hour")  # type: ignore[misc]
+async def remove_member(
+    request: Request,
+    organisation_id: uuid.UUID,
+    user_id: uuid.UUID,
+    actor: OrganisationMember = Depends(get_org_member(OrganisationRole.manager)),
+    db: AsyncSession = Depends(get_db),
+) -> None:
+    """Remove a member from an organisation."""
+    del request
+    try:
+        await _service(db).remove_member(
+            actor_id=actor.user_id,
+            organisation_id=organisation_id,
+            member_user_id=user_id,
+        )
+    except OrganisationError as exc:
+        raise _bad_request(exc) from exc

--- a/api/src/com/qode/qrew/v1/service/schemas/organisation/__init__.py
+++ b/api/src/com/qode/qrew/v1/service/schemas/organisation/__init__.py
@@ -1,0 +1,15 @@
+from com.qode.qrew.v1.service.schemas.organisation.organisation import (
+    OrganisationCreateRequest,
+    OrganisationMemberInviteRequest,
+    OrganisationMemberResponse,
+    OrganisationPublicResponse,
+    OrganisationResponse,
+)
+
+__all__ = [
+    "OrganisationCreateRequest",
+    "OrganisationMemberInviteRequest",
+    "OrganisationMemberResponse",
+    "OrganisationPublicResponse",
+    "OrganisationResponse",
+]

--- a/api/src/com/qode/qrew/v1/service/schemas/organisation/organisation.py
+++ b/api/src/com/qode/qrew/v1/service/schemas/organisation/organisation.py
@@ -1,0 +1,39 @@
+import uuid
+from datetime import datetime
+
+from pydantic import BaseModel, EmailStr, Field
+
+from com.qode.qrew.v1.service.models.organisation import OrganisationRole
+
+
+class OrganisationCreateRequest(BaseModel):
+    slug: str = Field(..., min_length=3, max_length=64)
+    name: str = Field(..., min_length=1, max_length=128)
+    description: str | None = Field(default=None, max_length=2000)
+
+
+class OrganisationResponse(BaseModel):
+    id: uuid.UUID
+    slug: str
+    name: str
+    description: str | None
+    created_at: datetime
+
+
+class OrganisationPublicResponse(BaseModel):
+    id: uuid.UUID
+    slug: str
+    name: str
+    description: str | None
+
+
+class OrganisationMemberInviteRequest(BaseModel):
+    email: EmailStr
+    role: OrganisationRole = OrganisationRole.member
+
+
+class OrganisationMemberResponse(BaseModel):
+    organisation_id: uuid.UUID
+    user_id: uuid.UUID
+    role: OrganisationRole
+    joined_at: datetime

--- a/api/src/com/qode/qrew/v1/service/services/organisation/__init__.py
+++ b/api/src/com/qode/qrew/v1/service/services/organisation/__init__.py
@@ -1,0 +1,6 @@
+from com.qode.qrew.v1.service.services.organisation.organisation import (
+    OrganisationError,
+    OrganisationService,
+)
+
+__all__ = ["OrganisationError", "OrganisationService"]

--- a/api/src/com/qode/qrew/v1/service/services/organisation/organisation.py
+++ b/api/src/com/qode/qrew/v1/service/services/organisation/organisation.py
@@ -1,0 +1,152 @@
+import re
+import uuid
+
+import structlog
+
+from com.qode.qrew.v1.service.core.infra.errors import DomainError
+from com.qode.qrew.v1.service.core.observability import traced
+from com.qode.qrew.v1.service.models.audit.audit import AuditAction
+from com.qode.qrew.v1.service.models.organisation import (
+    Organisation,
+    OrganisationMember,
+    OrganisationRole,
+)
+from com.qode.qrew.v1.service.repositories.auth.user import UserRepository
+from com.qode.qrew.v1.service.repositories.organisation import (
+    OrganisationMemberRepository,
+    OrganisationRepository,
+)
+from com.qode.qrew.v1.service.services.audit import AuditService
+
+logger = structlog.get_logger(__name__)
+
+_SLUG_PATTERN = re.compile(r"^[a-z][a-z0-9_-]{2,63}$")
+
+
+class OrganisationError(DomainError):
+    """Raised when an organisation operation fails a domain rule."""
+
+
+class OrganisationService:
+    """Business logic for organisations and their membership."""
+
+    def __init__(
+        self,
+        org_repo: OrganisationRepository,
+        member_repo: OrganisationMemberRepository,
+        user_repo: UserRepository,
+        audit: AuditService,
+    ) -> None:
+        self._orgs = org_repo
+        self._members = member_repo
+        self._users = user_repo
+        self._audit = audit
+
+    @traced("organisation.create")
+    async def create_organisation(
+        self,
+        *,
+        owner_id: uuid.UUID,
+        slug: str,
+        name: str,
+        description: str | None,
+    ) -> Organisation:
+        """Create a new organisation with the caller as its sole owner."""
+        if not _SLUG_PATTERN.fullmatch(slug):
+            raise OrganisationError("Invalid slug", field="slug")
+        existing = await self._orgs.get_by_slug(slug)
+        if existing is not None:
+            raise OrganisationError("Slug already taken", field="slug")
+        org = Organisation(slug=slug, name=name, description=description)
+        org = await self._orgs.insert(org)
+        await self._members.insert(
+            organisation_id=org.id, user_id=owner_id, role=OrganisationRole.owner
+        )
+        await self._audit_safe(
+            AuditAction.ORGANISATION_CREATED,
+            actor_id=owner_id,
+            organisation_id=org.id,
+            payload={"slug": org.slug, "name": org.name},
+        )
+        return org
+
+    @traced("organisation.invite_member")
+    async def invite_member(
+        self,
+        *,
+        actor_id: uuid.UUID,
+        organisation_id: uuid.UUID,
+        invitee_email: str,
+        role: OrganisationRole,
+    ) -> OrganisationMember:
+        """Add an existing user to an organisation with the requested role."""
+        if role == OrganisationRole.owner:
+            raise OrganisationError("Owners are promoted, not invited", field="role")
+        invitee = await self._users.get_by_email(invitee_email)
+        if invitee is None:
+            raise OrganisationError("No user with this email", field="email")
+        existing = await self._members.get(organisation_id, invitee.id)
+        if existing is not None:
+            raise OrganisationError(
+                "User is already a member of this organisation",
+                field="email",
+            )
+        member = await self._members.insert(
+            organisation_id=organisation_id, user_id=invitee.id, role=role
+        )
+        await self._audit_safe(
+            AuditAction.ORGANISATION_MEMBER_ADDED,
+            actor_id=actor_id,
+            organisation_id=organisation_id,
+            payload={"member_user_id": str(invitee.id), "role": str(role)},
+        )
+        return member
+
+    @traced("organisation.remove_member")
+    async def remove_member(
+        self,
+        *,
+        actor_id: uuid.UUID,
+        organisation_id: uuid.UUID,
+        member_user_id: uuid.UUID,
+    ) -> None:
+        """Remove a member; refuse to drop the last owner of an organisation."""
+        member = await self._members.get(organisation_id, member_user_id)
+        if member is None:
+            raise OrganisationError(
+                "User is not a member of this organisation",
+                field="user_id",
+            )
+        if member.role == OrganisationRole.owner:
+            owners = await self._members.count_owners(organisation_id)
+            if owners <= 1:
+                raise OrganisationError(
+                    "Cannot remove the last owner of an organisation",
+                    field="user_id",
+                )
+        await self._members.delete(organisation_id, member_user_id)
+        await self._audit_safe(
+            AuditAction.ORGANISATION_MEMBER_REMOVED,
+            actor_id=actor_id,
+            organisation_id=organisation_id,
+            payload={"member_user_id": str(member_user_id)},
+        )
+
+    async def _audit_safe(
+        self,
+        action: AuditAction,
+        *,
+        actor_id: uuid.UUID,
+        organisation_id: uuid.UUID,
+        payload: dict[str, object],
+    ) -> None:
+        try:
+            await self._audit.record(
+                action=action,
+                actor_id=actor_id,
+                entity_type="organisation",
+                entity_id=str(organisation_id),
+                payload=payload,
+            )
+        except Exception:
+            await logger.awarning("audit_write_failed", action=action)

--- a/api/tests/v1/organisation/acl_test.py
+++ b/api/tests/v1/organisation/acl_test.py
@@ -1,0 +1,120 @@
+import uuid
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import HTTPException
+
+from com.qode.qrew.v1.service.core.auth import organisation_acl
+from com.qode.qrew.v1.service.core.auth.organisation_acl import get_org_member
+from com.qode.qrew.v1.service.models.organisation import (
+    OrganisationMember,
+    OrganisationRole,
+)
+
+
+def _user(user_id: uuid.UUID) -> MagicMock:
+    user = MagicMock()
+    user.id = user_id
+    return user
+
+
+def _org() -> MagicMock:
+    org = MagicMock()
+    org.deleted_at = None
+    return org
+
+
+def _member(role: OrganisationRole, user_id: uuid.UUID) -> OrganisationMember:
+    return OrganisationMember(
+        organisation_id=uuid.uuid4(),
+        user_id=user_id,
+        role=role,
+    )
+
+
+async def _invoke(
+    dependency: Any,
+    *,
+    monkeypatch: pytest.MonkeyPatch,
+    org_get_returns: Any,
+    member_get_returns: Any,
+    user_id: uuid.UUID,
+) -> Any:
+    org_repo = MagicMock()
+    org_repo.get_by_id = AsyncMock(return_value=org_get_returns)
+    member_repo = MagicMock()
+    member_repo.get = AsyncMock(return_value=member_get_returns)
+
+    def _org_repo_factory(_db: Any) -> MagicMock:
+        return org_repo
+
+    def _member_repo_factory(_db: Any) -> MagicMock:
+        return member_repo
+
+    monkeypatch.setattr(organisation_acl, "OrganisationRepository", _org_repo_factory)
+    monkeypatch.setattr(
+        organisation_acl, "OrganisationMemberRepository", _member_repo_factory
+    )
+    return await dependency(
+        organisation_id=uuid.uuid4(),
+        current_user=_user(user_id),
+        db=MagicMock(),
+    )
+
+
+async def test_acl_allows_member_at_required_role(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    user_id = uuid.uuid4()
+    member = _member(OrganisationRole.manager, user_id)
+    result = await _invoke(
+        get_org_member(OrganisationRole.member),
+        monkeypatch=monkeypatch,
+        org_get_returns=_org(),
+        member_get_returns=member,
+        user_id=user_id,
+    )
+    assert result is member
+
+
+async def test_acl_rejects_member_below_required_role(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    user_id = uuid.uuid4()
+    member = _member(OrganisationRole.member, user_id)
+    with pytest.raises(HTTPException) as info:
+        await _invoke(
+            get_org_member(OrganisationRole.manager),
+            monkeypatch=monkeypatch,
+            org_get_returns=_org(),
+            member_get_returns=member,
+            user_id=user_id,
+        )
+    assert info.value.status_code == 403
+
+
+async def test_acl_rejects_non_member(monkeypatch: pytest.MonkeyPatch) -> None:
+    with pytest.raises(HTTPException) as info:
+        await _invoke(
+            get_org_member(OrganisationRole.member),
+            monkeypatch=monkeypatch,
+            org_get_returns=_org(),
+            member_get_returns=None,
+            user_id=uuid.uuid4(),
+        )
+    assert info.value.status_code == 403
+
+
+async def test_acl_returns_404_when_org_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    with pytest.raises(HTTPException) as info:
+        await _invoke(
+            get_org_member(OrganisationRole.member),
+            monkeypatch=monkeypatch,
+            org_get_returns=None,
+            member_get_returns=None,
+            user_id=uuid.uuid4(),
+        )
+    assert info.value.status_code == 404

--- a/api/tests/v1/organisation/service_test.py
+++ b/api/tests/v1/organisation/service_test.py
@@ -1,0 +1,159 @@
+import uuid
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from com.qode.qrew.v1.service.models.organisation import (
+    OrganisationMember,
+    OrganisationRole,
+)
+from com.qode.qrew.v1.service.services.organisation import (
+    OrganisationError,
+    OrganisationService,
+)
+
+
+def _service_with(
+    *,
+    get_by_slug: object | None = None,
+    get_member: object | None = None,
+    get_user: object | None = None,
+    owners_count: int = 1,
+) -> tuple[OrganisationService, MagicMock, MagicMock, MagicMock, MagicMock]:
+    org_repo = MagicMock()
+    org_repo.get_by_slug = AsyncMock(return_value=get_by_slug)
+
+    inserted_orgs: list[object] = []
+
+    async def _insert_org(org: object) -> object:
+        inserted_orgs.append(org)
+        return org
+
+    org_repo.insert = AsyncMock(side_effect=_insert_org)
+
+    member_repo = MagicMock()
+    member_repo.get = AsyncMock(return_value=get_member)
+
+    async def _insert_member(**kwargs: Any) -> OrganisationMember:
+        return OrganisationMember(**kwargs)
+
+    member_repo.insert = AsyncMock(side_effect=_insert_member)
+    member_repo.delete = AsyncMock(return_value=True)
+    member_repo.count_owners = AsyncMock(return_value=owners_count)
+
+    user_repo = MagicMock()
+    user_repo.get_by_email = AsyncMock(return_value=get_user)
+
+    audit = MagicMock()
+    audit.record = AsyncMock()
+
+    return (
+        OrganisationService(org_repo, member_repo, user_repo, audit),
+        org_repo,
+        member_repo,
+        user_repo,
+        audit,
+    )
+
+
+async def test_create_organisation_rejects_invalid_slug() -> None:
+    service, *_ = _service_with()
+    with pytest.raises(OrganisationError, match="Invalid slug"):
+        await service.create_organisation(
+            owner_id=uuid.uuid4(), slug="BadSlug!", name="x", description=None
+        )
+
+
+async def test_create_organisation_rejects_taken_slug() -> None:
+    service, *_ = _service_with(get_by_slug=MagicMock())
+    with pytest.raises(OrganisationError, match="Slug already taken"):
+        await service.create_organisation(
+            owner_id=uuid.uuid4(), slug="qrew", name="x", description=None
+        )
+
+
+async def test_create_organisation_inserts_owner_membership() -> None:
+    owner_id = uuid.uuid4()
+    service, _org_repo, member_repo, _, audit = _service_with()
+    await service.create_organisation(
+        owner_id=owner_id, slug="qrew", name="Qrew", description="hi"
+    )
+    member_repo.insert.assert_awaited_once()
+    insert_kwargs = member_repo.insert.await_args.kwargs
+    assert insert_kwargs["user_id"] == owner_id
+    assert insert_kwargs["role"] == OrganisationRole.owner
+    audit.record.assert_awaited_once()
+
+
+async def test_invite_member_requires_existing_user() -> None:
+    service, *_ = _service_with(get_user=None)
+    with pytest.raises(OrganisationError, match="No user"):
+        await service.invite_member(
+            actor_id=uuid.uuid4(),
+            organisation_id=uuid.uuid4(),
+            invitee_email="ghost@example.com",
+            role=OrganisationRole.member,
+        )
+
+
+async def test_invite_member_rejects_owner_role() -> None:
+    service, *_ = _service_with(get_user=MagicMock(id=uuid.uuid4()))
+    with pytest.raises(OrganisationError, match="Owners are promoted"):
+        await service.invite_member(
+            actor_id=uuid.uuid4(),
+            organisation_id=uuid.uuid4(),
+            invitee_email="x@example.com",
+            role=OrganisationRole.owner,
+        )
+
+
+async def test_invite_member_rejects_duplicate() -> None:
+    service, *_ = _service_with(
+        get_user=MagicMock(id=uuid.uuid4()),
+        get_member=OrganisationMember(
+            organisation_id=uuid.uuid4(),
+            user_id=uuid.uuid4(),
+            role=OrganisationRole.member,
+        ),
+    )
+    with pytest.raises(OrganisationError, match="already a member"):
+        await service.invite_member(
+            actor_id=uuid.uuid4(),
+            organisation_id=uuid.uuid4(),
+            invitee_email="x@example.com",
+            role=OrganisationRole.member,
+        )
+
+
+async def test_remove_member_refuses_to_drop_last_owner() -> None:
+    org_id = uuid.uuid4()
+    user_id = uuid.uuid4()
+    service, *_ = _service_with(
+        get_member=OrganisationMember(
+            organisation_id=org_id, user_id=user_id, role=OrganisationRole.owner
+        ),
+        owners_count=1,
+    )
+    with pytest.raises(OrganisationError, match="last owner"):
+        await service.remove_member(
+            actor_id=user_id,
+            organisation_id=org_id,
+            member_user_id=user_id,
+        )
+
+
+async def test_remove_member_allows_dropping_non_last_owner() -> None:
+    org_id = uuid.uuid4()
+    user_id = uuid.uuid4()
+    service, *_ = _service_with(
+        get_member=OrganisationMember(
+            organisation_id=org_id, user_id=user_id, role=OrganisationRole.owner
+        ),
+        owners_count=2,
+    )
+    await service.remove_member(
+        actor_id=uuid.uuid4(),
+        organisation_id=org_id,
+        member_user_id=user_id,
+    )


### PR DESCRIPTION
## Summary

Lays the multi-tenant foundation every later issue (venues, events, ticket types, public catalog) builds on. 

Without this, events have no owner, organiser endpoints have no ACL, and admin tooling has nothing to scope against.

## Verification

- `tests/v1/organisation/service_test.py`
- `tests/v1/organisation/acl_test.py`

## Issue Reference

Closes [QRW-146](https://github.com/cristiangilsanz/qrew/issues/146)

## Checklist
- [x] I confirm that this PR follows the project's established coding standards.