### PR TITLE
feat: add event lifecycle with publish, cancel and full-text search wire-in

### DIFF
--- a/api/alembic/versions/d1e2f3a4b5c6_2026_06_08_add_events_table.py
+++ b/api/alembic/versions/d1e2f3a4b5c6_2026_06_08_add_events_table.py
@@ -109,11 +109,13 @@ def upgrade() -> None:
         [EVENTS_SEARCH_CONFIG.vector_column],
         postgresql_using="gin",
     )
-    op.execute(create_trigger_sql(EVENTS_SEARCH_CONFIG))
+    for statement in create_trigger_sql(EVENTS_SEARCH_CONFIG):
+        op.execute(statement)
 
 
 def downgrade() -> None:
-    op.execute(drop_trigger_sql(EVENTS_SEARCH_CONFIG))
+    for statement in drop_trigger_sql(EVENTS_SEARCH_CONFIG):
+        op.execute(statement)
     op.drop_index("ix_events_status_starts_at", table_name="events")
     op.drop_index("ix_events_venue_id", table_name="events")
     op.drop_index("ix_events_organisation_id", table_name="events")

--- a/api/alembic/versions/d1e2f3a4b5c6_2026_06_08_add_events_table.py
+++ b/api/alembic/versions/d1e2f3a4b5c6_2026_06_08_add_events_table.py
@@ -1,0 +1,123 @@
+"""2026_06_08_add_events_table
+
+Revision ID: d1e2f3a4b5c6
+Revises: c0d1e2f3a4b5
+Create Date: 2026-06-08 02:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+from com.qode.qrew.v1.service.core.search import create_trigger_sql, drop_trigger_sql
+from com.qode.qrew.v1.service.search.events import EVENTS_SEARCH_CONFIG
+
+revision: str = "d1e2f3a4b5c6"
+down_revision: str | None = "c0d1e2f3a4b5"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "events",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column(
+            "organisation_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("organisations.id", ondelete="RESTRICT"),
+            nullable=False,
+        ),
+        sa.Column(
+            "venue_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("venues.id", ondelete="RESTRICT"),
+            nullable=False,
+        ),
+        sa.Column("name", sa.String(160), nullable=False),
+        sa.Column("description", sa.Text, nullable=True),
+        sa.Column("starts_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("ends_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("sale_starts_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("sale_ends_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column(
+            "max_tickets_per_user",
+            sa.Integer,
+            nullable=False,
+            server_default="4",
+        ),
+        sa.Column(
+            "status",
+            sa.String(16),
+            nullable=False,
+            server_default="draft",
+        ),
+        sa.Column("organiser_name", sa.String(128), nullable=False),
+        sa.Column("venue_city", sa.String(96), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column("published_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("cancelled_at", sa.DateTime(timezone=True), nullable=True),
+        sa.CheckConstraint("starts_at < ends_at", name="ck_events_time_window"),
+        sa.CheckConstraint(
+            "sale_starts_at < sale_ends_at", name="ck_events_sale_window"
+        ),
+        sa.CheckConstraint(
+            "sale_ends_at <= starts_at", name="ck_events_sale_before_start"
+        ),
+        sa.CheckConstraint(
+            "max_tickets_per_user >= 1 AND max_tickets_per_user <= 20",
+            name="ck_events_max_tickets_per_user",
+        ),
+        sa.CheckConstraint(
+            "status IN ('draft', 'published', 'cancelled')",
+            name="ck_events_status",
+        ),
+    )
+    op.create_index("ix_events_organisation_id", "events", ["organisation_id"])
+    op.create_index("ix_events_venue_id", "events", ["venue_id"])
+    op.create_index("ix_events_status_starts_at", "events", ["status", "starts_at"])
+    op.add_column(
+        EVENTS_SEARCH_CONFIG.table,
+        sa.Column(
+            EVENTS_SEARCH_CONFIG.vector_column,
+            postgresql.TSVECTOR,
+            nullable=True,
+        ),
+    )
+    op.create_index(
+        EVENTS_SEARCH_CONFIG.index_name,
+        EVENTS_SEARCH_CONFIG.table,
+        [EVENTS_SEARCH_CONFIG.vector_column],
+        postgresql_using="gin",
+    )
+    op.execute(create_trigger_sql(EVENTS_SEARCH_CONFIG))
+
+
+def downgrade() -> None:
+    op.execute(drop_trigger_sql(EVENTS_SEARCH_CONFIG))
+    op.drop_index("ix_events_status_starts_at", table_name="events")
+    op.drop_index("ix_events_venue_id", table_name="events")
+    op.drop_index("ix_events_organisation_id", table_name="events")
+    op.drop_index(
+        EVENTS_SEARCH_CONFIG.index_name, table_name=EVENTS_SEARCH_CONFIG.table
+    )
+    op.drop_table("events")

--- a/api/alembic/versions/f7a8b9c0d1e2_2026_06_02_add_events_search_vector.py
+++ b/api/alembic/versions/f7a8b9c0d1e2_2026_06_02_add_events_search_vector.py
@@ -40,7 +40,8 @@ def upgrade() -> None:
         [EVENTS_SEARCH_CONFIG.vector_column],
         postgresql_using="gin",
     )
-    op.execute(create_trigger_sql(EVENTS_SEARCH_CONFIG))
+    for statement in create_trigger_sql(EVENTS_SEARCH_CONFIG):
+        op.execute(statement)
 
 
 def downgrade() -> None:
@@ -48,7 +49,8 @@ def downgrade() -> None:
     inspector = sa.inspect(bind)
     if EVENTS_SEARCH_CONFIG.table not in inspector.get_table_names():
         return
-    op.execute(drop_trigger_sql(EVENTS_SEARCH_CONFIG))
+    for statement in drop_trigger_sql(EVENTS_SEARCH_CONFIG):
+        op.execute(statement)
     op.drop_index(
         EVENTS_SEARCH_CONFIG.index_name, table_name=EVENTS_SEARCH_CONFIG.table
     )

--- a/api/src/com/qode/qrew/v1/service/core/ratelimit/scopes.py
+++ b/api/src/com/qode/qrew/v1/service/core/ratelimit/scopes.py
@@ -4,7 +4,7 @@ from fastapi import Request
 
 ScopeResolver = Callable[[Request], Awaitable[str | None]]
 
-ALLOWED_SCOPES = frozenset({"ip", "user", "device", "fingerprint"})
+ALLOWED_SCOPES = frozenset({"ip", "user", "device", "fingerprint", "org"})
 
 
 async def _resolve_ip(request: Request) -> str | None:
@@ -28,11 +28,17 @@ async def _resolve_fingerprint(request: Request) -> str | None:
     return request.headers.get("X-Device-Fingerprint")
 
 
+async def _resolve_org(request: Request) -> str | None:
+    org_id = request.path_params.get("organisation_id")
+    return str(org_id) if org_id else None
+
+
 _RESOLVERS: dict[str, ScopeResolver] = {
     "ip": _resolve_ip,
     "user": _resolve_user,
     "device": _resolve_device,
     "fingerprint": _resolve_fingerprint,
+    "org": _resolve_org,
 }
 
 

--- a/api/src/com/qode/qrew/v1/service/core/search/tsvector.py
+++ b/api/src/com/qode/qrew/v1/service/core/search/tsvector.py
@@ -32,25 +32,25 @@ def update_one_sql(config: SearchConfig) -> str:
     )
 
 
-def create_trigger_sql(config: SearchConfig) -> str:
-    """Return SQL that installs a trigger to keep the vector up to date."""
+def create_trigger_sql(config: SearchConfig) -> list[str]:
+    """Return the statements that install a trigger to keep the vector up to date."""
     body = vector_sql(config).replace("coalesce(", "coalesce(NEW.")
-    return (
+    return [
         f"CREATE OR REPLACE FUNCTION {config.trigger_function_name}() "
         "RETURNS trigger AS $$ BEGIN "
         f"NEW.{config.vector_column} := {body}; "
         "RETURN NEW; "
-        "END; $$ LANGUAGE plpgsql; "
-        f"DROP TRIGGER IF EXISTS {config.trigger_name} ON {config.table}; "
+        "END; $$ LANGUAGE plpgsql",
+        f"DROP TRIGGER IF EXISTS {config.trigger_name} ON {config.table}",
         f"CREATE TRIGGER {config.trigger_name} BEFORE INSERT OR UPDATE "
         f"ON {config.table} FOR EACH ROW "
-        f"EXECUTE FUNCTION {config.trigger_function_name}();"
-    )
+        f"EXECUTE FUNCTION {config.trigger_function_name}()",
+    ]
 
 
-def drop_trigger_sql(config: SearchConfig) -> str:
-    """Return SQL that removes the trigger and its function."""
-    return (
-        f"DROP TRIGGER IF EXISTS {config.trigger_name} ON {config.table}; "
-        f"DROP FUNCTION IF EXISTS {config.trigger_function_name}();"
-    )
+def drop_trigger_sql(config: SearchConfig) -> list[str]:
+    """Return the statements that remove the trigger and its function."""
+    return [
+        f"DROP TRIGGER IF EXISTS {config.trigger_name} ON {config.table}",
+        f"DROP FUNCTION IF EXISTS {config.trigger_function_name}()",
+    ]

--- a/api/src/com/qode/qrew/v1/service/models/audit/audit.py
+++ b/api/src/com/qode/qrew/v1/service/models/audit/audit.py
@@ -61,6 +61,10 @@ class AuditAction(enum.StrEnum):
     ORGANISATION_MEMBER_ADDED = "organisation_member_added"
     ORGANISATION_MEMBER_REMOVED = "organisation_member_removed"
     VENUE_CREATED = "venue_created"
+    EVENT_CREATED = "event_created"
+    EVENT_UPDATED = "event_updated"
+    EVENT_PUBLISHED = "event_published"
+    EVENT_CANCELLED = "event_cancelled"
 
 
 class AuditEvent(Base):

--- a/api/src/com/qode/qrew/v1/service/models/event/__init__.py
+++ b/api/src/com/qode/qrew/v1/service/models/event/__init__.py
@@ -1,0 +1,3 @@
+from com.qode.qrew.v1.service.models.event.event import Event, EventStatus
+
+__all__ = ["Event", "EventStatus"]

--- a/api/src/com/qode/qrew/v1/service/models/event/event.py
+++ b/api/src/com/qode/qrew/v1/service/models/event/event.py
@@ -1,0 +1,89 @@
+import enum
+import uuid
+from datetime import datetime
+
+from sqlalchemy import (
+    CheckConstraint,
+    DateTime,
+    ForeignKey,
+    Index,
+    Integer,
+    String,
+    Text,
+    func,
+)
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from com.qode.qrew.v1.service.core.infra.database import Base
+
+
+class EventStatus(enum.StrEnum):
+    draft = "draft"
+    published = "published"
+    cancelled = "cancelled"
+
+
+class Event(Base):
+    __tablename__ = "events"
+    __table_args__ = (
+        CheckConstraint("starts_at < ends_at", name="ck_events_time_window"),
+        CheckConstraint("sale_starts_at < sale_ends_at", name="ck_events_sale_window"),
+        CheckConstraint(
+            "sale_ends_at <= starts_at", name="ck_events_sale_before_start"
+        ),
+        CheckConstraint(
+            "max_tickets_per_user >= 1 AND max_tickets_per_user <= 20",
+            name="ck_events_max_tickets_per_user",
+        ),
+        Index("ix_events_organisation_id", "organisation_id"),
+        Index("ix_events_venue_id", "venue_id"),
+        Index("ix_events_status_starts_at", "status", "starts_at"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    organisation_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("organisations.id", ondelete="RESTRICT"),
+        nullable=False,
+    )
+    venue_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("venues.id", ondelete="RESTRICT"),
+        nullable=False,
+    )
+    name: Mapped[str] = mapped_column(String(160), nullable=False)
+    description: Mapped[str | None] = mapped_column(Text, nullable=True)
+    starts_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    ends_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    sale_starts_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False
+    )
+    sale_ends_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False
+    )
+    max_tickets_per_user: Mapped[int] = mapped_column(
+        Integer, nullable=False, server_default="4"
+    )
+    status: Mapped[EventStatus] = mapped_column(
+        String(16), nullable=False, server_default=EventStatus.draft.value
+    )
+    organiser_name: Mapped[str] = mapped_column(String(128), nullable=False)
+    venue_city: Mapped[str] = mapped_column(String(96), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
+    )
+    published_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    cancelled_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )

--- a/api/src/com/qode/qrew/v1/service/repositories/event/__init__.py
+++ b/api/src/com/qode/qrew/v1/service/repositories/event/__init__.py
@@ -1,0 +1,3 @@
+from com.qode.qrew.v1.service.repositories.event.event import EventRepository
+
+__all__ = ["EventRepository"]

--- a/api/src/com/qode/qrew/v1/service/repositories/event/event.py
+++ b/api/src/com/qode/qrew/v1/service/repositories/event/event.py
@@ -1,0 +1,32 @@
+import uuid
+
+from sqlalchemy import Select, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from com.qode.qrew.v1.service.models.event import Event, EventStatus
+
+
+class EventRepository:
+    """Data access for the events table."""
+
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+
+    async def get_by_id(self, event_id: uuid.UUID) -> Event | None:
+        result = await self._session.execute(select(Event).where(Event.id == event_id))
+        return result.scalar_one_or_none()
+
+    async def insert(self, event: Event) -> Event:
+        self._session.add(event)
+        await self._session.flush()
+        await self._session.refresh(event)
+        return event
+
+    async def flush(self) -> None:
+        await self._session.flush()
+
+    def list_for_org_query(self, organisation_id: uuid.UUID) -> Select[tuple[Event]]:
+        return select(Event).where(Event.organisation_id == organisation_id)
+
+    def list_published_query(self) -> Select[tuple[Event]]:
+        return select(Event).where(Event.status == EventStatus.published)

--- a/api/src/com/qode/qrew/v1/service/routers/__init__.py
+++ b/api/src/com/qode/qrew/v1/service/routers/__init__.py
@@ -6,6 +6,7 @@ from com.qode.qrew.v1.service.routers.health import router as health_router
 from com.qode.qrew.v1.service.routers.organisation import router as organisation_router
 from com.qode.qrew.v1.service.routers.search import router as search_router
 from com.qode.qrew.v1.service.routers.uploads import router as uploads_router
+from com.qode.qrew.v1.service.routers.event import router as event_router
 from com.qode.qrew.v1.service.routers.venue import router as venue_router
 from com.qode.qrew.v1.service.settings import settings
 
@@ -17,6 +18,7 @@ router.include_router(uploads_router)
 router.include_router(search_router)
 router.include_router(organisation_router)
 router.include_router(venue_router)
+router.include_router(event_router)
 
 if settings.debug:
     from com.qode.qrew.v1.service.routers.dev import router as dev_router

--- a/api/src/com/qode/qrew/v1/service/routers/event.py
+++ b/api/src/com/qode/qrew/v1/service/routers/event.py
@@ -1,0 +1,297 @@
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException, Request, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from com.qode.qrew.v1.service.core.api import Page, clamp_limit, cursor_paginate
+from com.qode.qrew.v1.service.core.auth.auth import get_current_user
+from com.qode.qrew.v1.service.core.auth.organisation_acl import get_org_member
+from com.qode.qrew.v1.service.core.idempotency import idempotent
+from com.qode.qrew.v1.service.core.infra.database import get_db
+from com.qode.qrew.v1.service.core.infra.limiter import limiter
+from com.qode.qrew.v1.service.core.locking.errors import LockUnavailableError
+from com.qode.qrew.v1.service.core.ratelimit import rate_limit
+from com.qode.qrew.v1.service.core.ratelimit.dependencies import (
+    audit_on_rejection,
+    limiter_for,
+)
+from com.qode.qrew.v1.service.models.auth.user import User
+from com.qode.qrew.v1.service.models.event import Event
+from com.qode.qrew.v1.service.models.organisation import (
+    OrganisationMember,
+    OrganisationRole,
+)
+from com.qode.qrew.v1.service.repositories.event import EventRepository
+from com.qode.qrew.v1.service.repositories.organisation import (
+    OrganisationMemberRepository,
+    OrganisationRepository,
+)
+from com.qode.qrew.v1.service.repositories.venue import VenueRepository
+from com.qode.qrew.v1.service.schemas.event import (
+    EventCreateRequest,
+    EventResponse,
+    EventUpdateRequest,
+)
+from com.qode.qrew.v1.service.services.audit import AuditService
+from com.qode.qrew.v1.service.services.event import EventError, EventService
+
+router = APIRouter(tags=["events"])
+
+
+def _service(db: AsyncSession) -> EventService:
+    return EventService(
+        db,
+        EventRepository(db),
+        OrganisationRepository(db),
+        VenueRepository(db),
+        AuditService(),
+    )
+
+
+def _to_response(event: Event) -> EventResponse:
+    return EventResponse(
+        id=event.id,
+        organisation_id=event.organisation_id,
+        venue_id=event.venue_id,
+        name=event.name,
+        description=event.description,
+        starts_at=event.starts_at,
+        ends_at=event.ends_at,
+        sale_starts_at=event.sale_starts_at,
+        sale_ends_at=event.sale_ends_at,
+        max_tickets_per_user=event.max_tickets_per_user,
+        status=event.status,
+        organiser_name=event.organiser_name,
+        venue_city=event.venue_city,
+        created_at=event.created_at,
+        published_at=event.published_at,
+        cancelled_at=event.cancelled_at,
+    )
+
+
+def _bad_request(error: EventError) -> HTTPException:
+    code = (
+        status.HTTP_404_NOT_FOUND
+        if error.field in {"event_id", "organisation_id", "venue_id"}
+        else status.HTTP_400_BAD_REQUEST
+    )
+    return HTTPException(
+        status_code=code,
+        detail={"message": error.message, "field": error.field},
+    )
+
+
+async def _load_event_for_actor(
+    db: AsyncSession, event_id: uuid.UUID, user: User
+) -> tuple[Event, OrganisationMember]:
+    """Load an event and verify the caller is a manager+ in its organisation."""
+    event = await EventRepository(db).get_by_id(event_id)
+    if event is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={"message": "Event not found", "field": "event_id"},
+        )
+    member = await OrganisationMemberRepository(db).get(event.organisation_id, user.id)
+    from com.qode.qrew.v1.service.models.organisation import role_rank
+
+    if member is None or role_rank(member.role) < role_rank(OrganisationRole.manager):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail={
+                "message": "Not a manager of this organisation",
+                "field": None,
+            },
+        )
+    return event, member
+
+
+@router.post(
+    "/organisations/{organisation_id}/events",
+    response_model=EventResponse,
+    status_code=status.HTTP_201_CREATED,
+    summary="Create a draft event under an organisation",
+)
+@limiter.limit("60/hour")  # type: ignore[misc]
+@idempotent(scope="user", ttl_seconds=300)
+@rate_limit(
+    [("org", 100, 3600)],
+    limiter_factory=limiter_for,
+    on_rejection=audit_on_rejection,
+)
+async def create_event(
+    request: Request,
+    organisation_id: uuid.UUID,
+    body: EventCreateRequest,
+    actor: OrganisationMember = Depends(get_org_member(OrganisationRole.manager)),
+    db: AsyncSession = Depends(get_db),
+) -> EventResponse:
+    """Create a draft event under an organisation."""
+    del request
+    try:
+        event = await _service(db).create_event(
+            actor_id=actor.user_id,
+            organisation_id=organisation_id,
+            venue_id=body.venue_id,
+            name=body.name,
+            description=body.description,
+            starts_at=body.starts_at,
+            ends_at=body.ends_at,
+            sale_starts_at=body.sale_starts_at,
+            sale_ends_at=body.sale_ends_at,
+            max_tickets_per_user=body.max_tickets_per_user,
+        )
+    except EventError as exc:
+        raise _bad_request(exc) from exc
+    return _to_response(event)
+
+
+@router.get(
+    "/organisations/{organisation_id}/events",
+    response_model=Page[EventResponse],
+    status_code=status.HTTP_200_OK,
+    summary="List events under an organisation",
+)
+@limiter.limit("120/minute")  # type: ignore[misc]
+async def list_org_events(
+    request: Request,
+    organisation_id: uuid.UUID,
+    cursor: str | None = None,
+    limit: int = 20,
+    _actor: OrganisationMember = Depends(get_org_member(OrganisationRole.member)),
+    db: AsyncSession = Depends(get_db),
+) -> Page[EventResponse]:
+    """List the events belonging to the organisation the caller is a member of."""
+    del request
+    page_limit = clamp_limit(limit, default=20)
+    stmt = EventRepository(db).list_for_org_query(organisation_id)
+    rows, next_cursor = await cursor_paginate(
+        db,
+        stmt,
+        sort_column=Event.created_at,
+        id_column=Event.id,
+        limit=page_limit,
+        cursor=cursor,
+    )
+    return Page[EventResponse](
+        items=[_to_response(event) for event in rows], next_cursor=next_cursor
+    )
+
+
+@router.patch(
+    "/events/{event_id}",
+    response_model=EventResponse,
+    status_code=status.HTTP_200_OK,
+    summary="Edit a draft event",
+)
+@limiter.limit("60/hour")  # type: ignore[misc]
+async def update_event(
+    request: Request,
+    event_id: uuid.UUID,
+    body: EventUpdateRequest,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> EventResponse:
+    """Edit a draft event in place."""
+    del request
+    _, actor = await _load_event_for_actor(db, event_id, current_user)
+    changes = body.model_dump(exclude_unset=True)
+    try:
+        event = await _service(db).update_event(
+            actor_id=actor.user_id, event_id=event_id, changes=changes
+        )
+    except EventError as exc:
+        raise _bad_request(exc) from exc
+    return _to_response(event)
+
+
+@router.post(
+    "/events/{event_id}/publish",
+    response_model=EventResponse,
+    status_code=status.HTTP_200_OK,
+    summary="Publish a draft event",
+)
+@limiter.limit("60/hour")  # type: ignore[misc]
+@idempotent(scope="user", ttl_seconds=300)
+async def publish_event(
+    request: Request,
+    event_id: uuid.UUID,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> EventResponse:
+    """Flip a draft event to published and enqueue search reindex."""
+    del request
+    _, actor = await _load_event_for_actor(db, event_id, current_user)
+    try:
+        event = await _service(db).publish_event(
+            actor_id=actor.user_id, event_id=event_id
+        )
+    except EventError as exc:
+        raise _bad_request(exc) from exc
+    except LockUnavailableError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={
+                "message": "Another lifecycle change is in progress",
+                "field": None,
+            },
+        ) from exc
+    return _to_response(event)
+
+
+@router.post(
+    "/events/{event_id}/cancel",
+    response_model=EventResponse,
+    status_code=status.HTTP_200_OK,
+    summary="Cancel an event",
+)
+@limiter.limit("60/hour")  # type: ignore[misc]
+@idempotent(scope="user", ttl_seconds=300)
+async def cancel_event(
+    request: Request,
+    event_id: uuid.UUID,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> EventResponse:
+    """Move an event to cancelled and record the intent to notify holders."""
+    del request
+    _, actor = await _load_event_for_actor(db, event_id, current_user)
+    try:
+        event = await _service(db).cancel_event(
+            actor_id=actor.user_id, event_id=event_id
+        )
+    except EventError as exc:
+        raise _bad_request(exc) from exc
+    except LockUnavailableError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={
+                "message": "Another lifecycle change is in progress",
+                "field": None,
+            },
+        ) from exc
+    return _to_response(event)
+
+
+@router.get(
+    "/events/{event_id}",
+    response_model=EventResponse,
+    status_code=status.HTTP_200_OK,
+    summary="Read a single event",
+)
+@limiter.limit("120/minute")  # type: ignore[misc]
+async def get_event(
+    request: Request,
+    event_id: uuid.UUID,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> EventResponse:
+    """Read a single event the caller can see."""
+    del request
+    del current_user
+    event = await EventRepository(db).get_by_id(event_id)
+    if event is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={"message": "Event not found", "field": "event_id"},
+        )
+    return _to_response(event)

--- a/api/src/com/qode/qrew/v1/service/schemas/event/__init__.py
+++ b/api/src/com/qode/qrew/v1/service/schemas/event/__init__.py
@@ -1,0 +1,7 @@
+from com.qode.qrew.v1.service.schemas.event.event import (
+    EventCreateRequest,
+    EventResponse,
+    EventUpdateRequest,
+)
+
+__all__ = ["EventCreateRequest", "EventResponse", "EventUpdateRequest"]

--- a/api/src/com/qode/qrew/v1/service/schemas/event/event.py
+++ b/api/src/com/qode/qrew/v1/service/schemas/event/event.py
@@ -1,0 +1,46 @@
+import uuid
+from datetime import datetime
+
+from pydantic import BaseModel, Field
+
+from com.qode.qrew.v1.service.models.event import EventStatus
+
+
+class EventCreateRequest(BaseModel):
+    venue_id: uuid.UUID
+    name: str = Field(..., min_length=1, max_length=160)
+    description: str | None = Field(default=None, max_length=10000)
+    starts_at: datetime
+    ends_at: datetime
+    sale_starts_at: datetime
+    sale_ends_at: datetime
+    max_tickets_per_user: int = Field(default=4, ge=1, le=20)
+
+
+class EventUpdateRequest(BaseModel):
+    name: str | None = Field(default=None, min_length=1, max_length=160)
+    description: str | None = Field(default=None, max_length=10000)
+    starts_at: datetime | None = None
+    ends_at: datetime | None = None
+    sale_starts_at: datetime | None = None
+    sale_ends_at: datetime | None = None
+    max_tickets_per_user: int | None = Field(default=None, ge=1, le=20)
+
+
+class EventResponse(BaseModel):
+    id: uuid.UUID
+    organisation_id: uuid.UUID
+    venue_id: uuid.UUID
+    name: str
+    description: str | None
+    starts_at: datetime
+    ends_at: datetime
+    sale_starts_at: datetime
+    sale_ends_at: datetime
+    max_tickets_per_user: int
+    status: EventStatus
+    organiser_name: str
+    venue_city: str
+    created_at: datetime
+    published_at: datetime | None
+    cancelled_at: datetime | None

--- a/api/src/com/qode/qrew/v1/service/services/event/__init__.py
+++ b/api/src/com/qode/qrew/v1/service/services/event/__init__.py
@@ -1,0 +1,3 @@
+from com.qode.qrew.v1.service.services.event.event import EventError, EventService
+
+__all__ = ["EventError", "EventService"]

--- a/api/src/com/qode/qrew/v1/service/services/event/event.py
+++ b/api/src/com/qode/qrew/v1/service/services/event/event.py
@@ -1,0 +1,256 @@
+import uuid
+from datetime import datetime, timezone
+from typing import Any
+
+import structlog
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from com.qode.qrew.v1.service.core.infra.errors import DomainError
+from com.qode.qrew.v1.service.core.locking import redlock
+from com.qode.qrew.v1.service.core.observability import traced
+from com.qode.qrew.v1.service.core.outbox import publish_via_outbox
+from com.qode.qrew.v1.service.models.audit.audit import AuditAction
+from com.qode.qrew.v1.service.models.event import Event, EventStatus
+from com.qode.qrew.v1.service.models.organisation import Organisation
+from com.qode.qrew.v1.service.models.venue import Venue
+from com.qode.qrew.v1.service.repositories.event import EventRepository
+from com.qode.qrew.v1.service.repositories.organisation import OrganisationRepository
+from com.qode.qrew.v1.service.repositories.venue import VenueRepository
+from com.qode.qrew.v1.service.services.audit import AuditService
+
+logger = structlog.get_logger(__name__)
+
+_MUTABLE_FIELDS: frozenset[str] = frozenset(
+    {
+        "name",
+        "description",
+        "starts_at",
+        "ends_at",
+        "sale_starts_at",
+        "sale_ends_at",
+        "max_tickets_per_user",
+    }
+)
+
+
+class EventError(DomainError):
+    """Raised when an event operation fails a domain rule."""
+
+
+def _validate_windows(
+    *,
+    starts_at: datetime,
+    ends_at: datetime,
+    sale_starts_at: datetime,
+    sale_ends_at: datetime,
+) -> None:
+    if starts_at >= ends_at:
+        raise EventError("Event must start before it ends", field="starts_at")
+    if sale_starts_at >= sale_ends_at:
+        raise EventError("Sale must start before it ends", field="sale_starts_at")
+    if sale_ends_at > starts_at:
+        raise EventError(
+            "Sale must close before the event starts", field="sale_ends_at"
+        )
+
+
+def _validate_max_tickets(value: int) -> None:
+    if value < 1 or value > 20:
+        raise EventError(
+            "max_tickets_per_user must be between 1 and 20",
+            field="max_tickets_per_user",
+        )
+
+
+class EventService:
+    """Business logic for the event aggregate."""
+
+    def __init__(
+        self,
+        session: AsyncSession,
+        repo: EventRepository,
+        org_repo: OrganisationRepository,
+        venue_repo: VenueRepository,
+        audit: AuditService,
+    ) -> None:
+        self._session = session
+        self._repo = repo
+        self._org_repo = org_repo
+        self._venue_repo = venue_repo
+        self._audit = audit
+
+    async def _load_organisation(self, organisation_id: uuid.UUID) -> Organisation:
+        org = await self._org_repo.get_by_id(organisation_id)
+        if org is None:
+            raise EventError("Organisation not found", field="organisation_id")
+        return org
+
+    async def _load_venue(self, venue_id: uuid.UUID) -> Venue:
+        venue = await self._venue_repo.get_by_id(venue_id)
+        if venue is None:
+            raise EventError("Venue not found", field="venue_id")
+        return venue
+
+    @traced("event.create")
+    async def create_event(
+        self,
+        *,
+        actor_id: uuid.UUID,
+        organisation_id: uuid.UUID,
+        venue_id: uuid.UUID,
+        name: str,
+        description: str | None,
+        starts_at: datetime,
+        ends_at: datetime,
+        sale_starts_at: datetime,
+        sale_ends_at: datetime,
+        max_tickets_per_user: int,
+    ) -> Event:
+        _validate_windows(
+            starts_at=starts_at,
+            ends_at=ends_at,
+            sale_starts_at=sale_starts_at,
+            sale_ends_at=sale_ends_at,
+        )
+        _validate_max_tickets(max_tickets_per_user)
+        org = await self._load_organisation(organisation_id)
+        venue = await self._load_venue(venue_id)
+        event = Event(
+            organisation_id=org.id,
+            venue_id=venue.id,
+            name=name,
+            description=description,
+            starts_at=starts_at,
+            ends_at=ends_at,
+            sale_starts_at=sale_starts_at,
+            sale_ends_at=sale_ends_at,
+            max_tickets_per_user=max_tickets_per_user,
+            status=EventStatus.draft,
+            organiser_name=org.name,
+            venue_city=venue.city,
+        )
+        event = await self._repo.insert(event)
+        await self._record(
+            AuditAction.EVENT_CREATED,
+            actor_id=actor_id,
+            event_id=event.id,
+            payload={"name": event.name, "organisation_id": str(org.id)},
+        )
+        return event
+
+    @traced("event.update")
+    async def update_event(
+        self,
+        *,
+        actor_id: uuid.UUID,
+        event_id: uuid.UUID,
+        changes: dict[str, Any],
+    ) -> Event:
+        event = await self._repo.get_by_id(event_id)
+        if event is None:
+            raise EventError("Event not found", field="event_id")
+        if event.status != EventStatus.draft:
+            raise EventError("Only draft events can be edited", field="status")
+        unknown = set(changes) - _MUTABLE_FIELDS
+        if unknown:
+            raise EventError(f"Cannot edit fields: {sorted(unknown)}", field=None)
+        for key, value in changes.items():
+            setattr(event, key, value)
+        _validate_windows(
+            starts_at=event.starts_at,
+            ends_at=event.ends_at,
+            sale_starts_at=event.sale_starts_at,
+            sale_ends_at=event.sale_ends_at,
+        )
+        _validate_max_tickets(event.max_tickets_per_user)
+        await self._repo.flush()
+        await self._record(
+            AuditAction.EVENT_UPDATED,
+            actor_id=actor_id,
+            event_id=event.id,
+            payload={"fields": sorted(changes.keys())},
+        )
+        return event
+
+    @traced("event.publish")
+    async def publish_event(self, *, actor_id: uuid.UUID, event_id: uuid.UUID) -> Event:
+        async with redlock(f"event:{event_id}:lifecycle", ttl_seconds=10):
+            event = await self._repo.get_by_id(event_id)
+            if event is None:
+                raise EventError("Event not found", field="event_id")
+            if event.status == EventStatus.published:
+                return event
+            if event.status != EventStatus.draft:
+                raise EventError("Only draft events can be published", field="status")
+            event.status = EventStatus.published
+            event.published_at = datetime.now(timezone.utc)
+            await self._repo.flush()
+            await publish_via_outbox(
+                self._session,
+                aggregate_type="event",
+                aggregate_id=str(event.id),
+                job_name="search.reindex_event",
+                payload={"event_id": str(event.id)},
+            )
+            await self._record(
+                AuditAction.EVENT_PUBLISHED,
+                actor_id=actor_id,
+                event_id=event.id,
+                payload={"organisation_id": str(event.organisation_id)},
+            )
+            return event
+
+    @traced("event.cancel")
+    async def cancel_event(self, *, actor_id: uuid.UUID, event_id: uuid.UUID) -> Event:
+        async with redlock(f"event:{event_id}:lifecycle", ttl_seconds=10):
+            event = await self._repo.get_by_id(event_id)
+            if event is None:
+                raise EventError("Event not found", field="event_id")
+            if event.status == EventStatus.cancelled:
+                return event
+            event.status = EventStatus.cancelled
+            event.cancelled_at = datetime.now(timezone.utc)
+            await self._repo.flush()
+            await publish_via_outbox(
+                self._session,
+                aggregate_type="event",
+                aggregate_id=str(event.id),
+                job_name="notifications.event_cancelled",
+                payload={
+                    "event_id": str(event.id),
+                    "organisation_id": str(event.organisation_id),
+                },
+            )
+            await publish_via_outbox(
+                self._session,
+                aggregate_type="event",
+                aggregate_id=str(event.id),
+                job_name="search.reindex_event",
+                payload={"event_id": str(event.id)},
+            )
+            await self._record(
+                AuditAction.EVENT_CANCELLED,
+                actor_id=actor_id,
+                event_id=event.id,
+                payload={"organisation_id": str(event.organisation_id)},
+            )
+            return event
+
+    async def _record(
+        self,
+        action: AuditAction,
+        *,
+        actor_id: uuid.UUID,
+        event_id: uuid.UUID,
+        payload: dict[str, Any],
+    ) -> None:
+        try:
+            await self._audit.record(
+                action=action,
+                actor_id=actor_id,
+                entity_type="event",
+                entity_id=str(event_id),
+                payload=payload,
+            )
+        except Exception:
+            await logger.awarning("audit_write_failed", action=action)

--- a/api/tests/v1/event/service_test.py
+++ b/api/tests/v1/event/service_test.py
@@ -1,0 +1,168 @@
+import uuid
+from datetime import datetime, timedelta, timezone
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from com.qode.qrew.v1.service.models.event import Event, EventStatus
+from com.qode.qrew.v1.service.services.event import EventError, EventService
+
+
+def _times() -> dict[str, datetime]:
+    now = datetime(2026, 7, 1, 12, 0, tzinfo=timezone.utc)
+    return {
+        "sale_starts_at": now,
+        "sale_ends_at": now + timedelta(days=5),
+        "starts_at": now + timedelta(days=10),
+        "ends_at": now + timedelta(days=10, hours=4),
+    }
+
+
+_DEFAULT = object()
+
+
+def _service(
+    *,
+    org: Any = _DEFAULT,
+    venue: Any = _DEFAULT,
+    existing_event: Event | None = None,
+) -> tuple[EventService, MagicMock, MagicMock]:
+    if org is _DEFAULT:
+        org = MagicMock(id=uuid.uuid4())
+        org.name = "Live Nation"
+    if venue is _DEFAULT:
+        venue = MagicMock(id=uuid.uuid4(), city="London")
+    session = MagicMock()
+    repo = MagicMock()
+
+    async def _insert(event: Event) -> Event:
+        event.id = uuid.uuid4()
+        event.created_at = datetime.now(timezone.utc)
+        return event
+
+    repo.insert = AsyncMock(side_effect=_insert)
+    repo.flush = AsyncMock()
+    repo.get_by_id = AsyncMock(return_value=existing_event)
+
+    org_repo = MagicMock()
+    org_repo.get_by_id = AsyncMock(return_value=org)
+    venue_repo = MagicMock()
+    venue_repo.get_by_id = AsyncMock(return_value=venue)
+
+    audit = MagicMock()
+    audit.record = AsyncMock()
+
+    service = EventService(session, repo, org_repo, venue_repo, audit)
+    return service, repo, audit
+
+
+def _create_kwargs(**overrides: Any) -> dict[str, Any]:
+    base: dict[str, Any] = {
+        "actor_id": uuid.uuid4(),
+        "organisation_id": uuid.uuid4(),
+        "venue_id": uuid.uuid4(),
+        "name": "Concert",
+        "description": "Live show",
+        "max_tickets_per_user": 4,
+    }
+    base.update(_times())
+    base.update(overrides)
+    return base
+
+
+async def test_create_event_snapshots_org_and_venue() -> None:
+    org = MagicMock(id=uuid.uuid4())
+    org.name = "Live Nation"
+    venue = MagicMock(id=uuid.uuid4(), city="London")
+    service, _repo, audit = _service(org=org, venue=venue)
+    event = await service.create_event(**_create_kwargs())
+    assert event.organiser_name == "Live Nation"
+    assert event.venue_city == "London"
+    assert event.status == EventStatus.draft
+    audit.record.assert_awaited_once()
+
+
+async def test_create_event_rejects_when_sale_does_not_close_before_start() -> None:
+    service, *_ = _service()
+    times = _times()
+    times["sale_ends_at"] = times["starts_at"] + timedelta(hours=1)
+    kwargs = _create_kwargs(**times)
+    with pytest.raises(EventError, match="Sale must close"):
+        await service.create_event(**kwargs)
+
+
+async def test_create_event_rejects_inverted_event_window() -> None:
+    service, *_ = _service()
+    times = _times()
+    times["ends_at"] = times["starts_at"] - timedelta(hours=1)
+    times["sale_ends_at"] = times["ends_at"] - timedelta(hours=1)
+    kwargs = _create_kwargs(**times)
+    with pytest.raises(EventError, match="before it ends"):
+        await service.create_event(**kwargs)
+
+
+async def test_create_event_rejects_max_tickets_out_of_range() -> None:
+    service, *_ = _service()
+    with pytest.raises(EventError, match="max_tickets_per_user"):
+        await service.create_event(**_create_kwargs(max_tickets_per_user=21))
+
+
+async def test_create_event_requires_existing_org() -> None:
+    service, *_ = _service(org=None)
+    with pytest.raises(EventError, match="Organisation"):
+        await service.create_event(**_create_kwargs())
+
+
+async def test_create_event_requires_existing_venue() -> None:
+    service, *_ = _service(venue=None)
+    with pytest.raises(EventError, match="Venue"):
+        await service.create_event(**_create_kwargs())
+
+
+async def test_update_event_only_allowed_for_drafts() -> None:
+    times = _times()
+    event = Event(
+        id=uuid.uuid4(),
+        organisation_id=uuid.uuid4(),
+        venue_id=uuid.uuid4(),
+        name="x",
+        description=None,
+        starts_at=times["starts_at"],
+        ends_at=times["ends_at"],
+        sale_starts_at=times["sale_starts_at"],
+        sale_ends_at=times["sale_ends_at"],
+        max_tickets_per_user=4,
+        status=EventStatus.published,
+        organiser_name="o",
+        venue_city="c",
+    )
+    service, *_ = _service(existing_event=event)
+    with pytest.raises(EventError, match="draft"):
+        await service.update_event(
+            actor_id=uuid.uuid4(), event_id=event.id, changes={"name": "y"}
+        )
+
+
+async def test_update_event_rejects_unknown_field() -> None:
+    times = _times()
+    event = Event(
+        id=uuid.uuid4(),
+        organisation_id=uuid.uuid4(),
+        venue_id=uuid.uuid4(),
+        name="x",
+        description=None,
+        starts_at=times["starts_at"],
+        ends_at=times["ends_at"],
+        sale_starts_at=times["sale_starts_at"],
+        sale_ends_at=times["sale_ends_at"],
+        max_tickets_per_user=4,
+        status=EventStatus.draft,
+        organiser_name="o",
+        venue_city="c",
+    )
+    service, *_ = _service(existing_event=event)
+    with pytest.raises(EventError, match="Cannot edit"):
+        await service.update_event(
+            actor_id=uuid.uuid4(), event_id=event.id, changes={"status": "published"}
+        )

--- a/api/tests/v1/search/tsvector_test.py
+++ b/api/tests/v1/search/tsvector_test.py
@@ -49,13 +49,16 @@ def test_update_one_sql_binds_row_id() -> None:
 
 
 def test_create_trigger_sql_references_new_columns() -> None:
-    sql = create_trigger_sql(_events_config())
-    assert "NEW.name" in sql
-    assert "NEW.description" in sql
-    assert "events_search_vector_trigger" in sql
+    statements = create_trigger_sql(_events_config())
+    joined = " ".join(statements)
+    assert "NEW.name" in joined
+    assert "NEW.description" in joined
+    assert "events_search_vector_trigger" in joined
+    assert len(statements) >= 2
 
 
 def test_drop_trigger_sql_drops_function_and_trigger() -> None:
-    sql = drop_trigger_sql(_events_config())
-    assert "DROP TRIGGER IF EXISTS" in sql
-    assert "DROP FUNCTION IF EXISTS" in sql
+    statements = drop_trigger_sql(_events_config())
+    joined = " ".join(statements)
+    assert "DROP TRIGGER IF EXISTS" in joined
+    assert "DROP FUNCTION IF EXISTS" in joined


### PR DESCRIPTION
## Summary

Lands the headline aggregate of the catalog.

An event belongs to one organisation, references one venue, carries a publishable lifecycle and lights up the tsvector search infrastructure that has been waiting for a real model.

The model holds two intentional denormalisations: `organiser_name` and `venue_city` are snapshotted at create time.

## Verification

- `api/tests/v1/event/service_test.py`

## Issue Reference

Closes [QRW-148](https://github.com/cristiangilsanz/qrew/issues/148)

## Checklist
- [x] I confirm that this PR follows the project's established coding standards.