### PR TITLE
feat: add venues with geofence radius and public read endpoint

### DIFF
--- a/api/alembic/versions/c0d1e2f3a4b5_2026_06_08_add_venues_table.py
+++ b/api/alembic/versions/c0d1e2f3a4b5_2026_06_08_add_venues_table.py
@@ -1,0 +1,73 @@
+"""2026_06_08_add_venues_table
+
+Revision ID: c0d1e2f3a4b5
+Revises: b9c0d1e2f3a4
+Create Date: 2026-06-08 01:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision: str = "c0d1e2f3a4b5"
+down_revision: str | None = "b9c0d1e2f3a4"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "venues",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column("name", sa.String(length=128), nullable=False),
+        sa.Column("address_line", sa.String(length=256), nullable=False),
+        sa.Column("city", sa.String(length=96), nullable=False),
+        sa.Column("country", sa.String(length=2), nullable=False),
+        sa.Column("latitude", sa.Numeric(9, 6), nullable=False),
+        sa.Column("longitude", sa.Numeric(9, 6), nullable=False),
+        sa.Column(
+            "geofence_radius_m",
+            sa.Integer,
+            nullable=False,
+            server_default="200",
+        ),
+        sa.Column("timezone", sa.String(length=64), nullable=False),
+        sa.Column("description", sa.Text, nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column("deleted_at", sa.DateTime(timezone=True), nullable=True),
+        sa.CheckConstraint(
+            "latitude >= -90 AND latitude <= 90", name="ck_venues_latitude"
+        ),
+        sa.CheckConstraint(
+            "longitude >= -180 AND longitude <= 180", name="ck_venues_longitude"
+        ),
+        sa.CheckConstraint(
+            "geofence_radius_m >= 50 AND geofence_radius_m <= 5000",
+            name="ck_venues_geofence_radius",
+        ),
+    )
+    op.create_index("ix_venues_city_country", "venues", ["city", "country"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_venues_city_country", table_name="venues")
+    op.drop_table("venues")

--- a/api/src/com/qode/qrew/v1/service/models/audit/audit.py
+++ b/api/src/com/qode/qrew/v1/service/models/audit/audit.py
@@ -60,6 +60,7 @@ class AuditAction(enum.StrEnum):
     ORGANISATION_CREATED = "organisation_created"
     ORGANISATION_MEMBER_ADDED = "organisation_member_added"
     ORGANISATION_MEMBER_REMOVED = "organisation_member_removed"
+    VENUE_CREATED = "venue_created"
 
 
 class AuditEvent(Base):

--- a/api/src/com/qode/qrew/v1/service/models/venue/__init__.py
+++ b/api/src/com/qode/qrew/v1/service/models/venue/__init__.py
@@ -1,0 +1,3 @@
+from com.qode.qrew.v1.service.models.venue.venue import Venue
+
+__all__ = ["Venue"]

--- a/api/src/com/qode/qrew/v1/service/models/venue/venue.py
+++ b/api/src/com/qode/qrew/v1/service/models/venue/venue.py
@@ -1,0 +1,41 @@
+import uuid
+from datetime import datetime
+from decimal import Decimal
+
+from sqlalchemy import DateTime, Index, Integer, Numeric, String, Text, func
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from com.qode.qrew.v1.service.core.infra.database import Base
+
+
+class Venue(Base):
+    __tablename__ = "venues"
+    __table_args__ = (Index("ix_venues_city_country", "city", "country"),)
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    name: Mapped[str] = mapped_column(String(128), nullable=False)
+    address_line: Mapped[str] = mapped_column(String(256), nullable=False)
+    city: Mapped[str] = mapped_column(String(96), nullable=False)
+    country: Mapped[str] = mapped_column(String(2), nullable=False)
+    latitude: Mapped[Decimal] = mapped_column(Numeric(9, 6), nullable=False)
+    longitude: Mapped[Decimal] = mapped_column(Numeric(9, 6), nullable=False)
+    geofence_radius_m: Mapped[int] = mapped_column(
+        Integer, nullable=False, server_default="200"
+    )
+    timezone: Mapped[str] = mapped_column(String(64), nullable=False)
+    description: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
+    )
+    deleted_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )

--- a/api/src/com/qode/qrew/v1/service/repositories/venue/__init__.py
+++ b/api/src/com/qode/qrew/v1/service/repositories/venue/__init__.py
@@ -1,0 +1,3 @@
+from com.qode.qrew.v1.service.repositories.venue.venue import VenueRepository
+
+__all__ = ["VenueRepository"]

--- a/api/src/com/qode/qrew/v1/service/repositories/venue/venue.py
+++ b/api/src/com/qode/qrew/v1/service/repositories/venue/venue.py
@@ -1,0 +1,36 @@
+import uuid
+
+from sqlalchemy import Select, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from com.qode.qrew.v1.service.models.venue import Venue
+
+
+class VenueRepository:
+    """Data access for the venues table."""
+
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+
+    async def get_by_id(self, venue_id: uuid.UUID) -> Venue | None:
+        result = await self._session.execute(
+            select(Venue).where(Venue.id == venue_id, Venue.deleted_at.is_(None))
+        )
+        return result.scalar_one_or_none()
+
+    async def insert(self, venue: Venue) -> Venue:
+        self._session.add(venue)
+        await self._session.flush()
+        await self._session.refresh(venue)
+        return venue
+
+    def list_query(
+        self, city: str | None = None, country: str | None = None
+    ) -> Select[tuple[Venue]]:
+        """Build a filtered, soft-delete-aware query for the public list."""
+        stmt = select(Venue).where(Venue.deleted_at.is_(None))
+        if city is not None:
+            stmt = stmt.where(Venue.city == city)
+        if country is not None:
+            stmt = stmt.where(Venue.country == country.upper())
+        return stmt

--- a/api/src/com/qode/qrew/v1/service/routers/__init__.py
+++ b/api/src/com/qode/qrew/v1/service/routers/__init__.py
@@ -6,6 +6,7 @@ from com.qode.qrew.v1.service.routers.health import router as health_router
 from com.qode.qrew.v1.service.routers.organisation import router as organisation_router
 from com.qode.qrew.v1.service.routers.search import router as search_router
 from com.qode.qrew.v1.service.routers.uploads import router as uploads_router
+from com.qode.qrew.v1.service.routers.venue import router as venue_router
 from com.qode.qrew.v1.service.settings import settings
 
 router = APIRouter(prefix="/v1")
@@ -15,6 +16,7 @@ router.include_router(admin_router)
 router.include_router(uploads_router)
 router.include_router(search_router)
 router.include_router(organisation_router)
+router.include_router(venue_router)
 
 if settings.debug:
     from com.qode.qrew.v1.service.routers.dev import router as dev_router

--- a/api/src/com/qode/qrew/v1/service/routers/venue.py
+++ b/api/src/com/qode/qrew/v1/service/routers/venue.py
@@ -1,0 +1,151 @@
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException, Request, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from com.qode.qrew.v1.service.core.api import Page, clamp_limit, cursor_paginate
+from com.qode.qrew.v1.service.core.auth.auth import get_current_user
+from com.qode.qrew.v1.service.core.idempotency import idempotent
+from com.qode.qrew.v1.service.core.infra.database import get_db
+from com.qode.qrew.v1.service.core.infra.limiter import limiter
+from com.qode.qrew.v1.service.models.auth.user import User
+from com.qode.qrew.v1.service.models.venue import Venue
+from com.qode.qrew.v1.service.repositories.venue import VenueRepository
+from com.qode.qrew.v1.service.schemas.venue import (
+    VenueCreateRequest,
+    VenuePublicResponse,
+    VenueResponse,
+)
+from com.qode.qrew.v1.service.services.audit import AuditService
+from com.qode.qrew.v1.service.services.venue import VenueError, VenueService
+
+router = APIRouter(prefix="/venues", tags=["venues"])
+
+
+def _service(db: AsyncSession) -> VenueService:
+    return VenueService(VenueRepository(db), AuditService())
+
+
+def _to_response(venue: Venue) -> VenueResponse:
+    return VenueResponse(
+        id=venue.id,
+        name=venue.name,
+        address_line=venue.address_line,
+        city=venue.city,
+        country=venue.country,
+        latitude=venue.latitude,
+        longitude=venue.longitude,
+        geofence_radius_m=venue.geofence_radius_m,
+        timezone=venue.timezone,
+        description=venue.description,
+        created_at=venue.created_at,
+    )
+
+
+def _to_public(venue: Venue) -> VenuePublicResponse:
+    return VenuePublicResponse(
+        id=venue.id,
+        name=venue.name,
+        city=venue.city,
+        country=venue.country,
+        latitude=venue.latitude,
+        longitude=venue.longitude,
+        geofence_radius_m=venue.geofence_radius_m,
+        timezone=venue.timezone,
+    )
+
+
+def _bad_request(error: VenueError) -> HTTPException:
+    return HTTPException(
+        status_code=status.HTTP_400_BAD_REQUEST,
+        detail={"message": error.message, "field": error.field},
+    )
+
+
+@router.post(
+    "",
+    response_model=VenueResponse,
+    status_code=status.HTTP_201_CREATED,
+    summary="Create a new venue",
+)
+@limiter.limit("60/hour")  # type: ignore[misc]
+@idempotent(scope="user", ttl_seconds=300)
+async def create_venue(
+    request: Request,
+    body: VenueCreateRequest,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> VenueResponse:
+    """Create a new venue."""
+    del request
+    try:
+        venue = await _service(db).create_venue(
+            actor_id=current_user.id,
+            name=body.name,
+            address_line=body.address_line,
+            city=body.city,
+            country=body.country,
+            latitude=body.latitude,
+            longitude=body.longitude,
+            geofence_radius_m=body.geofence_radius_m,
+            timezone=body.timezone,
+            description=body.description,
+        )
+    except VenueError as exc:
+        raise _bad_request(exc) from exc
+    return _to_response(venue)
+
+
+@router.get(
+    "",
+    response_model=Page[VenuePublicResponse],
+    status_code=status.HTTP_200_OK,
+    summary="List venues with optional city and country filters",
+)
+@limiter.limit("120/minute")  # type: ignore[misc]
+async def list_venues(
+    request: Request,
+    city: str | None = None,
+    country: str | None = None,
+    cursor: str | None = None,
+    limit: int = 20,
+    db: AsyncSession = Depends(get_db),
+) -> Page[VenuePublicResponse]:
+    """List venues, optionally filtered by city or country."""
+    del request
+    page_limit = clamp_limit(limit, default=20)
+    stmt = VenueRepository(db).list_query(city=city, country=country)
+    rows, next_cursor = await cursor_paginate(
+        db,
+        stmt,
+        sort_column=Venue.created_at,
+        id_column=Venue.id,
+        limit=page_limit,
+        cursor=cursor,
+    )
+    return Page[VenuePublicResponse](
+        items=[_to_public(venue) for venue in rows], next_cursor=next_cursor
+    )
+
+
+@router.get(
+    "/{venue_id}",
+    response_model=VenuePublicResponse,
+    status_code=status.HTTP_200_OK,
+    summary="Read the public profile of a venue",
+)
+@limiter.limit("120/minute")  # type: ignore[misc]
+async def get_public_venue(
+    request: Request,
+    venue_id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
+) -> VenuePublicResponse:
+    """Return the public profile of a venue."""
+    del request
+    venue = await VenueRepository(db).get_by_id(venue_id)
+    if venue is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={"message": "Venue not found", "field": "venue_id"},
+        )
+    return _to_public(venue)

--- a/api/src/com/qode/qrew/v1/service/schemas/venue/__init__.py
+++ b/api/src/com/qode/qrew/v1/service/schemas/venue/__init__.py
@@ -1,0 +1,7 @@
+from com.qode.qrew.v1.service.schemas.venue.venue import (
+    VenueCreateRequest,
+    VenuePublicResponse,
+    VenueResponse,
+)
+
+__all__ = ["VenueCreateRequest", "VenuePublicResponse", "VenueResponse"]

--- a/api/src/com/qode/qrew/v1/service/schemas/venue/venue.py
+++ b/api/src/com/qode/qrew/v1/service/schemas/venue/venue.py
@@ -1,0 +1,44 @@
+import uuid
+from datetime import datetime
+from decimal import Decimal
+
+from pydantic import BaseModel, Field
+
+
+class VenueCreateRequest(BaseModel):
+    name: str = Field(..., min_length=1, max_length=128)
+    address_line: str = Field(..., min_length=1, max_length=256)
+    city: str = Field(..., min_length=1, max_length=96)
+    country: str = Field(..., min_length=2, max_length=2)
+    latitude: Decimal = Field(..., ge=Decimal("-90"), le=Decimal("90"))
+    longitude: Decimal = Field(..., ge=Decimal("-180"), le=Decimal("180"))
+    geofence_radius_m: int = Field(default=200, ge=50, le=5000)
+    timezone: str = Field(..., min_length=1, max_length=64)
+    description: str | None = Field(default=None, max_length=2000)
+
+
+class VenueResponse(BaseModel):
+    id: uuid.UUID
+    name: str
+    address_line: str
+    city: str
+    country: str
+    latitude: Decimal
+    longitude: Decimal
+    geofence_radius_m: int
+    timezone: str
+    description: str | None
+    created_at: datetime
+
+
+class VenuePublicResponse(BaseModel):
+    """Trimmed-down read shape that the future event detail embeds."""
+
+    id: uuid.UUID
+    name: str
+    city: str
+    country: str
+    latitude: Decimal
+    longitude: Decimal
+    geofence_radius_m: int
+    timezone: str

--- a/api/src/com/qode/qrew/v1/service/services/venue/__init__.py
+++ b/api/src/com/qode/qrew/v1/service/services/venue/__init__.py
@@ -1,0 +1,3 @@
+from com.qode.qrew.v1.service.services.venue.venue import VenueError, VenueService
+
+__all__ = ["VenueError", "VenueService"]

--- a/api/src/com/qode/qrew/v1/service/services/venue/venue.py
+++ b/api/src/com/qode/qrew/v1/service/services/venue/venue.py
@@ -1,0 +1,110 @@
+import uuid
+from decimal import Decimal
+from zoneinfo import available_timezones
+
+import structlog
+
+from com.qode.qrew.v1.service.core.infra.errors import DomainError
+from com.qode.qrew.v1.service.core.observability import traced
+from com.qode.qrew.v1.service.models.audit.audit import AuditAction
+from com.qode.qrew.v1.service.models.venue import Venue
+from com.qode.qrew.v1.service.repositories.venue import VenueRepository
+from com.qode.qrew.v1.service.services.audit import AuditService
+
+logger = structlog.get_logger(__name__)
+
+_GEOFENCE_MIN_M = 50
+_GEOFENCE_MAX_M = 5000
+
+_AVAILABLE_TIMEZONES = available_timezones()
+
+
+class VenueError(DomainError):
+    """Raised when a venue operation fails a domain rule."""
+
+
+def _validate_coordinates(latitude: Decimal, longitude: Decimal) -> None:
+    if latitude < Decimal("-90") or latitude > Decimal("90"):
+        raise VenueError("Latitude out of range", field="latitude")
+    if longitude < Decimal("-180") or longitude > Decimal("180"):
+        raise VenueError("Longitude out of range", field="longitude")
+
+
+def _validate_radius(radius_m: int) -> None:
+    if radius_m < _GEOFENCE_MIN_M or radius_m > _GEOFENCE_MAX_M:
+        raise VenueError(
+            "Geofence radius must be between 50 and 5000 metres",
+            field="geofence_radius_m",
+        )
+
+
+def _validate_timezone(timezone: str) -> None:
+    if timezone not in _AVAILABLE_TIMEZONES:
+        raise VenueError("Unknown timezone", field="timezone")
+
+
+def _validate_country(country: str) -> None:
+    if len(country) != 2 or not country.isalpha():
+        raise VenueError("Country must be an ISO-3166-1 alpha-2 code", field="country")
+
+
+class VenueService:
+    """Business logic for venues."""
+
+    def __init__(
+        self,
+        repo: VenueRepository,
+        audit: AuditService,
+    ) -> None:
+        self._repo = repo
+        self._audit = audit
+
+    @traced("venue.create")
+    async def create_venue(
+        self,
+        *,
+        actor_id: uuid.UUID,
+        name: str,
+        address_line: str,
+        city: str,
+        country: str,
+        latitude: Decimal,
+        longitude: Decimal,
+        geofence_radius_m: int,
+        timezone: str,
+        description: str | None,
+    ) -> Venue:
+        """Create a new venue after validating geography and timezone."""
+        _validate_country(country)
+        _validate_coordinates(latitude, longitude)
+        _validate_radius(geofence_radius_m)
+        _validate_timezone(timezone)
+        venue = Venue(
+            name=name,
+            address_line=address_line,
+            city=city,
+            country=country.upper(),
+            latitude=latitude,
+            longitude=longitude,
+            geofence_radius_m=geofence_radius_m,
+            timezone=timezone,
+            description=description,
+        )
+        venue = await self._repo.insert(venue)
+        try:
+            await self._audit.record(
+                action=AuditAction.VENUE_CREATED,
+                actor_id=actor_id,
+                entity_type="venue",
+                entity_id=str(venue.id),
+                payload={
+                    "name": venue.name,
+                    "city": venue.city,
+                    "country": venue.country,
+                },
+            )
+        except Exception:
+            await logger.awarning(
+                "audit_write_failed", action=AuditAction.VENUE_CREATED
+            )
+        return venue

--- a/api/tests/v1/venue/service_test.py
+++ b/api/tests/v1/venue/service_test.py
@@ -1,0 +1,86 @@
+import uuid
+from decimal import Decimal
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from com.qode.qrew.v1.service.models.venue import Venue
+from com.qode.qrew.v1.service.services.venue import VenueError, VenueService
+
+
+def _service() -> tuple[VenueService, MagicMock, MagicMock]:
+    repo = MagicMock()
+
+    async def _insert(venue: Venue) -> Venue:
+        venue.id = uuid.uuid4()
+        return venue
+
+    repo.insert = AsyncMock(side_effect=_insert)
+    audit = MagicMock()
+    audit.record = AsyncMock()
+    return VenueService(repo, audit), repo, audit
+
+
+def _valid_kwargs() -> dict[str, object]:
+    return {
+        "actor_id": uuid.uuid4(),
+        "name": "Wembley",
+        "address_line": "Olympic Way",
+        "city": "London",
+        "country": "GB",
+        "latitude": Decimal("51.555973"),
+        "longitude": Decimal("-0.279672"),
+        "geofence_radius_m": 300,
+        "timezone": "Europe/London",
+        "description": None,
+    }
+
+
+async def test_create_venue_persists_and_audits() -> None:
+    service, repo, audit = _service()
+    venue = await service.create_venue(**_valid_kwargs())  # type: ignore[arg-type]
+    assert venue.country == "GB"
+    repo.insert.assert_awaited_once()
+    audit.record.assert_awaited_once()
+
+
+async def test_create_venue_rejects_bad_country() -> None:
+    service, *_ = _service()
+    kwargs = _valid_kwargs() | {"country": "GBR"}
+    with pytest.raises(VenueError, match="ISO-3166"):
+        await service.create_venue(**kwargs)  # type: ignore[arg-type]
+
+
+async def test_create_venue_rejects_bad_latitude() -> None:
+    service, *_ = _service()
+    kwargs = _valid_kwargs() | {"latitude": Decimal("91")}
+    with pytest.raises(VenueError, match="Latitude"):
+        await service.create_venue(**kwargs)  # type: ignore[arg-type]
+
+
+async def test_create_venue_rejects_bad_longitude() -> None:
+    service, *_ = _service()
+    kwargs = _valid_kwargs() | {"longitude": Decimal("-181")}
+    with pytest.raises(VenueError, match="Longitude"):
+        await service.create_venue(**kwargs)  # type: ignore[arg-type]
+
+
+async def test_create_venue_rejects_bad_radius() -> None:
+    service, *_ = _service()
+    kwargs = _valid_kwargs() | {"geofence_radius_m": 10}
+    with pytest.raises(VenueError, match="radius"):
+        await service.create_venue(**kwargs)  # type: ignore[arg-type]
+
+
+async def test_create_venue_rejects_unknown_timezone() -> None:
+    service, *_ = _service()
+    kwargs = _valid_kwargs() | {"timezone": "Mars/Olympus_Mons"}
+    with pytest.raises(VenueError, match="timezone"):
+        await service.create_venue(**kwargs)  # type: ignore[arg-type]
+
+
+async def test_create_venue_normalises_country_to_upper() -> None:
+    service, *_ = _service()
+    kwargs = _valid_kwargs() | {"country": "gb"}
+    venue = await service.create_venue(**kwargs)  # type: ignore[arg-type]
+    assert venue.country == "GB"


### PR DESCRIPTION
## Summary

Adds the venue domain as the geographic anchor for future events.

A venue carries name, address, city, ISO-3166-1 alpha-2 country, decimal lat/long, geofence radius (50–5000 m), IANA timezone and optional description.

Venues are global rather than org-scoped, so the model carries no organisation foreign key.

## Verification

- `api/tests/v1/venue/service_test.py`

## Issue Reference

Closes [QRW-147](https://github.com/cristiangilsanz/qrew/issues/147)

## Checklist
- [x] I confirm that this PR follows the project's established coding standards.