### PR TITLE
feat: expose public catalog endpoints with cursor pagination and search

### DIFF
--- a/api/src/com/qode/qrew/v1/service/routers/__init__.py
+++ b/api/src/com/qode/qrew/v1/service/routers/__init__.py
@@ -7,6 +7,9 @@ from com.qode.qrew.v1.service.routers.organisation import router as organisation
 from com.qode.qrew.v1.service.routers.search import router as search_router
 from com.qode.qrew.v1.service.routers.uploads import router as uploads_router
 from com.qode.qrew.v1.service.routers.event import router as event_router
+from com.qode.qrew.v1.service.routers.public_catalog import (
+    router as public_catalog_router,
+)
 from com.qode.qrew.v1.service.routers.ticket_type import router as ticket_type_router
 from com.qode.qrew.v1.service.routers.venue import router as venue_router
 from com.qode.qrew.v1.service.settings import settings
@@ -21,6 +24,7 @@ router.include_router(organisation_router)
 router.include_router(venue_router)
 router.include_router(event_router)
 router.include_router(ticket_type_router)
+router.include_router(public_catalog_router)
 
 if settings.debug:
     from com.qode.qrew.v1.service.routers.dev import router as dev_router

--- a/api/src/com/qode/qrew/v1/service/routers/event.py
+++ b/api/src/com/qode/qrew/v1/service/routers/event.py
@@ -286,7 +286,7 @@ async def get_org_event(
     _actor: OrganisationMember = Depends(get_org_member(OrganisationRole.member)),
     db: AsyncSession = Depends(get_db),
 ) -> EventResponse:
-    """Organiser-side single event read; returns any status the caller owns."""
+    """Organiser-side single event read and returns any status the caller owns."""
     del request
     event = await EventRepository(db).get_by_id(event_id)
     if event is None or event.organisation_id != organisation_id:

