### PR TITLE
feat: add ticket types with capacity and pricing under events

### DIFF
--- a/api/alembic/versions/e2f3a4b5c6d7_2026_06_08_add_ticket_types_table.py
+++ b/api/alembic/versions/e2f3a4b5c6d7_2026_06_08_add_ticket_types_table.py
@@ -1,0 +1,75 @@
+"""2026_06_08_add_ticket_types_table
+
+Revision ID: e2f3a4b5c6d7
+Revises: d1e2f3a4b5c6
+Create Date: 2026-06-08 03:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision: str = "e2f3a4b5c6d7"
+down_revision: str | None = "d1e2f3a4b5c6"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "ticket_types",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column(
+            "event_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("events.id", ondelete="RESTRICT"),
+            nullable=False,
+        ),
+        sa.Column("name", sa.String(32), nullable=False),
+        sa.Column("description", sa.Text, nullable=True),
+        sa.Column("capacity", sa.Integer, nullable=False),
+        sa.Column("reserved_count", sa.Integer, nullable=False, server_default="0"),
+        sa.Column("price_cents", sa.Integer, nullable=False),
+        sa.Column("currency", sa.String(3), nullable=False),
+        sa.Column("position", sa.Integer, nullable=False, server_default="0"),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column("deleted_at", sa.DateTime(timezone=True), nullable=True),
+        sa.UniqueConstraint("event_id", "name", name="uq_ticket_types_event_id_name"),
+        sa.CheckConstraint(
+            "capacity >= 1 AND capacity <= 100000",
+            name="ck_ticket_types_capacity",
+        ),
+        sa.CheckConstraint(
+            "reserved_count >= 0 AND reserved_count <= capacity",
+            name="ck_ticket_types_reserved_count",
+        ),
+        sa.CheckConstraint(
+            "price_cents >= 0 AND price_cents <= 10000000",
+            name="ck_ticket_types_price_cents",
+        ),
+    )
+    op.create_index("ix_ticket_types_event_id", "ticket_types", ["event_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_ticket_types_event_id", table_name="ticket_types")
+    op.drop_table("ticket_types")

--- a/api/src/com/qode/qrew/v1/service/models/audit/audit.py
+++ b/api/src/com/qode/qrew/v1/service/models/audit/audit.py
@@ -65,6 +65,9 @@ class AuditAction(enum.StrEnum):
     EVENT_UPDATED = "event_updated"
     EVENT_PUBLISHED = "event_published"
     EVENT_CANCELLED = "event_cancelled"
+    TICKET_TYPE_CREATED = "ticket_type_created"  # noqa: S105
+    TICKET_TYPE_UPDATED = "ticket_type_updated"  # noqa: S105
+    TICKET_TYPE_DELETED = "ticket_type_deleted"  # noqa: S105
 
 
 class AuditEvent(Base):

--- a/api/src/com/qode/qrew/v1/service/models/ticket_type/__init__.py
+++ b/api/src/com/qode/qrew/v1/service/models/ticket_type/__init__.py
@@ -1,0 +1,3 @@
+from com.qode.qrew.v1.service.models.ticket_type.ticket_type import TicketType
+
+__all__ = ["TicketType"]

--- a/api/src/com/qode/qrew/v1/service/models/ticket_type/ticket_type.py
+++ b/api/src/com/qode/qrew/v1/service/models/ticket_type/ticket_type.py
@@ -1,0 +1,68 @@
+import uuid
+from datetime import datetime
+
+from sqlalchemy import (
+    CheckConstraint,
+    DateTime,
+    ForeignKey,
+    Index,
+    Integer,
+    String,
+    Text,
+    UniqueConstraint,
+    func,
+)
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from com.qode.qrew.v1.service.core.infra.database import Base
+
+
+class TicketType(Base):
+    __tablename__ = "ticket_types"
+    __table_args__ = (
+        UniqueConstraint("event_id", "name", name="uq_ticket_types_event_id_name"),
+        CheckConstraint(
+            "capacity >= 1 AND capacity <= 100000",
+            name="ck_ticket_types_capacity",
+        ),
+        CheckConstraint(
+            "reserved_count >= 0 AND reserved_count <= capacity",
+            name="ck_ticket_types_reserved_count",
+        ),
+        CheckConstraint(
+            "price_cents >= 0 AND price_cents <= 10000000",
+            name="ck_ticket_types_price_cents",
+        ),
+        Index("ix_ticket_types_event_id", "event_id"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    event_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("events.id", ondelete="RESTRICT"),
+        nullable=False,
+    )
+    name: Mapped[str] = mapped_column(String(32), nullable=False)
+    description: Mapped[str | None] = mapped_column(Text, nullable=True)
+    capacity: Mapped[int] = mapped_column(Integer, nullable=False)
+    reserved_count: Mapped[int] = mapped_column(
+        Integer, nullable=False, server_default="0"
+    )
+    price_cents: Mapped[int] = mapped_column(Integer, nullable=False)
+    currency: Mapped[str] = mapped_column(String(3), nullable=False)
+    position: Mapped[int] = mapped_column(Integer, nullable=False, server_default="0")
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
+    )
+    deleted_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )

--- a/api/src/com/qode/qrew/v1/service/repositories/ticket_type/__init__.py
+++ b/api/src/com/qode/qrew/v1/service/repositories/ticket_type/__init__.py
@@ -1,0 +1,5 @@
+from com.qode.qrew.v1.service.repositories.ticket_type.ticket_type import (
+    TicketTypeRepository,
+)
+
+__all__ = ["TicketTypeRepository"]

--- a/api/src/com/qode/qrew/v1/service/repositories/ticket_type/ticket_type.py
+++ b/api/src/com/qode/qrew/v1/service/repositories/ticket_type/ticket_type.py
@@ -1,0 +1,50 @@
+import uuid
+
+from sqlalchemy import Select, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from com.qode.qrew.v1.service.models.ticket_type import TicketType
+
+
+class TicketTypeRepository:
+    """Data access for the ticket_types table."""
+
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+
+    async def get_by_id(self, ticket_type_id: uuid.UUID) -> TicketType | None:
+        result = await self._session.execute(
+            select(TicketType).where(
+                TicketType.id == ticket_type_id,
+                TicketType.deleted_at.is_(None),
+            )
+        )
+        return result.scalar_one_or_none()
+
+    async def get_by_event_and_name(
+        self, event_id: uuid.UUID, name: str
+    ) -> TicketType | None:
+        result = await self._session.execute(
+            select(TicketType).where(
+                TicketType.event_id == event_id,
+                TicketType.name == name,
+                TicketType.deleted_at.is_(None),
+            )
+        )
+        return result.scalar_one_or_none()
+
+    async def insert(self, ticket_type: TicketType) -> TicketType:
+        self._session.add(ticket_type)
+        await self._session.flush()
+        await self._session.refresh(ticket_type)
+        return ticket_type
+
+    async def flush(self) -> None:
+        await self._session.flush()
+
+    def list_for_event_query(self, event_id: uuid.UUID) -> Select[tuple[TicketType]]:
+        return (
+            select(TicketType)
+            .where(TicketType.event_id == event_id, TicketType.deleted_at.is_(None))
+            .order_by(TicketType.position, TicketType.created_at)
+        )

--- a/api/src/com/qode/qrew/v1/service/routers/__init__.py
+++ b/api/src/com/qode/qrew/v1/service/routers/__init__.py
@@ -7,6 +7,7 @@ from com.qode.qrew.v1.service.routers.organisation import router as organisation
 from com.qode.qrew.v1.service.routers.search import router as search_router
 from com.qode.qrew.v1.service.routers.uploads import router as uploads_router
 from com.qode.qrew.v1.service.routers.event import router as event_router
+from com.qode.qrew.v1.service.routers.ticket_type import router as ticket_type_router
 from com.qode.qrew.v1.service.routers.venue import router as venue_router
 from com.qode.qrew.v1.service.settings import settings
 
@@ -19,6 +20,7 @@ router.include_router(search_router)
 router.include_router(organisation_router)
 router.include_router(venue_router)
 router.include_router(event_router)
+router.include_router(ticket_type_router)
 
 if settings.debug:
     from com.qode.qrew.v1.service.routers.dev import router as dev_router

--- a/api/src/com/qode/qrew/v1/service/routers/ticket_type.py
+++ b/api/src/com/qode/qrew/v1/service/routers/ticket_type.py
@@ -1,0 +1,241 @@
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException, Request, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from com.qode.qrew.v1.service.core.api import Page, clamp_limit, cursor_paginate
+from com.qode.qrew.v1.service.core.auth.auth import get_current_user
+from com.qode.qrew.v1.service.core.idempotency import idempotent
+from com.qode.qrew.v1.service.core.infra.database import get_db
+from com.qode.qrew.v1.service.core.infra.limiter import limiter
+from com.qode.qrew.v1.service.core.locking.errors import LockUnavailableError
+from com.qode.qrew.v1.service.models.auth.user import User
+from com.qode.qrew.v1.service.models.event import Event
+from com.qode.qrew.v1.service.models.organisation import (
+    OrganisationMember,
+    OrganisationRole,
+    role_rank,
+)
+from com.qode.qrew.v1.service.models.ticket_type import TicketType
+from com.qode.qrew.v1.service.repositories.event import EventRepository
+from com.qode.qrew.v1.service.repositories.organisation import (
+    OrganisationMemberRepository,
+)
+from com.qode.qrew.v1.service.repositories.ticket_type import TicketTypeRepository
+from com.qode.qrew.v1.service.schemas.ticket_type import (
+    TicketTypeCreateRequest,
+    TicketTypeResponse,
+    TicketTypeUpdateRequest,
+)
+from com.qode.qrew.v1.service.services.audit import AuditService
+from com.qode.qrew.v1.service.services.ticket_type import (
+    TicketTypeError,
+    TicketTypeService,
+)
+
+router = APIRouter(prefix="/events/{event_id}/ticket-types", tags=["ticket-types"])
+
+
+def _service(db: AsyncSession) -> TicketTypeService:
+    return TicketTypeService(
+        EventRepository(db), TicketTypeRepository(db), AuditService()
+    )
+
+
+def _to_response(ticket_type: TicketType) -> TicketTypeResponse:
+    return TicketTypeResponse(
+        id=ticket_type.id,
+        event_id=ticket_type.event_id,
+        name=ticket_type.name,
+        description=ticket_type.description,
+        capacity=ticket_type.capacity,
+        reserved_count=ticket_type.reserved_count,
+        available=ticket_type.capacity - ticket_type.reserved_count,
+        price_cents=ticket_type.price_cents,
+        currency=ticket_type.currency,
+        position=ticket_type.position,
+        created_at=ticket_type.created_at,
+    )
+
+
+def _domain_to_http(error: TicketTypeError) -> HTTPException:
+    code = (
+        status.HTTP_404_NOT_FOUND
+        if error.field in {"event_id", "ticket_type_id"}
+        else status.HTTP_409_CONFLICT
+        if error.field == "name"
+        else status.HTTP_400_BAD_REQUEST
+    )
+    return HTTPException(
+        status_code=code,
+        detail={"message": error.message, "field": error.field},
+    )
+
+
+async def _load_event_for_manager(
+    db: AsyncSession, event_id: uuid.UUID, user: User
+) -> tuple[Event, OrganisationMember]:
+    """Load the event and verify the caller is a manager+ in its organisation."""
+    event = await EventRepository(db).get_by_id(event_id)
+    if event is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={"message": "Event not found", "field": "event_id"},
+        )
+    member = await OrganisationMemberRepository(db).get(event.organisation_id, user.id)
+    if member is None or role_rank(member.role) < role_rank(OrganisationRole.manager):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail={
+                "message": "Not a manager of this organisation",
+                "field": None,
+            },
+        )
+    return event, member
+
+
+@router.post(
+    "",
+    response_model=TicketTypeResponse,
+    status_code=status.HTTP_201_CREATED,
+    summary="Create a ticket type under an event",
+)
+@limiter.limit("60/hour")  # type: ignore[misc]
+@idempotent(scope="user", ttl_seconds=300)
+async def create_ticket_type(
+    request: Request,
+    event_id: uuid.UUID,
+    body: TicketTypeCreateRequest,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> TicketTypeResponse:
+    """Create a new ticket tier under an event."""
+    del request
+    _, actor = await _load_event_for_manager(db, event_id, current_user)
+    try:
+        ticket_type = await _service(db).create(
+            actor_id=actor.user_id,
+            event_id=event_id,
+            name=body.name,
+            description=body.description,
+            capacity=body.capacity,
+            price_cents=body.price_cents,
+            currency=body.currency,
+            position=body.position,
+        )
+    except TicketTypeError as exc:
+        raise _domain_to_http(exc) from exc
+    except LockUnavailableError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={
+                "message": "Another ticket-type change is in progress",
+                "field": None,
+            },
+        ) from exc
+    return _to_response(ticket_type)
+
+
+@router.patch(
+    "/{ticket_type_id}",
+    response_model=TicketTypeResponse,
+    status_code=status.HTTP_200_OK,
+    summary="Edit a ticket type",
+)
+@limiter.limit("60/hour")  # type: ignore[misc]
+@idempotent(scope="user", ttl_seconds=300)
+async def update_ticket_type(
+    request: Request,
+    event_id: uuid.UUID,
+    ticket_type_id: uuid.UUID,
+    body: TicketTypeUpdateRequest,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> TicketTypeResponse:
+    """Edit a ticket tier. Capacity may only increase."""
+    del request
+    _, actor = await _load_event_for_manager(db, event_id, current_user)
+    changes = body.model_dump(exclude_unset=True)
+    try:
+        ticket_type = await _service(db).update(
+            actor_id=actor.user_id,
+            event_id=event_id,
+            ticket_type_id=ticket_type_id,
+            changes=changes,
+        )
+    except TicketTypeError as exc:
+        raise _domain_to_http(exc) from exc
+    except LockUnavailableError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={
+                "message": "Another ticket-type change is in progress",
+                "field": None,
+            },
+        ) from exc
+    return _to_response(ticket_type)
+
+
+@router.delete(
+    "/{ticket_type_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    summary="Soft-delete a ticket type",
+)
+@limiter.limit("60/hour")  # type: ignore[misc]
+async def delete_ticket_type(
+    request: Request,
+    event_id: uuid.UUID,
+    ticket_type_id: uuid.UUID,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> None:
+    """Soft-delete a ticket tier; rejected if any reservations are live."""
+    del request
+    _, actor = await _load_event_for_manager(db, event_id, current_user)
+    try:
+        await _service(db).delete(
+            actor_id=actor.user_id,
+            event_id=event_id,
+            ticket_type_id=ticket_type_id,
+        )
+    except TicketTypeError as exc:
+        raise _domain_to_http(exc) from exc
+    except LockUnavailableError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={
+                "message": "Another ticket-type change is in progress",
+                "field": None,
+            },
+        ) from exc
+
+
+@router.get(
+    "",
+    response_model=Page[TicketTypeResponse],
+    status_code=status.HTTP_200_OK,
+    summary="List ticket types for an event",
+)
+@limiter.limit("120/minute")  # type: ignore[misc]
+async def list_ticket_types(
+    request: Request,
+    event_id: uuid.UUID,
+    cursor: str | None = None,
+    limit: int = 20,
+    db: AsyncSession = Depends(get_db),
+) -> Page[TicketTypeResponse]:
+    """List the public ticket tiers of an event."""
+    del request
+    page_limit = clamp_limit(limit, default=20)
+    stmt = TicketTypeRepository(db).list_for_event_query(event_id)
+    rows, next_cursor = await cursor_paginate(
+        db,
+        stmt,
+        sort_column=TicketType.position,
+        id_column=TicketType.id,
+        limit=page_limit,
+        cursor=cursor,
+    )
+    return Page[TicketTypeResponse](
+        items=[_to_response(row) for row in rows], next_cursor=next_cursor
+    )

--- a/api/src/com/qode/qrew/v1/service/schemas/ticket_type/__init__.py
+++ b/api/src/com/qode/qrew/v1/service/schemas/ticket_type/__init__.py
@@ -1,0 +1,11 @@
+from com.qode.qrew.v1.service.schemas.ticket_type.ticket_type import (
+    TicketTypeCreateRequest,
+    TicketTypeResponse,
+    TicketTypeUpdateRequest,
+)
+
+__all__ = [
+    "TicketTypeCreateRequest",
+    "TicketTypeResponse",
+    "TicketTypeUpdateRequest",
+]

--- a/api/src/com/qode/qrew/v1/service/schemas/ticket_type/ticket_type.py
+++ b/api/src/com/qode/qrew/v1/service/schemas/ticket_type/ticket_type.py
@@ -1,0 +1,35 @@
+import uuid
+from datetime import datetime
+
+from pydantic import BaseModel, Field
+
+
+class TicketTypeCreateRequest(BaseModel):
+    name: str = Field(..., min_length=1, max_length=32)
+    description: str | None = Field(default=None, max_length=2000)
+    capacity: int = Field(..., ge=1, le=100_000)
+    price_cents: int = Field(..., ge=0, le=10_000_000)
+    currency: str = Field(..., min_length=3, max_length=3)
+    position: int = Field(default=0, ge=0)
+
+
+class TicketTypeUpdateRequest(BaseModel):
+    name: str | None = Field(default=None, min_length=1, max_length=32)
+    description: str | None = Field(default=None, max_length=2000)
+    capacity: int | None = Field(default=None, ge=1, le=100_000)
+    price_cents: int | None = Field(default=None, ge=0, le=10_000_000)
+    position: int | None = Field(default=None, ge=0)
+
+
+class TicketTypeResponse(BaseModel):
+    id: uuid.UUID
+    event_id: uuid.UUID
+    name: str
+    description: str | None
+    capacity: int
+    reserved_count: int
+    available: int
+    price_cents: int
+    currency: str
+    position: int
+    created_at: datetime

--- a/api/src/com/qode/qrew/v1/service/services/ticket_type/__init__.py
+++ b/api/src/com/qode/qrew/v1/service/services/ticket_type/__init__.py
@@ -1,0 +1,7 @@
+from com.qode.qrew.v1.service.services.ticket_type.ticket_type import (
+    ALLOWED_CURRENCIES,
+    TicketTypeError,
+    TicketTypeService,
+)
+
+__all__ = ["ALLOWED_CURRENCIES", "TicketTypeError", "TicketTypeService"]

--- a/api/src/com/qode/qrew/v1/service/services/ticket_type/ticket_type.py
+++ b/api/src/com/qode/qrew/v1/service/services/ticket_type/ticket_type.py
@@ -1,0 +1,214 @@
+import re
+import uuid
+from datetime import datetime, timezone
+from typing import Any
+
+import structlog
+
+from com.qode.qrew.v1.service.core.infra.errors import DomainError
+from com.qode.qrew.v1.service.core.locking import redlock
+from com.qode.qrew.v1.service.core.observability import traced
+from com.qode.qrew.v1.service.models.audit.audit import AuditAction
+from com.qode.qrew.v1.service.models.event import EventStatus
+from com.qode.qrew.v1.service.models.ticket_type import TicketType
+from com.qode.qrew.v1.service.repositories.event import EventRepository
+from com.qode.qrew.v1.service.repositories.ticket_type import TicketTypeRepository
+from com.qode.qrew.v1.service.services.audit import AuditService
+
+logger = structlog.get_logger(__name__)
+
+_NAME_PATTERN = re.compile(r"^[a-z][a-z0-9_]{0,31}$")
+ALLOWED_CURRENCIES: frozenset[str] = frozenset({"EUR", "USD", "GBP"})
+_MUTABLE_FIELDS: frozenset[str] = frozenset(
+    {"name", "description", "price_cents", "position", "capacity"}
+)
+
+
+class TicketTypeError(DomainError):
+    """Raised when a ticket type operation fails a domain rule."""
+
+
+def _validate_name(name: str) -> None:
+    if not _NAME_PATTERN.match(name):
+        raise TicketTypeError(
+            "Name must be lowercase letters, digits or underscores",
+            field="name",
+        )
+
+
+def _validate_capacity(capacity: int) -> None:
+    if capacity < 1 or capacity > 100_000:
+        raise TicketTypeError("Capacity must be between 1 and 100000", field="capacity")
+
+
+def _validate_price(price_cents: int) -> None:
+    if price_cents < 0 or price_cents > 10_000_000:
+        raise TicketTypeError(
+            "Price must be between 0 and 10000000 cents", field="price_cents"
+        )
+
+
+def _validate_currency(currency: str) -> None:
+    if currency not in ALLOWED_CURRENCIES:
+        raise TicketTypeError(
+            f"Currency must be one of {sorted(ALLOWED_CURRENCIES)}",
+            field="currency",
+        )
+
+
+class TicketTypeService:
+    """Business logic for the ticket-type aggregate."""
+
+    def __init__(
+        self,
+        event_repo: EventRepository,
+        repo: TicketTypeRepository,
+        audit: AuditService,
+    ) -> None:
+        self._event_repo = event_repo
+        self._repo = repo
+        self._audit = audit
+
+    @traced("ticket_type.create")
+    async def create(
+        self,
+        *,
+        actor_id: uuid.UUID,
+        event_id: uuid.UUID,
+        name: str,
+        description: str | None,
+        capacity: int,
+        price_cents: int,
+        currency: str,
+        position: int,
+    ) -> TicketType:
+        _validate_name(name)
+        _validate_capacity(capacity)
+        _validate_price(price_cents)
+        _validate_currency(currency)
+        async with redlock(f"event:{event_id}:ticket-types", ttl_seconds=10):
+            event = await self._event_repo.get_by_id(event_id)
+            if event is None:
+                raise TicketTypeError("Event not found", field="event_id")
+            if event.status == EventStatus.cancelled:
+                raise TicketTypeError(
+                    "Cannot add ticket types to a cancelled event",
+                    field="status",
+                )
+            existing = await self._repo.get_by_event_and_name(event_id, name)
+            if existing is not None:
+                raise TicketTypeError(
+                    "A ticket type with that name already exists",
+                    field="name",
+                )
+            ticket_type = TicketType(
+                event_id=event_id,
+                name=name,
+                description=description,
+                capacity=capacity,
+                reserved_count=0,
+                price_cents=price_cents,
+                currency=currency,
+                position=position,
+            )
+            ticket_type = await self._repo.insert(ticket_type)
+            await self._record(
+                AuditAction.TICKET_TYPE_CREATED,
+                actor_id=actor_id,
+                ticket_type_id=ticket_type.id,
+                payload={"event_id": str(event_id), "name": name},
+            )
+            return ticket_type
+
+    @traced("ticket_type.update")
+    async def update(
+        self,
+        *,
+        actor_id: uuid.UUID,
+        event_id: uuid.UUID,
+        ticket_type_id: uuid.UUID,
+        changes: dict[str, Any],
+    ) -> TicketType:
+        unknown = set(changes) - _MUTABLE_FIELDS
+        if unknown:
+            raise TicketTypeError(f"Cannot edit fields: {sorted(unknown)}", field=None)
+        async with redlock(f"event:{event_id}:ticket-types", ttl_seconds=10):
+            ticket_type = await self._repo.get_by_id(ticket_type_id)
+            if ticket_type is None or ticket_type.event_id != event_id:
+                raise TicketTypeError("Ticket type not found", field="ticket_type_id")
+            if "name" in changes:
+                _validate_name(changes["name"])
+                if changes["name"] != ticket_type.name:
+                    conflict = await self._repo.get_by_event_and_name(
+                        event_id, changes["name"]
+                    )
+                    if conflict is not None and conflict.id != ticket_type.id:
+                        raise TicketTypeError(
+                            "A ticket type with that name already exists",
+                            field="name",
+                        )
+            if "capacity" in changes:
+                _validate_capacity(changes["capacity"])
+                if changes["capacity"] < ticket_type.capacity:
+                    raise TicketTypeError(
+                        "Capacity can only increase; "
+                        "lower it by soft-deleting and re-creating the tier",
+                        field="capacity",
+                    )
+            if "price_cents" in changes:
+                _validate_price(changes["price_cents"])
+            for key, value in changes.items():
+                setattr(ticket_type, key, value)
+            await self._repo.flush()
+            await self._record(
+                AuditAction.TICKET_TYPE_UPDATED,
+                actor_id=actor_id,
+                ticket_type_id=ticket_type.id,
+                payload={"fields": sorted(changes.keys())},
+            )
+            return ticket_type
+
+    @traced("ticket_type.delete")
+    async def delete(
+        self,
+        *,
+        actor_id: uuid.UUID,
+        event_id: uuid.UUID,
+        ticket_type_id: uuid.UUID,
+    ) -> None:
+        async with redlock(f"event:{event_id}:ticket-types", ttl_seconds=10):
+            ticket_type = await self._repo.get_by_id(ticket_type_id)
+            if ticket_type is None or ticket_type.event_id != event_id:
+                raise TicketTypeError("Ticket type not found", field="ticket_type_id")
+            if ticket_type.reserved_count > 0:
+                raise TicketTypeError(
+                    "Cannot delete a tier with live reservations",
+                    field="reserved_count",
+                )
+            ticket_type.deleted_at = datetime.now(timezone.utc)
+            await self._repo.flush()
+            await self._record(
+                AuditAction.TICKET_TYPE_DELETED,
+                actor_id=actor_id,
+                ticket_type_id=ticket_type.id,
+                payload={"event_id": str(event_id)},
+            )
+
+    async def _record(
+        self,
+        action: AuditAction,
+        *,
+        actor_id: uuid.UUID,
+        ticket_type_id: uuid.UUID,
+        payload: dict[str, Any],
+    ) -> None:
+        try:
+            await self._audit.record(
+                action=action,
+                actor_id=actor_id,
+                entity_type="ticket_type",
+                entity_id=str(ticket_type_id),
+                payload=payload,
+            )
+        except Exception:
+            await logger.awarning("audit_write_failed", action=action)

--- a/api/tests/v1/ticket_type/service_test.py
+++ b/api/tests/v1/ticket_type/service_test.py
@@ -1,0 +1,176 @@
+import uuid
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import fakeredis.aioredis
+import pytest
+import pytest_asyncio
+
+from com.qode.qrew.v1.service.core.locking import lock as lock_module
+from com.qode.qrew.v1.service.models.event import EventStatus
+from com.qode.qrew.v1.service.models.ticket_type import TicketType
+from com.qode.qrew.v1.service.services.ticket_type import (
+    TicketTypeError,
+    TicketTypeService,
+)
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def _fake_redis_for_locks() -> Any:  # pyright: ignore[reportUnusedFunction]
+    """Swap the locking module's shared Redis client for an in-memory fake."""
+    fake = fakeredis.aioredis.FakeRedis()
+    previous = lock_module._ClientState.client  # pyright: ignore[reportPrivateUsage]
+    lock_module._ClientState.client = fake  # pyright: ignore[reportPrivateUsage]
+    try:
+        yield fake
+    finally:
+        await fake.aclose()
+        lock_module._ClientState.client = previous  # pyright: ignore[reportPrivateUsage]
+
+
+def _service(
+    *,
+    event_status: EventStatus = EventStatus.draft,
+    existing_named: TicketType | None = None,
+    existing_by_id: TicketType | None = None,
+) -> tuple[TicketTypeService, MagicMock, MagicMock]:
+    event_repo = MagicMock()
+    event = MagicMock(id=uuid.uuid4(), status=event_status)
+    event_repo.get_by_id = AsyncMock(return_value=event)
+
+    repo = MagicMock()
+    repo.get_by_event_and_name = AsyncMock(return_value=existing_named)
+    repo.get_by_id = AsyncMock(return_value=existing_by_id)
+
+    async def _insert(ticket_type: TicketType) -> TicketType:
+        ticket_type.id = uuid.uuid4()
+        return ticket_type
+
+    repo.insert = AsyncMock(side_effect=_insert)
+    repo.flush = AsyncMock()
+
+    audit = MagicMock()
+    audit.record = AsyncMock()
+    service = TicketTypeService(event_repo, repo, audit)
+    return service, repo, audit
+
+
+def _create_kwargs(**overrides: Any) -> dict[str, Any]:
+    base: dict[str, Any] = {
+        "actor_id": uuid.uuid4(),
+        "event_id": uuid.uuid4(),
+        "name": "general",
+        "description": "General admission",
+        "capacity": 500,
+        "price_cents": 5000,
+        "currency": "EUR",
+        "position": 0,
+    }
+    base.update(overrides)
+    return base
+
+
+async def test_create_persists_and_audits() -> None:
+    service, _repo, audit = _service()
+    ticket_type = await service.create(**_create_kwargs())
+    assert ticket_type.name == "general"
+    audit.record.assert_awaited_once()
+
+
+async def test_create_rejects_cancelled_event() -> None:
+    service, *_ = _service(event_status=EventStatus.cancelled)
+    with pytest.raises(TicketTypeError, match="cancelled"):
+        await service.create(**_create_kwargs())
+
+
+async def test_create_rejects_invalid_name() -> None:
+    service, *_ = _service()
+    with pytest.raises(TicketTypeError, match="lowercase"):
+        await service.create(**_create_kwargs(name="VIP!"))
+
+
+async def test_create_rejects_unsupported_currency() -> None:
+    service, *_ = _service()
+    with pytest.raises(TicketTypeError, match="Currency"):
+        await service.create(**_create_kwargs(currency="JPY"))
+
+
+async def test_create_rejects_duplicate_name() -> None:
+    existing = MagicMock(spec=TicketType)
+    service, *_ = _service(existing_named=existing)
+    with pytest.raises(TicketTypeError, match="already exists"):
+        await service.create(**_create_kwargs())
+
+
+def _ticket(**overrides: Any) -> TicketType:
+    base: dict[str, Any] = {
+        "id": uuid.uuid4(),
+        "event_id": uuid.uuid4(),
+        "name": "general",
+        "description": None,
+        "capacity": 100,
+        "reserved_count": 0,
+        "price_cents": 5000,
+        "currency": "EUR",
+        "position": 0,
+    }
+    base.update(overrides)
+    return TicketType(**base)
+
+
+async def test_update_refuses_lowering_capacity() -> None:
+    existing = _ticket(capacity=100)
+    service, *_ = _service(existing_by_id=existing)
+    with pytest.raises(TicketTypeError, match="only increase"):
+        await service.update(
+            actor_id=uuid.uuid4(),
+            event_id=existing.event_id,
+            ticket_type_id=existing.id,
+            changes={"capacity": 50},
+        )
+
+
+async def test_update_allows_raising_capacity() -> None:
+    existing = _ticket(capacity=100)
+    service, _repo, _audit = _service(existing_by_id=existing)
+    updated = await service.update(
+        actor_id=uuid.uuid4(),
+        event_id=existing.event_id,
+        ticket_type_id=existing.id,
+        changes={"capacity": 200},
+    )
+    assert updated.capacity == 200
+
+
+async def test_update_rejects_unknown_field() -> None:
+    existing = _ticket()
+    service, *_ = _service(existing_by_id=existing)
+    with pytest.raises(TicketTypeError, match="Cannot edit"):
+        await service.update(
+            actor_id=uuid.uuid4(),
+            event_id=existing.event_id,
+            ticket_type_id=existing.id,
+            changes={"reserved_count": 5},
+        )
+
+
+async def test_delete_blocked_when_reservations_exist() -> None:
+    existing = _ticket(reserved_count=1)
+    service, *_ = _service(existing_by_id=existing)
+    with pytest.raises(TicketTypeError, match="live reservations"):
+        await service.delete(
+            actor_id=uuid.uuid4(),
+            event_id=existing.event_id,
+            ticket_type_id=existing.id,
+        )
+
+
+async def test_delete_sets_deleted_at() -> None:
+    existing = _ticket(reserved_count=0)
+    service, _repo, _audit = _service(existing_by_id=existing)
+    await service.delete(
+        actor_id=uuid.uuid4(),
+        event_id=existing.event_id,
+        ticket_type_id=existing.id,
+    )
+    assert existing.deleted_at is not None


### PR DESCRIPTION
## Summary

Lands the ticket-type aggregate that reservations and payments will hang off.

A ticket type belongs to one event and carries name, description, capacity, reserved count, price in cents, ISO-4217 currency and a sort position. It's the contract the rest of the catalog reads for capacity, price and currency.

## Verification

- `api/tests/v1/ticket_type/service_test.py`

## Issue Reference

Closes [QRW-149](https://github.com/cristiangilsanz/qrew/issues/149)

## Checklist
- [x] I confirm that this PR follows the project's established coding standards.