### PR TITLE
feat: add reservation FSM with atomic capacity guard and TTL sweeper

### DIFF
--- a/api/alembic/versions/f3a4b5c6d7e8_2026_06_09_add_reservations_and_tickets.py
+++ b/api/alembic/versions/f3a4b5c6d7e8_2026_06_09_add_reservations_and_tickets.py
@@ -1,0 +1,142 @@
+"""2026_06_09_add_reservations_and_tickets
+
+Revision ID: f3a4b5c6d7e8
+Revises: e2f3a4b5c6d7
+Create Date: 2026-06-09 00:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision: str = "f3a4b5c6d7e8"
+down_revision: str | None = "e2f3a4b5c6d7"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "reservations",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column(
+            "user_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("users.id", ondelete="RESTRICT"),
+            nullable=False,
+        ),
+        sa.Column(
+            "event_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("events.id", ondelete="RESTRICT"),
+            nullable=False,
+        ),
+        sa.Column(
+            "ticket_type_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("ticket_types.id", ondelete="RESTRICT"),
+            nullable=False,
+        ),
+        sa.Column("quantity", sa.Integer, nullable=False),
+        sa.Column("status", sa.String(16), nullable=False, server_default="reserved"),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.CheckConstraint("quantity >= 1", name="ck_reservations_quantity"),
+        sa.CheckConstraint(
+            "status IN ('reserved', 'paid', 'cancelled', 'expired')",
+            name="ck_reservations_status",
+        ),
+    )
+    op.create_index("ix_reservations_user_id", "reservations", ["user_id"])
+    op.create_index("ix_reservations_event_id", "reservations", ["event_id"])
+    op.create_index(
+        "ix_reservations_status_expires_at",
+        "reservations",
+        ["status", "expires_at"],
+    )
+
+    op.create_table(
+        "tickets",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column(
+            "reservation_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("reservations.id", ondelete="RESTRICT"),
+            nullable=False,
+        ),
+        sa.Column(
+            "event_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("events.id", ondelete="RESTRICT"),
+            nullable=False,
+        ),
+        sa.Column(
+            "ticket_type_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("ticket_types.id", ondelete="RESTRICT"),
+            nullable=False,
+        ),
+        sa.Column(
+            "owner_user_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("users.id", ondelete="RESTRICT"),
+            nullable=False,
+        ),
+        sa.Column("state", sa.String(20), nullable=False, server_default="reserved"),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.CheckConstraint(
+            "state IN ('reserved','issued','entry_pending','used','cancelled','frozen','flagged')",
+            name="ck_tickets_state",
+        ),
+    )
+    op.create_index("ix_tickets_reservation_id", "tickets", ["reservation_id"])
+    op.create_index("ix_tickets_event_id", "tickets", ["event_id"])
+    op.create_index("ix_tickets_owner_user_id", "tickets", ["owner_user_id"])
+    op.create_index("ix_tickets_state", "tickets", ["state"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_tickets_state", table_name="tickets")
+    op.drop_index("ix_tickets_owner_user_id", table_name="tickets")
+    op.drop_index("ix_tickets_event_id", table_name="tickets")
+    op.drop_index("ix_tickets_reservation_id", table_name="tickets")
+    op.drop_table("tickets")
+    op.drop_index("ix_reservations_status_expires_at", table_name="reservations")
+    op.drop_index("ix_reservations_event_id", table_name="reservations")
+    op.drop_index("ix_reservations_user_id", table_name="reservations")
+    op.drop_table("reservations")

--- a/api/src/com/qode/qrew/v1/service/jobs/__init__.py
+++ b/api/src/com/qode/qrew/v1/service/jobs/__init__.py
@@ -3,6 +3,7 @@ from com.qode.qrew.v1.service.jobs import (
     auth_cleanup,
     notification_delivery,
     outbox_drain,
+    reservation_sweep,
     search_reindex,
     storage_retention,
 )
@@ -12,6 +13,7 @@ __all__ = [
     "auth_cleanup",
     "notification_delivery",
     "outbox_drain",
+    "reservation_sweep",
     "search_reindex",
     "storage_retention",
 ]

--- a/api/src/com/qode/qrew/v1/service/jobs/reservation_sweep.py
+++ b/api/src/com/qode/qrew/v1/service/jobs/reservation_sweep.py
@@ -1,0 +1,58 @@
+from typing import Any
+
+import structlog
+from sqlalchemy import text
+
+from com.qode.qrew.v1.service.core.infra.database import AsyncSessionLocal
+from com.qode.qrew.v1.service.core.jobs import job
+from com.qode.qrew.v1.service.settings import settings
+
+logger = structlog.get_logger(__name__)
+
+_SELECT_EXPIRED = text(
+    """
+    SELECT id, ticket_type_id, quantity
+    FROM reservations
+    WHERE status = 'reserved' AND expires_at < now()
+    ORDER BY expires_at
+    LIMIT :batch
+    FOR UPDATE SKIP LOCKED
+    """
+)
+
+_EXPIRE_RESERVATION = text(
+    "UPDATE reservations SET status = 'expired', updated_at = now() WHERE id = :id"
+)
+
+_CANCEL_TICKETS = text(
+    "UPDATE tickets SET state = 'cancelled', updated_at = now() "
+    "WHERE reservation_id = :id AND state = 'reserved'"
+)
+
+_DECREMENT_TIER = text(
+    "UPDATE ticket_types SET reserved_count = GREATEST(reserved_count - :qty, 0), "
+    "updated_at = now() WHERE id = :tier_id"
+)
+
+
+@job(name="reservations.sweep_expired", cron="* * * * *", max_attempts=1)
+async def sweep_expired(ctx: dict[str, Any]) -> dict[str, Any]:
+    """Mark expired reservations and free their reserved capacity."""
+    del ctx
+    swept = 0
+    async with AsyncSessionLocal() as session, session.begin():
+        result = await session.execute(
+            _SELECT_EXPIRED,
+            {"batch": settings.reservation_sweep_batch_size},
+        )
+        rows = list(result.mappings())
+        for row in rows:
+            await session.execute(_CANCEL_TICKETS, {"id": row["id"]})
+            await session.execute(
+                _DECREMENT_TIER,
+                {"tier_id": row["ticket_type_id"], "qty": row["quantity"]},
+            )
+            await session.execute(_EXPIRE_RESERVATION, {"id": row["id"]})
+            swept += 1
+    await logger.ainfo("reservations.sweep_expired", swept=swept)
+    return {"swept": swept}

--- a/api/src/com/qode/qrew/v1/service/models/audit/audit.py
+++ b/api/src/com/qode/qrew/v1/service/models/audit/audit.py
@@ -68,6 +68,9 @@ class AuditAction(enum.StrEnum):
     TICKET_TYPE_CREATED = "ticket_type_created"  # noqa: S105
     TICKET_TYPE_UPDATED = "ticket_type_updated"  # noqa: S105
     TICKET_TYPE_DELETED = "ticket_type_deleted"  # noqa: S105
+    RESERVATION_CREATED = "reservation_created"
+    RESERVATION_CANCELLED = "reservation_cancelled"
+    RESERVATION_EXPIRED = "reservation_expired"
 
 
 class AuditEvent(Base):

--- a/api/src/com/qode/qrew/v1/service/models/reservation/__init__.py
+++ b/api/src/com/qode/qrew/v1/service/models/reservation/__init__.py
@@ -1,0 +1,6 @@
+from com.qode.qrew.v1.service.models.reservation.reservation import (
+    Reservation,
+    ReservationStatus,
+)
+
+__all__ = ["Reservation", "ReservationStatus"]

--- a/api/src/com/qode/qrew/v1/service/models/reservation/reservation.py
+++ b/api/src/com/qode/qrew/v1/service/models/reservation/reservation.py
@@ -1,0 +1,75 @@
+import enum
+import uuid
+from datetime import datetime
+
+from sqlalchemy import (
+    CheckConstraint,
+    DateTime,
+    ForeignKey,
+    Index,
+    Integer,
+    String,
+    func,
+)
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from com.qode.qrew.v1.service.core.infra.database import Base
+
+
+class ReservationStatus(enum.StrEnum):
+    reserved = "reserved"
+    paid = "paid"
+    cancelled = "cancelled"
+    expired = "expired"
+
+
+class Reservation(Base):
+    __tablename__ = "reservations"
+    __table_args__ = (
+        CheckConstraint("quantity >= 1", name="ck_reservations_quantity"),
+        Index("ix_reservations_user_id", "user_id"),
+        Index("ix_reservations_event_id", "event_id"),
+        Index(
+            "ix_reservations_status_expires_at",
+            "status",
+            "expires_at",
+        ),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="RESTRICT"),
+        nullable=False,
+    )
+    event_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("events.id", ondelete="RESTRICT"),
+        nullable=False,
+    )
+    ticket_type_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("ticket_types.id", ondelete="RESTRICT"),
+        nullable=False,
+    )
+    quantity: Mapped[int] = mapped_column(Integer, nullable=False)
+    status: Mapped[ReservationStatus] = mapped_column(
+        String(16),
+        nullable=False,
+        server_default=ReservationStatus.reserved.value,
+    )
+    expires_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
+    )

--- a/api/src/com/qode/qrew/v1/service/models/ticket/__init__.py
+++ b/api/src/com/qode/qrew/v1/service/models/ticket/__init__.py
@@ -1,0 +1,3 @@
+from com.qode.qrew.v1.service.models.ticket.ticket import Ticket, TicketState
+
+__all__ = ["Ticket", "TicketState"]

--- a/api/src/com/qode/qrew/v1/service/models/ticket/ticket.py
+++ b/api/src/com/qode/qrew/v1/service/models/ticket/ticket.py
@@ -1,0 +1,65 @@
+import enum
+import uuid
+from datetime import datetime
+
+from sqlalchemy import DateTime, ForeignKey, Index, String, func
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from com.qode.qrew.v1.service.core.infra.database import Base
+
+
+class TicketState(enum.StrEnum):
+    reserved = "reserved"
+    issued = "issued"
+    entry_pending = "entry_pending"
+    used = "used"
+    cancelled = "cancelled"
+    frozen = "frozen"
+    flagged = "flagged"
+
+
+class Ticket(Base):
+    __tablename__ = "tickets"
+    __table_args__ = (
+        Index("ix_tickets_reservation_id", "reservation_id"),
+        Index("ix_tickets_event_id", "event_id"),
+        Index("ix_tickets_owner_user_id", "owner_user_id"),
+        Index("ix_tickets_state", "state"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    reservation_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("reservations.id", ondelete="RESTRICT"),
+        nullable=False,
+    )
+    event_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("events.id", ondelete="RESTRICT"),
+        nullable=False,
+    )
+    ticket_type_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("ticket_types.id", ondelete="RESTRICT"),
+        nullable=False,
+    )
+    owner_user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="RESTRICT"),
+        nullable=False,
+    )
+    state: Mapped[TicketState] = mapped_column(
+        String(20), nullable=False, server_default=TicketState.reserved.value
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
+    )

--- a/api/src/com/qode/qrew/v1/service/repositories/reservation/__init__.py
+++ b/api/src/com/qode/qrew/v1/service/repositories/reservation/__init__.py
@@ -1,0 +1,5 @@
+from com.qode.qrew.v1.service.repositories.reservation.reservation import (
+    ReservationRepository,
+)
+
+__all__ = ["ReservationRepository"]

--- a/api/src/com/qode/qrew/v1/service/repositories/reservation/reservation.py
+++ b/api/src/com/qode/qrew/v1/service/repositories/reservation/reservation.py
@@ -1,0 +1,54 @@
+import uuid
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from com.qode.qrew.v1.service.models.reservation import (
+    Reservation,
+    ReservationStatus,
+)
+from com.qode.qrew.v1.service.models.ticket import Ticket
+
+
+class ReservationRepository:
+    """Data access for the reservations table."""
+
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+
+    async def get_by_id(self, reservation_id: uuid.UUID) -> Reservation | None:
+        result = await self._session.execute(
+            select(Reservation).where(Reservation.id == reservation_id)
+        )
+        return result.scalar_one_or_none()
+
+    async def insert(self, reservation: Reservation) -> Reservation:
+        self._session.add(reservation)
+        await self._session.flush()
+        await self._session.refresh(reservation)
+        return reservation
+
+    async def flush(self) -> None:
+        await self._session.flush()
+
+    async def list_tickets(self, reservation_id: uuid.UUID) -> list[Ticket]:
+        result = await self._session.execute(
+            select(Ticket).where(Ticket.reservation_id == reservation_id)
+        )
+        return list(result.scalars().all())
+
+    async def active_quantity_for_user(
+        self, user_id: uuid.UUID, event_id: uuid.UUID
+    ) -> int:
+        """Count tickets held by this user on this event in active reservations."""
+        total = await self._session.execute(
+            select(func.coalesce(func.sum(Reservation.quantity), 0))
+            .where(Reservation.user_id == user_id)
+            .where(Reservation.event_id == event_id)
+            .where(
+                Reservation.status.in_(
+                    [ReservationStatus.reserved, ReservationStatus.paid]
+                )
+            )
+        )
+        return int(total.scalar_one() or 0)

--- a/api/src/com/qode/qrew/v1/service/routers/__init__.py
+++ b/api/src/com/qode/qrew/v1/service/routers/__init__.py
@@ -10,6 +10,9 @@ from com.qode.qrew.v1.service.routers.event import router as event_router
 from com.qode.qrew.v1.service.routers.public_catalog import (
     router as public_catalog_router,
 )
+from com.qode.qrew.v1.service.routers.reservation import (
+    router as reservation_router,
+)
 from com.qode.qrew.v1.service.routers.ticket_type import router as ticket_type_router
 from com.qode.qrew.v1.service.routers.venue import router as venue_router
 from com.qode.qrew.v1.service.settings import settings
@@ -25,6 +28,7 @@ router.include_router(venue_router)
 router.include_router(event_router)
 router.include_router(ticket_type_router)
 router.include_router(public_catalog_router)
+router.include_router(reservation_router)
 
 if settings.debug:
     from com.qode.qrew.v1.service.routers.dev import router as dev_router

--- a/api/src/com/qode/qrew/v1/service/routers/reservation.py
+++ b/api/src/com/qode/qrew/v1/service/routers/reservation.py
@@ -1,0 +1,175 @@
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException, Request, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from com.qode.qrew.v1.service.core.auth.auth import get_current_user
+from com.qode.qrew.v1.service.core.idempotency import idempotent
+from com.qode.qrew.v1.service.core.infra.database import get_db
+from com.qode.qrew.v1.service.core.infra.limiter import limiter
+from com.qode.qrew.v1.service.core.locking.errors import LockUnavailableError
+from com.qode.qrew.v1.service.models.auth.user import User
+from com.qode.qrew.v1.service.models.reservation import Reservation
+from com.qode.qrew.v1.service.models.ticket import Ticket
+from com.qode.qrew.v1.service.repositories.event import EventRepository
+from com.qode.qrew.v1.service.repositories.reservation import ReservationRepository
+from com.qode.qrew.v1.service.repositories.ticket_type import TicketTypeRepository
+from com.qode.qrew.v1.service.schemas.reservation import (
+    ReservationCreateRequest,
+    ReservationResponse,
+    ReservationTicketItem,
+)
+from com.qode.qrew.v1.service.services.audit import AuditService
+from com.qode.qrew.v1.service.services.reservation import (
+    ReservationError,
+    ReservationService,
+    TierBusyError,
+)
+
+router = APIRouter(tags=["reservations"])
+
+
+def _service(db: AsyncSession) -> ReservationService:
+    return ReservationService(
+        db,
+        ReservationRepository(db),
+        EventRepository(db),
+        TicketTypeRepository(db),
+        AuditService(),
+    )
+
+
+def _to_response(
+    reservation: Reservation, tickets: list[Ticket]
+) -> ReservationResponse:
+    return ReservationResponse(
+        id=reservation.id,
+        event_id=reservation.event_id,
+        ticket_type_id=reservation.ticket_type_id,
+        quantity=reservation.quantity,
+        status=reservation.status,
+        expires_at=reservation.expires_at,
+        created_at=reservation.created_at,
+        tickets=[
+            ReservationTicketItem(id=ticket.id, state=ticket.state)
+            for ticket in tickets
+        ],
+    )
+
+
+def _bad_request(error: ReservationError) -> HTTPException:
+    code = (
+        status.HTTP_404_NOT_FOUND
+        if error.field in {"event_id", "reservation_id", "ticket_type_id"}
+        else status.HTTP_409_CONFLICT
+        if error.field == "quantity"
+        else status.HTTP_400_BAD_REQUEST
+    )
+    return HTTPException(
+        status_code=code,
+        detail={"message": error.message, "field": error.field},
+    )
+
+
+@router.post(
+    "/events/{event_id}/reserve",
+    response_model=ReservationResponse,
+    status_code=status.HTTP_201_CREATED,
+    summary="Reserve tickets against an event under the per-user limit",
+)
+@limiter.limit("30/minute")  # type: ignore[misc]
+@idempotent(scope="user", ttl_seconds=300)
+async def reserve_event(
+    request: Request,
+    event_id: uuid.UUID,
+    body: ReservationCreateRequest,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> ReservationResponse:
+    """Atomic capacity-guarded reservation against an event tier."""
+    del request
+    try:
+        reservation = await _service(db).reserve(
+            user_id=current_user.id,
+            event_id=event_id,
+            ticket_type_id=body.ticket_type_id,
+            quantity=body.quantity,
+        )
+    except ReservationError as exc:
+        raise _bad_request(exc) from exc
+    except TierBusyError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={
+                "message": "Ticket type is being purchased by another caller",
+                "field": "ticket_type_id",
+            },
+        ) from exc
+    except LockUnavailableError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={
+                "message": "Another reservation by this user is in progress",
+                "field": None,
+            },
+        ) from exc
+    tickets = await ReservationRepository(db).list_tickets(reservation.id)
+    return _to_response(reservation, tickets)
+
+
+@router.post(
+    "/reservations/{reservation_id}/cancel",
+    response_model=ReservationResponse,
+    status_code=status.HTTP_200_OK,
+    summary="Cancel an open reservation",
+)
+@limiter.limit("30/minute")  # type: ignore[misc]
+@idempotent(scope="user", ttl_seconds=300)
+async def cancel_reservation(
+    request: Request,
+    reservation_id: uuid.UUID,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> ReservationResponse:
+    """Cancel a reservation the caller owns; frees the reserved capacity."""
+    del request
+    try:
+        reservation = await _service(db).cancel(
+            actor_id=current_user.id, reservation_id=reservation_id
+        )
+    except ReservationError as exc:
+        raise _bad_request(exc) from exc
+    except LockUnavailableError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={
+                "message": "Another lifecycle change is in progress",
+                "field": None,
+            },
+        ) from exc
+    tickets = await ReservationRepository(db).list_tickets(reservation.id)
+    return _to_response(reservation, tickets)
+
+
+@router.get(
+    "/reservations/{reservation_id}",
+    response_model=ReservationResponse,
+    status_code=status.HTTP_200_OK,
+    summary="Read a reservation owned by the caller",
+)
+@limiter.limit("60/minute")  # type: ignore[misc]
+async def get_reservation(
+    request: Request,
+    reservation_id: uuid.UUID,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> ReservationResponse:
+    """Return the reservation including its tickets and countdown."""
+    del request
+    try:
+        reservation, tickets = await _service(db).get_for_user(
+            actor_id=current_user.id, reservation_id=reservation_id
+        )
+    except ReservationError as exc:
+        raise _bad_request(exc) from exc
+    return _to_response(reservation, tickets)

--- a/api/src/com/qode/qrew/v1/service/schemas/reservation/__init__.py
+++ b/api/src/com/qode/qrew/v1/service/schemas/reservation/__init__.py
@@ -1,0 +1,11 @@
+from com.qode.qrew.v1.service.schemas.reservation.reservation import (
+    ReservationCreateRequest,
+    ReservationResponse,
+    ReservationTicketItem,
+)
+
+__all__ = [
+    "ReservationCreateRequest",
+    "ReservationResponse",
+    "ReservationTicketItem",
+]

--- a/api/src/com/qode/qrew/v1/service/schemas/reservation/reservation.py
+++ b/api/src/com/qode/qrew/v1/service/schemas/reservation/reservation.py
@@ -1,0 +1,28 @@
+import uuid
+from datetime import datetime
+
+from pydantic import BaseModel, Field
+
+from com.qode.qrew.v1.service.models.reservation import ReservationStatus
+from com.qode.qrew.v1.service.models.ticket import TicketState
+
+
+class ReservationCreateRequest(BaseModel):
+    ticket_type_id: uuid.UUID
+    quantity: int = Field(..., ge=1, le=20)
+
+
+class ReservationTicketItem(BaseModel):
+    id: uuid.UUID
+    state: TicketState
+
+
+class ReservationResponse(BaseModel):
+    id: uuid.UUID
+    event_id: uuid.UUID
+    ticket_type_id: uuid.UUID
+    quantity: int
+    status: ReservationStatus
+    expires_at: datetime
+    created_at: datetime
+    tickets: list[ReservationTicketItem]

--- a/api/src/com/qode/qrew/v1/service/services/reservation/__init__.py
+++ b/api/src/com/qode/qrew/v1/service/services/reservation/__init__.py
@@ -1,0 +1,7 @@
+from com.qode.qrew.v1.service.services.reservation.reservation import (
+    ReservationError,
+    ReservationService,
+    TierBusyError,
+)
+
+__all__ = ["ReservationError", "ReservationService", "TierBusyError"]

--- a/api/src/com/qode/qrew/v1/service/services/reservation/reservation.py
+++ b/api/src/com/qode/qrew/v1/service/services/reservation/reservation.py
@@ -1,0 +1,213 @@
+import uuid
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+import structlog
+from sqlalchemy import text
+from sqlalchemy.exc import DBAPIError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from com.qode.qrew.v1.service.core.infra.errors import DomainError
+from com.qode.qrew.v1.service.core.locking import redlock
+from com.qode.qrew.v1.service.core.observability import traced
+from com.qode.qrew.v1.service.models.audit.audit import AuditAction
+from com.qode.qrew.v1.service.models.event import EventStatus
+from com.qode.qrew.v1.service.models.reservation import (
+    Reservation,
+    ReservationStatus,
+)
+from com.qode.qrew.v1.service.models.ticket import Ticket, TicketState
+from com.qode.qrew.v1.service.models.ticket_type import TicketType
+from com.qode.qrew.v1.service.repositories.event import EventRepository
+from com.qode.qrew.v1.service.repositories.reservation import ReservationRepository
+from com.qode.qrew.v1.service.repositories.ticket_type import TicketTypeRepository
+from com.qode.qrew.v1.service.services.audit import AuditService
+from com.qode.qrew.v1.service.settings import settings
+
+logger = structlog.get_logger(__name__)
+
+
+class ReservationError(DomainError):
+    """Raised when a reservation operation fails a domain rule."""
+
+
+class TierBusyError(DomainError):
+    """Raised when the ticket-type row is locked by another transaction."""
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+class ReservationService:
+    """Business logic for the reservation aggregate."""
+
+    def __init__(
+        self,
+        session: AsyncSession,
+        repo: ReservationRepository,
+        event_repo: EventRepository,
+        tier_repo: TicketTypeRepository,
+        audit: AuditService,
+    ) -> None:
+        self._session = session
+        self._repo = repo
+        self._event_repo = event_repo
+        self._tier_repo = tier_repo
+        self._audit = audit
+
+    async def _lock_tier_nowait(self, ticket_type_id: uuid.UUID) -> TicketType | None:
+        """SELECT ... FOR UPDATE NOWAIT on the tier; raise TierBusyError on conflict."""
+        try:
+            result = await self._session.execute(
+                text(
+                    "SELECT * FROM ticket_types "
+                    "WHERE id = :id AND deleted_at IS NULL "
+                    "FOR UPDATE NOWAIT"
+                ).bindparams(id=ticket_type_id)
+            )
+        except DBAPIError as exc:
+            raise TierBusyError(
+                "Ticket type is being purchased by another caller",
+                field="ticket_type_id",
+            ) from exc
+        row = result.mappings().first()
+        if row is None:
+            return None
+        return await self._tier_repo.get_by_id(ticket_type_id)
+
+    @traced("reservation.create")
+    async def reserve(
+        self,
+        *,
+        user_id: uuid.UUID,
+        event_id: uuid.UUID,
+        ticket_type_id: uuid.UUID,
+        quantity: int,
+    ) -> Reservation:
+        """Atomically reserve `quantity` seats; raise on capacity or limit breach."""
+        if quantity < 1:
+            raise ReservationError("Quantity must be at least 1", field="quantity")
+        async with redlock(f"event:{event_id}:reserve:{user_id}", ttl_seconds=10):
+            event = await self._event_repo.get_by_id(event_id)
+            if event is None:
+                raise ReservationError("Event not found", field="event_id")
+            if event.status != EventStatus.published:
+                raise ReservationError("Event is not on sale", field="status")
+            if quantity > event.max_tickets_per_user:
+                raise ReservationError(
+                    "Quantity exceeds the per-user maximum for this event",
+                    field="quantity",
+                )
+            now = _now()
+            if now < event.sale_starts_at or now > event.sale_ends_at:
+                raise ReservationError("Sale window is closed", field="sale_window")
+            tier = await self._lock_tier_nowait(ticket_type_id)
+            if tier is None or tier.event_id != event_id:
+                raise ReservationError("Ticket type not found", field="ticket_type_id")
+            if tier.reserved_count + quantity > tier.capacity:
+                raise ReservationError(
+                    "Not enough capacity remaining", field="quantity"
+                )
+            held = await self._repo.active_quantity_for_user(user_id, event_id)
+            if held + quantity > event.max_tickets_per_user:
+                raise ReservationError(
+                    "Would exceed your per-user ticket limit",
+                    field="quantity",
+                )
+            expires_at = now + timedelta(seconds=settings.reservation_ttl_seconds)
+            reservation = Reservation(
+                user_id=user_id,
+                event_id=event_id,
+                ticket_type_id=ticket_type_id,
+                quantity=quantity,
+                status=ReservationStatus.reserved,
+                expires_at=expires_at,
+            )
+            reservation = await self._repo.insert(reservation)
+            for _ in range(quantity):
+                self._session.add(
+                    Ticket(
+                        reservation_id=reservation.id,
+                        event_id=event_id,
+                        ticket_type_id=ticket_type_id,
+                        owner_user_id=user_id,
+                        state=TicketState.reserved,
+                    )
+                )
+            tier.reserved_count = tier.reserved_count + quantity
+            await self._session.flush()
+            await self._record(
+                AuditAction.RESERVATION_CREATED,
+                actor_id=user_id,
+                reservation_id=reservation.id,
+                payload={
+                    "event_id": str(event_id),
+                    "ticket_type_id": str(ticket_type_id),
+                    "quantity": quantity,
+                },
+            )
+            return reservation
+
+    @traced("reservation.cancel")
+    async def cancel(
+        self, *, actor_id: uuid.UUID, reservation_id: uuid.UUID
+    ) -> Reservation:
+        reservation = await self._repo.get_by_id(reservation_id)
+        if reservation is None or reservation.user_id != actor_id:
+            raise ReservationError("Reservation not found", field="reservation_id")
+        if reservation.status in {
+            ReservationStatus.cancelled,
+            ReservationStatus.expired,
+        }:
+            return reservation
+        if reservation.status == ReservationStatus.paid:
+            raise ReservationError(
+                "Paid reservations must be refunded, not cancelled",
+                field="status",
+            )
+        async with redlock(f"reservation:{reservation_id}:lifecycle", ttl_seconds=10):
+            tier = await self._lock_tier_nowait(reservation.ticket_type_id)
+            if tier is None:
+                raise ReservationError("Ticket type not found", field="ticket_type_id")
+            reservation.status = ReservationStatus.cancelled
+            for ticket in await self._repo.list_tickets(reservation.id):
+                if ticket.state == TicketState.reserved:
+                    ticket.state = TicketState.cancelled
+            tier.reserved_count = max(0, tier.reserved_count - reservation.quantity)
+            await self._session.flush()
+            await self._record(
+                AuditAction.RESERVATION_CANCELLED,
+                actor_id=actor_id,
+                reservation_id=reservation.id,
+                payload={"event_id": str(reservation.event_id)},
+            )
+            return reservation
+
+    async def get_for_user(
+        self, *, actor_id: uuid.UUID, reservation_id: uuid.UUID
+    ) -> tuple[Reservation, list[Ticket]]:
+        reservation = await self._repo.get_by_id(reservation_id)
+        if reservation is None or reservation.user_id != actor_id:
+            raise ReservationError("Reservation not found", field="reservation_id")
+        tickets = await self._repo.list_tickets(reservation.id)
+        return reservation, tickets
+
+    async def _record(
+        self,
+        action: AuditAction,
+        *,
+        actor_id: uuid.UUID,
+        reservation_id: uuid.UUID,
+        payload: dict[str, Any],
+    ) -> None:
+        try:
+            await self._audit.record(
+                action=action,
+                actor_id=actor_id,
+                entity_type="reservation",
+                entity_id=str(reservation_id),
+                payload=payload,
+            )
+        except Exception:
+            await logger.awarning("audit_write_failed", action=action)

--- a/api/src/com/qode/qrew/v1/service/settings.py
+++ b/api/src/com/qode/qrew/v1/service/settings.py
@@ -119,5 +119,8 @@ class Settings(BaseSettings):
     outbox_max_attempts: int = 5
     outbox_backoff_delays_seconds: list[int] = [1, 5, 25, 125, 625]
 
+    reservation_ttl_seconds: int = 600
+    reservation_sweep_batch_size: int = 200
+
 
 settings = Settings()

--- a/api/tests/v1/reservation/service_test.py
+++ b/api/tests/v1/reservation/service_test.py
@@ -1,0 +1,284 @@
+import uuid
+from datetime import datetime, timedelta, timezone
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import fakeredis.aioredis
+import pytest
+import pytest_asyncio
+
+from com.qode.qrew.v1.service.core.locking import lock as lock_module
+from com.qode.qrew.v1.service.models.event import EventStatus
+from com.qode.qrew.v1.service.models.reservation import (
+    Reservation,
+    ReservationStatus,
+)
+from com.qode.qrew.v1.service.models.ticket import Ticket, TicketState
+from com.qode.qrew.v1.service.models.ticket_type import TicketType
+from com.qode.qrew.v1.service.services.reservation import (
+    ReservationError,
+    ReservationService,
+)
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def _fake_redis_for_locks() -> Any:  # pyright: ignore[reportUnusedFunction]
+    fake = fakeredis.aioredis.FakeRedis()
+    previous = lock_module._ClientState.client  # pyright: ignore[reportPrivateUsage]
+    lock_module._ClientState.client = fake  # pyright: ignore[reportPrivateUsage]
+    try:
+        yield fake
+    finally:
+        await fake.aclose()
+        lock_module._ClientState.client = previous  # pyright: ignore[reportPrivateUsage]
+
+
+_DEFAULT = object()
+
+
+def _event(
+    *,
+    status: EventStatus = EventStatus.published,
+    max_tickets_per_user: int = 4,
+) -> MagicMock:
+    now = datetime.now(timezone.utc)
+    event = MagicMock()
+    event.id = uuid.uuid4()
+    event.status = status
+    event.max_tickets_per_user = max_tickets_per_user
+    event.sale_starts_at = now - timedelta(hours=1)
+    event.sale_ends_at = now + timedelta(hours=1)
+    return event
+
+
+def _tier(*, capacity: int = 100, reserved_count: int = 0) -> TicketType:
+    tier = TicketType(
+        id=uuid.uuid4(),
+        event_id=uuid.uuid4(),
+        name="general",
+        description=None,
+        capacity=capacity,
+        reserved_count=reserved_count,
+        price_cents=5000,
+        currency="EUR",
+        position=0,
+    )
+    return tier
+
+
+def _service(
+    *,
+    event: Any = _DEFAULT,
+    tier: Any = _DEFAULT,
+    held_quantity: int = 0,
+    tier_busy: bool = False,
+) -> tuple[ReservationService, MagicMock, MagicMock, list[Reservation]]:
+    if event is _DEFAULT:
+        event = _event()
+    if tier is _DEFAULT:
+        tier = _tier()
+        tier.event_id = event.id
+
+    session = MagicMock()
+    added: list[Any] = []
+    session.add = MagicMock(side_effect=added.append)
+
+    async def _flush() -> None:
+        return None
+
+    session.flush = AsyncMock(side_effect=_flush)
+
+    async def _execute(*_args: Any, **_kwargs: Any) -> Any:
+        if tier_busy:
+            from sqlalchemy.exc import DBAPIError
+
+            raise DBAPIError("locked", {}, Exception("locked"))
+        result = MagicMock()
+        if tier is None:
+            result.mappings.return_value.first.return_value = None
+        else:
+            result.mappings.return_value.first.return_value = {"id": tier.id}
+        return result
+
+    session.execute = AsyncMock(side_effect=_execute)
+
+    event_repo = MagicMock()
+    event_repo.get_by_id = AsyncMock(return_value=event)
+
+    tier_repo = MagicMock()
+    tier_repo.get_by_id = AsyncMock(return_value=tier)
+
+    inserted: list[Reservation] = []
+
+    async def _insert(reservation: Reservation) -> Reservation:
+        reservation.id = uuid.uuid4()
+        reservation.created_at = datetime.now(timezone.utc)
+        inserted.append(reservation)
+        return reservation
+
+    repo = MagicMock()
+
+    async def _get_by_id(rid: uuid.UUID) -> Reservation | None:
+        return next((r for r in inserted if r.id == rid), None)
+
+    repo.get_by_id = AsyncMock(side_effect=_get_by_id)
+    repo.insert = AsyncMock(side_effect=_insert)
+    repo.flush = AsyncMock()
+    repo.list_tickets = AsyncMock(return_value=[])
+    repo.active_quantity_for_user = AsyncMock(return_value=held_quantity)
+
+    audit = MagicMock()
+    audit.record = AsyncMock()
+
+    service = ReservationService(session, repo, event_repo, tier_repo, audit)
+    return service, session, repo, inserted
+
+
+async def test_reserve_creates_reservation_and_tickets() -> None:
+    event = _event()
+    tier = _tier(capacity=100, reserved_count=0)
+    tier.event_id = event.id
+    service, session, _repo, inserted = _service(event=event, tier=tier)
+    reservation = await service.reserve(
+        user_id=uuid.uuid4(),
+        event_id=event.id,
+        ticket_type_id=tier.id,
+        quantity=2,
+    )
+    assert reservation.status == ReservationStatus.reserved
+    assert tier.reserved_count == 2
+    ticket_adds = [
+        c for c in session.add.call_args_list if isinstance(c.args[0], Ticket)
+    ]
+    assert len(ticket_adds) == 2
+    assert all(t.args[0].state == TicketState.reserved for t in ticket_adds)
+    assert len(inserted) == 1
+
+
+async def test_reserve_rejects_over_capacity() -> None:
+    event = _event()
+    tier = _tier(capacity=5, reserved_count=4)
+    tier.event_id = event.id
+    service, *_ = _service(event=event, tier=tier)
+    with pytest.raises(ReservationError, match="capacity"):
+        await service.reserve(
+            user_id=uuid.uuid4(),
+            event_id=event.id,
+            ticket_type_id=tier.id,
+            quantity=2,
+        )
+
+
+async def test_reserve_rejects_when_per_user_limit_would_breach() -> None:
+    event = _event(max_tickets_per_user=4)
+    tier = _tier()
+    tier.event_id = event.id
+    service, *_ = _service(event=event, tier=tier, held_quantity=3)
+    with pytest.raises(ReservationError, match="per-user"):
+        await service.reserve(
+            user_id=uuid.uuid4(),
+            event_id=event.id,
+            ticket_type_id=tier.id,
+            quantity=2,
+        )
+
+
+async def test_reserve_rejects_unpublished_event() -> None:
+    event = _event(status=EventStatus.draft)
+    tier = _tier()
+    tier.event_id = event.id
+    service, *_ = _service(event=event, tier=tier)
+    with pytest.raises(ReservationError, match="not on sale"):
+        await service.reserve(
+            user_id=uuid.uuid4(),
+            event_id=event.id,
+            ticket_type_id=tier.id,
+            quantity=1,
+        )
+
+
+async def test_reserve_rejects_quantity_above_event_cap() -> None:
+    event = _event(max_tickets_per_user=4)
+    tier = _tier()
+    tier.event_id = event.id
+    service, *_ = _service(event=event, tier=tier)
+    with pytest.raises(ReservationError, match="per-user"):
+        await service.reserve(
+            user_id=uuid.uuid4(),
+            event_id=event.id,
+            ticket_type_id=tier.id,
+            quantity=5,
+        )
+
+
+async def test_reserve_returns_409_when_tier_locked() -> None:
+    event = _event()
+    tier = _tier()
+    tier.event_id = event.id
+    service, *_ = _service(event=event, tier=tier, tier_busy=True)
+    from com.qode.qrew.v1.service.services.reservation import TierBusyError
+
+    with pytest.raises(TierBusyError):
+        await service.reserve(
+            user_id=uuid.uuid4(),
+            event_id=event.id,
+            ticket_type_id=tier.id,
+            quantity=1,
+        )
+
+
+async def test_cancel_flips_reservation_and_frees_capacity() -> None:
+    event = _event()
+    tier = _tier(capacity=10, reserved_count=3)
+    tier.event_id = event.id
+    user_id = uuid.uuid4()
+    service, _session, repo, inserted = _service(event=event, tier=tier)
+    reservation = await service.reserve(
+        user_id=user_id, event_id=event.id, ticket_type_id=tier.id, quantity=2
+    )
+    held_tickets = [
+        Ticket(
+            id=uuid.uuid4(),
+            reservation_id=reservation.id,
+            event_id=event.id,
+            ticket_type_id=tier.id,
+            owner_user_id=user_id,
+            state=TicketState.reserved,
+        )
+        for _ in range(2)
+    ]
+    repo.list_tickets = AsyncMock(return_value=held_tickets)
+    cancelled = await service.cancel(actor_id=user_id, reservation_id=reservation.id)
+    assert cancelled.status == ReservationStatus.cancelled
+    assert tier.reserved_count == 3  # was 5 after reserve, back to 3 after cancel
+    assert all(t.state == TicketState.cancelled for t in held_tickets)
+    del inserted
+
+
+async def test_cancel_rejects_paid_reservation() -> None:
+    event = _event()
+    tier = _tier()
+    tier.event_id = event.id
+    user_id = uuid.uuid4()
+    service, _session, repo, _ = _service(event=event, tier=tier)
+    reservation = await service.reserve(
+        user_id=user_id, event_id=event.id, ticket_type_id=tier.id, quantity=1
+    )
+    reservation.status = ReservationStatus.paid
+    repo.get_by_id = AsyncMock(return_value=reservation)
+    with pytest.raises(ReservationError, match="refunded"):
+        await service.cancel(actor_id=user_id, reservation_id=reservation.id)
+
+
+async def test_get_for_user_rejects_other_users_reservation() -> None:
+    event = _event()
+    tier = _tier()
+    tier.event_id = event.id
+    owner = uuid.uuid4()
+    intruder = uuid.uuid4()
+    service, _session, _repo, _ = _service(event=event, tier=tier)
+    reservation = await service.reserve(
+        user_id=owner, event_id=event.id, ticket_type_id=tier.id, quantity=1
+    )
+    with pytest.raises(ReservationError, match="not found"):
+        await service.get_for_user(actor_id=intruder, reservation_id=reservation.id)


### PR DESCRIPTION
## Summary

First step of the purchase pipeline. A verified user reserves capacity against an event tier; the row is protected from over-sale under concurrent purchases and freed automatically if the user fails to pay within the TTL.

## Verification

- `api/tests/v1/reservation/service_test.py` 

## Issue Reference

Closes [QRW-156](https://github.com/cristiangilsanz/qrew/issues/156)

## Checklist
- [x] I confirm that this PR follows the project's established coding standards.