--- a/api/src/com/qode/qrew/v1/service/routers/event.py
+++ b/api/src/com/qode/qrew/v1/service/routers/event.py
@@ -273,23 +273,23 @@ async def cancel_event(
 
 
 @router.get(
-    "/events/{event_id}",
+    "/organisations/{organisation_id}/events/{event_id}",
     response_model=EventResponse,
     status_code=status.HTTP_200_OK,
-    summary="Read a single event",
+    summary="Read a single event the caller's organisation owns",
 )
 @limiter.limit("120/minute")  # type: ignore[misc]
-async def get_event(
+async def get_org_event(
     request: Request,
+    organisation_id: uuid.UUID,
     event_id: uuid.UUID,
-    current_user: User = Depends(get_current_user),
+    _actor: OrganisationMember = Depends(get_org_member(OrganisationRole.member)),
     db: AsyncSession = Depends(get_db),
 ) -> EventResponse:
-    """Read a single event the caller can see."""
+    """Organiser-side single event read; returns any status the caller owns."""
     del request
-    del current_user
     event = await EventRepository(db).get_by_id(event_id)
-    if event is None:
+    if event is None or event.organisation_id != organisation_id:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail={"message": "Event not found", "field": "event_id"},

--- a/api/src/com/qode/qrew/v1/service/routers/public_catalog.py
+++ b/api/src/com/qode/qrew/v1/service/routers/public_catalog.py
@@ -1,0 +1,127 @@
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException, Request, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from com.qode.qrew.v1.service.core.infra.database import get_db
+from com.qode.qrew.v1.service.core.infra.limiter import limiter
+from com.qode.qrew.v1.service.models.event import EventStatus
+from com.qode.qrew.v1.service.repositories.event import EventRepository
+from com.qode.qrew.v1.service.repositories.organisation import OrganisationRepository
+from com.qode.qrew.v1.service.repositories.ticket_type import TicketTypeRepository
+from com.qode.qrew.v1.service.repositories.venue import VenueRepository
+from com.qode.qrew.v1.service.schemas.organisation import OrganisationPublicResponse
+from com.qode.qrew.v1.service.schemas.public_catalog import (
+    AvailabilityItem,
+    EventAvailabilityResponse,
+    PublicEventDetailResponse,
+    PublicTicketTypeItem,
+)
+from com.qode.qrew.v1.service.schemas.venue import VenuePublicResponse
+
+router = APIRouter(prefix="/events", tags=["public-catalog"])
+
+
+def _not_found() -> HTTPException:
+    return HTTPException(
+        status_code=status.HTTP_404_NOT_FOUND,
+        detail={"message": "Event not found", "field": "event_id"},
+    )
+
+
+@router.get(
+    "/{event_id}",
+    response_model=PublicEventDetailResponse,
+    status_code=status.HTTP_200_OK,
+    summary="Read a published event with embedded organisation, venue and tiers",
+)
+@limiter.limit("120/minute")  # type: ignore[misc]
+async def get_public_event(
+    request: Request,
+    event_id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
+) -> PublicEventDetailResponse:
+    """Return the public detail of a published event."""
+    del request
+    event = await EventRepository(db).get_by_id(event_id)
+    if event is None or event.status != EventStatus.published:
+        raise _not_found()
+    org = await OrganisationRepository(db).get_by_id(event.organisation_id)
+    venue = await VenueRepository(db).get_by_id(event.venue_id)
+    if org is None or venue is None:
+        raise _not_found()
+    stmt = TicketTypeRepository(db).list_for_event_query(event_id)
+    result = await db.execute(stmt)
+    tiers = result.scalars().all()
+    return PublicEventDetailResponse(
+        id=event.id,
+        name=event.name,
+        description=event.description,
+        starts_at=event.starts_at,
+        ends_at=event.ends_at,
+        sale_starts_at=event.sale_starts_at,
+        sale_ends_at=event.sale_ends_at,
+        max_tickets_per_user=event.max_tickets_per_user,
+        published_at=event.published_at,
+        organisation=OrganisationPublicResponse(
+            id=org.id, slug=org.slug, name=org.name, description=org.description
+        ),
+        venue=VenuePublicResponse(
+            id=venue.id,
+            name=venue.name,
+            city=venue.city,
+            country=venue.country,
+            latitude=venue.latitude,
+            longitude=venue.longitude,
+            geofence_radius_m=venue.geofence_radius_m,
+            timezone=venue.timezone,
+        ),
+        ticket_types=[
+            PublicTicketTypeItem(
+                id=tier.id,
+                name=tier.name,
+                description=tier.description,
+                capacity=tier.capacity,
+                reserved_count=tier.reserved_count,
+                available=tier.capacity - tier.reserved_count,
+                price_cents=tier.price_cents,
+                currency=tier.currency,
+                position=tier.position,
+            )
+            for tier in tiers
+        ],
+    )
+
+
+@router.get(
+    "/{event_id}/availability",
+    response_model=EventAvailabilityResponse,
+    status_code=status.HTTP_200_OK,
+    summary="Lightweight availability projection for an event",
+)
+@limiter.limit("120/minute")  # type: ignore[misc]
+async def get_event_availability(
+    request: Request,
+    event_id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
+) -> EventAvailabilityResponse:
+    """Return only the availability projection used by the pre-checkout pass."""
+    del request
+    event = await EventRepository(db).get_by_id(event_id)
+    if event is None or event.status != EventStatus.published:
+        raise _not_found()
+    stmt = TicketTypeRepository(db).list_for_event_query(event_id)
+    result = await db.execute(stmt)
+    tiers = result.scalars().all()
+    return EventAvailabilityResponse(
+        ticket_types=[
+            AvailabilityItem(
+                id=tier.id,
+                name=tier.name,
+                available=tier.capacity - tier.reserved_count,
+                price_cents=tier.price_cents,
+                currency=tier.currency,
+            )
+            for tier in tiers
+        ]
+    )

--- a/api/src/com/qode/qrew/v1/service/routers/search.py
+++ b/api/src/com/qode/qrew/v1/service/routers/search.py
@@ -36,12 +36,19 @@ async def _events_table_exists(db: AsyncSession) -> bool:
 
 
 @router.get(
+    "",
+    response_model=Page[EventSearchResult],
+    status_code=status.HTTP_200_OK,
+    summary="Public catalog list of events with cursor pagination and search",
+)
+@router.get(
     "/search",
     response_model=Page[EventSearchResult],
     status_code=status.HTTP_200_OK,
     summary="Search published events by text and filters",
+    include_in_schema=False,
 )
-@limiter.limit("60/minute")  # type: ignore[misc]
+@limiter.limit("120/minute")  # type: ignore[misc]
 async def search_events(
     request: Request,
     q: str | None = Query(default=None, max_length=256),
@@ -59,7 +66,7 @@ async def search_events(
     page_limit = min(page_limit, settings.search_max_limit)
 
     if not await _events_table_exists(db):
-        await logger.ainfo("search_events_skipped", reason="events_table_missing")
+        await logger.ainfo("events.search.miss", reason="events_table_missing")
         return Page[EventSearchResult](items=[], next_cursor=None)
 
     clause = build_search_clause(
@@ -120,4 +127,10 @@ async def search_events(
         )
         for row in rows
     ]
+    await logger.ainfo(
+        "events.search.indexed",
+        result_count=len(items),
+        has_query=q is not None,
+        page_limit=page_limit,
+    )
     return Page[EventSearchResult](items=items, next_cursor=next_cursor)

--- a/api/src/com/qode/qrew/v1/service/schemas/public_catalog/__init__.py
+++ b/api/src/com/qode/qrew/v1/service/schemas/public_catalog/__init__.py
@@ -1,0 +1,13 @@
+from com.qode.qrew.v1.service.schemas.public_catalog.public_catalog import (
+    AvailabilityItem,
+    EventAvailabilityResponse,
+    PublicEventDetailResponse,
+    PublicTicketTypeItem,
+)
+
+__all__ = [
+    "AvailabilityItem",
+    "EventAvailabilityResponse",
+    "PublicEventDetailResponse",
+    "PublicTicketTypeItem",
+]

--- a/api/src/com/qode/qrew/v1/service/schemas/public_catalog/public_catalog.py
+++ b/api/src/com/qode/qrew/v1/service/schemas/public_catalog/public_catalog.py
@@ -1,0 +1,46 @@
+import uuid
+from datetime import datetime
+
+from pydantic import BaseModel
+
+from com.qode.qrew.v1.service.schemas.organisation import OrganisationPublicResponse
+from com.qode.qrew.v1.service.schemas.venue import VenuePublicResponse
+
+
+class PublicTicketTypeItem(BaseModel):
+    id: uuid.UUID
+    name: str
+    description: str | None
+    capacity: int
+    reserved_count: int
+    available: int
+    price_cents: int
+    currency: str
+    position: int
+
+
+class PublicEventDetailResponse(BaseModel):
+    id: uuid.UUID
+    name: str
+    description: str | None
+    starts_at: datetime
+    ends_at: datetime
+    sale_starts_at: datetime
+    sale_ends_at: datetime
+    max_tickets_per_user: int
+    published_at: datetime | None
+    organisation: OrganisationPublicResponse
+    venue: VenuePublicResponse
+    ticket_types: list[PublicTicketTypeItem]
+
+
+class AvailabilityItem(BaseModel):
+    id: uuid.UUID
+    name: str
+    available: int
+    price_cents: int
+    currency: str
+
+
+class EventAvailabilityResponse(BaseModel):
+    ticket_types: list[AvailabilityItem]

--- a/api/tests/v1/public_catalog/router_test.py
+++ b/api/tests/v1/public_catalog/router_test.py
@@ -1,0 +1,223 @@
+import uuid
+from collections.abc import AsyncGenerator, Sequence
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest_asyncio
+from httpx import AsyncClient
+
+from com.qode.qrew.v1.service.core.infra.database import get_db
+from com.qode.qrew.v1.service.main import app
+from com.qode.qrew.v1.service.models.event import Event, EventStatus
+from com.qode.qrew.v1.service.models.organisation import Organisation
+from com.qode.qrew.v1.service.models.ticket_type import TicketType
+from com.qode.qrew.v1.service.models.venue import Venue
+
+
+def _event(status: EventStatus = EventStatus.published, **overrides: Any) -> Event:
+    now = datetime(2026, 7, 1, 12, 0, tzinfo=timezone.utc)
+    base: dict[str, Any] = {
+        "id": uuid.uuid4(),
+        "organisation_id": uuid.uuid4(),
+        "venue_id": uuid.uuid4(),
+        "name": "Concert",
+        "description": "Live show",
+        "starts_at": now + timedelta(days=10),
+        "ends_at": now + timedelta(days=10, hours=4),
+        "sale_starts_at": now,
+        "sale_ends_at": now + timedelta(days=5),
+        "max_tickets_per_user": 4,
+        "status": status,
+        "organiser_name": "Live Nation",
+        "venue_city": "London",
+        "published_at": now,
+        "cancelled_at": None,
+    }
+    base.update(overrides)
+    event = Event(**base)
+    event.created_at = now
+    event.updated_at = now
+    return event
+
+
+def _org(**overrides: Any) -> Organisation:
+    base: dict[str, Any] = {
+        "id": uuid.uuid4(),
+        "slug": "live-nation",
+        "name": "Live Nation",
+        "description": "Promoter",
+    }
+    base.update(overrides)
+    org = Organisation(**base)
+    org.created_at = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    return org
+
+
+def _venue(**overrides: Any) -> Venue:
+    base: dict[str, Any] = {
+        "id": uuid.uuid4(),
+        "name": "Wembley",
+        "address_line": "Olympic Way",
+        "city": "London",
+        "country": "GB",
+        "latitude": Decimal("51.555973"),
+        "longitude": Decimal("-0.279672"),
+        "geofence_radius_m": 300,
+        "timezone": "Europe/London",
+        "description": None,
+    }
+    base.update(overrides)
+    venue = Venue(**base)
+    venue.created_at = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    return venue
+
+
+def _tier(**overrides: Any) -> TicketType:
+    base: dict[str, Any] = {
+        "id": uuid.uuid4(),
+        "event_id": uuid.uuid4(),
+        "name": "general",
+        "description": None,
+        "capacity": 100,
+        "reserved_count": 25,
+        "price_cents": 5000,
+        "currency": "EUR",
+        "position": 0,
+    }
+    base.update(overrides)
+    tier = TicketType(**base)
+    tier.created_at = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    return tier
+
+
+def _install_db(
+    event: Event | None,
+    org: Organisation | None,
+    venue: Venue | None,
+    tiers: Sequence[TicketType],
+) -> None:
+    """Override get_db with a session whose repository lookups return the fixtures."""
+
+    class _Session:
+        async def execute(self, *_args: Any, **_kwargs: Any) -> Any:
+            scalars = MagicMock()
+            scalars.scalar_one_or_none = MagicMock()
+            target = self._scalar_one_or_none()
+            scalars.scalar_one_or_none.return_value = target
+            result = MagicMock()
+            result.scalar_one_or_none.return_value = target
+            scalars_obj = MagicMock()
+            scalars_obj.all.return_value = list(tiers)
+            result.scalars.return_value = scalars_obj
+            return result
+
+        def _scalar_one_or_none(self) -> Any:
+            return None
+
+    session = _Session()
+    # Repositories use select(...).where(...) which we can't introspect cheaply,
+    # so we patch the repository methods instead.
+    from com.qode.qrew.v1.service.repositories.event.event import EventRepository
+    from com.qode.qrew.v1.service.repositories.organisation.organisation import (
+        OrganisationRepository,
+    )
+    from com.qode.qrew.v1.service.repositories.venue.venue import VenueRepository
+
+    async def _evt_get(self: Any, _id: uuid.UUID) -> Event | None:
+        del self
+        return event
+
+    async def _org_get(self: Any, _id: uuid.UUID) -> Organisation | None:
+        del self
+        return org
+
+    async def _venue_get(self: Any, _id: uuid.UUID) -> Venue | None:
+        del self
+        return venue
+
+    EventRepository.get_by_id = _evt_get  # type: ignore[method-assign]
+    OrganisationRepository.get_by_id = _org_get  # type: ignore[method-assign]
+    VenueRepository.get_by_id = _venue_get  # type: ignore[method-assign]
+
+    async def _db() -> AsyncGenerator[Any, None]:
+        yield session
+
+    app.dependency_overrides[get_db] = _db
+
+
+@pytest_asyncio.fixture
+async def _cleanup_overrides() -> AsyncGenerator[None, None]:  # pyright: ignore[reportUnusedFunction]
+    yield
+    app.dependency_overrides.pop(get_db, None)
+
+
+async def test_get_public_event_returns_404_for_draft(
+    client: AsyncClient, _cleanup_overrides: None
+) -> None:
+    del _cleanup_overrides
+    event = _event(status=EventStatus.draft)
+    _install_db(event, _org(), _venue(), [])
+    response = await client.get(f"/v1/events/{event.id}")
+    assert response.status_code == 404
+
+
+async def test_get_public_event_returns_404_for_cancelled(
+    client: AsyncClient, _cleanup_overrides: None
+) -> None:
+    del _cleanup_overrides
+    event = _event(status=EventStatus.cancelled)
+    _install_db(event, _org(), _venue(), [])
+    response = await client.get(f"/v1/events/{event.id}")
+    assert response.status_code == 404
+
+
+async def test_get_public_event_returns_payload_for_published(
+    client: AsyncClient, _cleanup_overrides: None
+) -> None:
+    del _cleanup_overrides
+    event = _event()
+    tier = _tier(event_id=event.id, capacity=100, reserved_count=25)
+    _install_db(
+        event, _org(id=event.organisation_id), _venue(id=event.venue_id), [tier]
+    )
+    response = await client.get(f"/v1/events/{event.id}")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["name"] == "Concert"
+    assert body["venue"]["geofence_radius_m"] == 300
+    assert body["ticket_types"][0]["available"] == 75
+
+
+async def test_event_availability_returns_only_projection(
+    client: AsyncClient, _cleanup_overrides: None
+) -> None:
+    del _cleanup_overrides
+    event = _event()
+    tier = _tier(event_id=event.id, capacity=100, reserved_count=40)
+    _install_db(
+        event, _org(id=event.organisation_id), _venue(id=event.venue_id), [tier]
+    )
+    response = await client.get(f"/v1/events/{event.id}/availability")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["ticket_types"] == [
+        {
+            "id": str(tier.id),
+            "name": tier.name,
+            "available": 60,
+            "price_cents": tier.price_cents,
+            "currency": tier.currency,
+        }
+    ]
+
+
+async def test_event_availability_404_for_unpublished(
+    client: AsyncClient, _cleanup_overrides: None
+) -> None:
+    del _cleanup_overrides
+    event = _event(status=EventStatus.draft)
+    _install_db(event, _org(), _venue(), [])
+    response = await client.get(f"/v1/events/{event.id}/availability")
+    assert response.status_code == 404


### PR DESCRIPTION
## Summary

Light up the public browse surface end-to-end. Mobile and the storyboard step both run against these routes.

The tsvector search handler that already shipped at `/v1/events/search` becomes the canonical listing at `GET /v1/events`. 

The old path stays as a hidden alias (`include_in_schema=False`) so existing clients keep working while OpenAPI advertises the clean shape. 

The handler now also emits structured `events.search.indexed` and `events.search.miss` log events so it can graph search adoption.

## Verification

- `api/tests/v1/public_catalog/router_test.py`

## Issue Reference

Closes [QRW-150](https://github.com/cristiangilsanz/qrew/issues/150)

## Checklist
- [x] I confirm that this PR follows the project's established coding standards.