### PR TITLE
feat: add synchronous fraud rule engine with composable signals before reservation

### DIFF
--- a/api/alembic/versions/b5c6d7e8f9a0_2026_06_09_add_reservation_risk_columns.py
+++ b/api/alembic/versions/b5c6d7e8f9a0_2026_06_09_add_reservation_risk_columns.py
@@ -1,0 +1,50 @@
+"""2026_06_09_add_reservation_risk_columns
+
+Revision ID: b5c6d7e8f9a0
+Revises: a4b5c6d7e8f9
+Create Date: 2026-06-09 02:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "b5c6d7e8f9a0"
+down_revision: str | None = "a4b5c6d7e8f9"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "reservations",
+        sa.Column(
+            "requires_review",
+            sa.Boolean,
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+    )
+    op.add_column(
+        "reservations",
+        sa.Column(
+            "risk_score",
+            sa.Integer,
+            nullable=False,
+            server_default="0",
+        ),
+    )
+    op.execute(
+        "CREATE OR REPLACE VIEW flagged_reservations AS "
+        "SELECT r.id, r.user_id, r.event_id, r.ticket_type_id, r.quantity, "
+        "r.status, r.risk_score, r.created_at "
+        "FROM reservations r WHERE r.requires_review = true"
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP VIEW IF EXISTS flagged_reservations")
+    op.drop_column("reservations", "risk_score")
+    op.drop_column("reservations", "requires_review")

--- a/api/src/com/qode/qrew/v1/service/models/audit/audit.py
+++ b/api/src/com/qode/qrew/v1/service/models/audit/audit.py
@@ -74,6 +74,8 @@ class AuditAction(enum.StrEnum):
     QUEUE_JOINED = "queue_joined"
     QUEUE_REDEEMED = "queue_redeemed"
     QUEUE_REDEEM_FAILED = "queue_redeem_failed"
+    RESERVATION_FLAGGED = "reservation_flagged"
+    RESERVATION_BLOCKED = "reservation_blocked"
 
 
 class AuditEvent(Base):

--- a/api/src/com/qode/qrew/v1/service/models/reservation/reservation.py
+++ b/api/src/com/qode/qrew/v1/service/models/reservation/reservation.py
@@ -3,6 +3,7 @@ import uuid
 from datetime import datetime
 
 from sqlalchemy import (
+    Boolean,
     CheckConstraint,
     DateTime,
     ForeignKey,
@@ -64,6 +65,10 @@ class Reservation(Base):
     expires_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), nullable=False
     )
+    requires_review: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, server_default="false"
+    )
+    risk_score: Mapped[int] = mapped_column(Integer, nullable=False, server_default="0")
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False
     )

--- a/api/src/com/qode/qrew/v1/service/routers/reservation.py
+++ b/api/src/com/qode/qrew/v1/service/routers/reservation.py
@@ -11,6 +11,7 @@ from com.qode.qrew.v1.service.core.infra.database import get_db
 from com.qode.qrew.v1.service.core.infra.limiter import limiter
 from com.qode.qrew.v1.service.core.locking.errors import LockUnavailableError
 from com.qode.qrew.v1.service.core.queue import consume_reservation_token
+from com.qode.qrew.v1.service.models.audit.audit import AuditAction
 from com.qode.qrew.v1.service.models.auth.user import User
 from com.qode.qrew.v1.service.models.reservation import Reservation
 from com.qode.qrew.v1.service.models.ticket import Ticket
@@ -23,6 +24,11 @@ from com.qode.qrew.v1.service.schemas.reservation import (
     ReservationTicketItem,
 )
 from com.qode.qrew.v1.service.services.audit import AuditService
+from com.qode.qrew.v1.service.services.fraud import (
+    FraudDecision,
+    PurchaseContext,
+)
+from com.qode.qrew.v1.service.services.fraud.dependencies import build_engine
 from com.qode.qrew.v1.service.services.reservation import (
     ReservationError,
     ReservationService,
@@ -90,7 +96,6 @@ async def reserve_event(
     db: AsyncSession = Depends(get_db),
 ) -> ReservationResponse:
     """Atomic capacity-guarded reservation against an event tier."""
-    del request
     event = await EventRepository(db).get_by_id(event_id)
     if event is None:
         raise HTTPException(
@@ -126,12 +131,48 @@ async def reserve_event(
                     "field": "reservation_window_token",
                 },
             )
+    from datetime import datetime, timezone
+
+    forwarded = request.headers.get("X-Forwarded-For")
+    if forwarded:
+        ip_address: str | None = forwarded.split(",", 1)[0].strip()
+    else:
+        ip_address = request.client.host if request.client else None
+    fingerprint = request.headers.get("X-Device-Fingerprint")
+    fraud_context = PurchaseContext(
+        user_id=current_user.id,
+        user_created_at=current_user.created_at,
+        phone_number=None,
+        ip_address=ip_address,
+        device_fingerprint_hash=fingerprint,
+        now=datetime.now(timezone.utc),
+    )
+    engine = build_engine(db)
+    evaluation = await engine.evaluate(fraud_context)
+    audit = AuditService()
+    if evaluation.decision == FraudDecision.block:
+        try:
+            await audit.record(
+                action=AuditAction.RESERVATION_BLOCKED,
+                actor_id=current_user.id,
+                entity_type="event",
+                entity_id=str(event_id),
+                payload=evaluation.to_payload(),
+            )
+        except Exception:
+            pass
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail={"message": "Reservation rejected for risk", "field": None},
+        )
     try:
         reservation = await _service(db).reserve(
             user_id=current_user.id,
             event_id=event_id,
             ticket_type_id=body.ticket_type_id,
             quantity=body.quantity,
+            risk_score=evaluation.score,
+            requires_review=evaluation.decision == FraudDecision.review,
         )
     except ReservationError as exc:
         raise _bad_request(exc) from exc
@@ -151,6 +192,17 @@ async def reserve_event(
                 "field": None,
             },
         ) from exc
+    if evaluation.decision == FraudDecision.review:
+        try:
+            await audit.record(
+                action=AuditAction.RESERVATION_FLAGGED,
+                actor_id=current_user.id,
+                entity_type="reservation",
+                entity_id=str(reservation.id),
+                payload=evaluation.to_payload(),
+            )
+        except Exception:
+            pass
     tickets = await ReservationRepository(db).list_tickets(reservation.id)
     return _to_response(reservation, tickets)
 

--- a/api/src/com/qode/qrew/v1/service/services/fraud/__init__.py
+++ b/api/src/com/qode/qrew/v1/service/services/fraud/__init__.py
@@ -1,0 +1,13 @@
+from com.qode.qrew.v1.service.services.fraud.context import PurchaseContext
+from com.qode.qrew.v1.service.services.fraud.engine import (
+    FraudDecision,
+    FraudEvaluation,
+    FraudRuleEngine,
+)
+
+__all__ = [
+    "FraudDecision",
+    "FraudEvaluation",
+    "FraudRuleEngine",
+    "PurchaseContext",
+]

--- a/api/src/com/qode/qrew/v1/service/services/fraud/context.py
+++ b/api/src/com/qode/qrew/v1/service/services/fraud/context.py
@@ -1,0 +1,15 @@
+import uuid
+from dataclasses import dataclass
+from datetime import datetime
+
+
+@dataclass(frozen=True)
+class PurchaseContext:
+    """Inputs every fraud signal reads from. Stateless."""
+
+    user_id: uuid.UUID
+    user_created_at: datetime
+    phone_number: str | None
+    ip_address: str | None
+    device_fingerprint_hash: str | None
+    now: datetime

--- a/api/src/com/qode/qrew/v1/service/services/fraud/dependencies.py
+++ b/api/src/com/qode/qrew/v1/service/services/fraud/dependencies.py
@@ -1,0 +1,44 @@
+import redis.asyncio as aioredis
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from com.qode.qrew.v1.service.services.fraud.engine import FraudRuleEngine
+from com.qode.qrew.v1.service.services.fraud.signals import (
+    AccountAgeSignal,
+    FingerprintReuseSignal,
+    IpVelocitySignal,
+    TimeToPurchaseSignal,
+    VoipPhoneSignal,
+)
+from com.qode.qrew.v1.service.settings import settings
+
+
+class _ClientState:
+    client: aioredis.Redis | None = None  # type: ignore[type-arg]
+
+
+def _shared_redis() -> aioredis.Redis:  # type: ignore[type-arg]
+    if _ClientState.client is None:
+        _ClientState.client = aioredis.from_url(  # type: ignore[type-arg]
+            settings.redis_url, decode_responses=True
+        )
+    return _ClientState.client
+
+
+async def close_fraud() -> None:
+    if _ClientState.client is not None:
+        await _ClientState.client.aclose()
+    _ClientState.client = None
+
+
+def build_engine(session: AsyncSession) -> FraudRuleEngine:
+    """Compose the default engine; reuses the shared Redis client and DB session."""
+    redis_client = _shared_redis()
+    return FraudRuleEngine(
+        [
+            AccountAgeSignal(),
+            VoipPhoneSignal(),
+            TimeToPurchaseSignal(),
+            IpVelocitySignal(redis_client),
+            FingerprintReuseSignal(session),
+        ]
+    )

--- a/api/src/com/qode/qrew/v1/service/services/fraud/engine.py
+++ b/api/src/com/qode/qrew/v1/service/services/fraud/engine.py
@@ -1,0 +1,75 @@
+from collections.abc import Sequence
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Any
+
+import structlog
+
+from com.qode.qrew.v1.service.services.fraud.context import PurchaseContext
+from com.qode.qrew.v1.service.services.fraud.signals import Signal, SignalResult
+from com.qode.qrew.v1.service.settings import settings
+
+logger = structlog.get_logger(__name__)
+
+
+class FraudDecision(StrEnum):
+    allow = "allow"
+    review = "review"
+    block = "block"
+
+
+@dataclass(frozen=True)
+class FraudEvaluation:
+    score: int
+    decision: FraudDecision
+    signals: list[SignalResult]
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "score": self.score,
+            "decision": self.decision.value,
+            "signals": [
+                {"name": s.name, "score": s.score, "reason": s.reason}
+                for s in self.signals
+            ],
+        }
+
+
+class FraudRuleEngine:
+    """Sums per-signal scores and maps to allow / review / block."""
+
+    def __init__(self, signals: Sequence[Signal]) -> None:
+        self._signals = list(signals)
+
+    async def evaluate(self, context: PurchaseContext) -> FraudEvaluation:
+        if not settings.fraud_signals_enabled:
+            return FraudEvaluation(score=0, decision=FraudDecision.allow, signals=[])
+        results: list[SignalResult] = []
+        for signal in self._signals:
+            try:
+                result = await signal.evaluate(context)
+            except Exception as exc:
+                await logger.awarning(
+                    "fraud_signal_failed", signal=signal.name, error=repr(exc)
+                )
+                continue
+            results.append(result)
+        total = sum(r.score for r in results)
+        decision = self._classify(total)
+        await logger.ainfo(
+            "fraud.score.computed",
+            score=total,
+            decision=decision.value,
+            signals=[
+                {"name": r.name, "score": r.score, "reason": r.reason} for r in results
+            ],
+        )
+        return FraudEvaluation(score=total, decision=decision, signals=results)
+
+    @staticmethod
+    def _classify(score: int) -> FraudDecision:
+        if score >= settings.fraud_score_block_threshold:
+            return FraudDecision.block
+        if score >= settings.fraud_score_review_threshold:
+            return FraudDecision.review
+        return FraudDecision.allow

--- a/api/src/com/qode/qrew/v1/service/services/fraud/signals/__init__.py
+++ b/api/src/com/qode/qrew/v1/service/services/fraud/signals/__init__.py
@@ -1,0 +1,26 @@
+from com.qode.qrew.v1.service.services.fraud.signals.account_age import (
+    AccountAgeSignal,
+)
+from com.qode.qrew.v1.service.services.fraud.signals.base import Signal, SignalResult
+from com.qode.qrew.v1.service.services.fraud.signals.fingerprint_reuse import (
+    FingerprintReuseSignal,
+)
+from com.qode.qrew.v1.service.services.fraud.signals.ip_velocity import (
+    IpVelocitySignal,
+)
+from com.qode.qrew.v1.service.services.fraud.signals.time_to_purchase import (
+    TimeToPurchaseSignal,
+)
+from com.qode.qrew.v1.service.services.fraud.signals.voip_phone import (
+    VoipPhoneSignal,
+)
+
+__all__ = [
+    "AccountAgeSignal",
+    "FingerprintReuseSignal",
+    "IpVelocitySignal",
+    "Signal",
+    "SignalResult",
+    "TimeToPurchaseSignal",
+    "VoipPhoneSignal",
+]

--- a/api/src/com/qode/qrew/v1/service/services/fraud/signals/account_age.py
+++ b/api/src/com/qode/qrew/v1/service/services/fraud/signals/account_age.py
@@ -1,0 +1,27 @@
+from datetime import timedelta
+
+from com.qode.qrew.v1.service.services.fraud.context import PurchaseContext
+from com.qode.qrew.v1.service.services.fraud.signals.base import SignalResult
+from com.qode.qrew.v1.service.settings import settings
+
+
+class AccountAgeSignal:
+    """Younger accounts score higher; brand-new ones add the most."""
+
+    name = "account_age"
+
+    async def evaluate(self, context: PurchaseContext) -> SignalResult:
+        age = context.now - context.user_created_at
+        if age < timedelta(minutes=10):
+            return SignalResult(
+                name=self.name,
+                score=settings.fraud_weight_account_age_recent,
+                reason="account_younger_than_10_minutes",
+            )
+        if age < timedelta(hours=1):
+            return SignalResult(
+                name=self.name,
+                score=settings.fraud_weight_account_age_young,
+                reason="account_younger_than_1_hour",
+            )
+        return SignalResult(name=self.name, score=0, reason="ok")

--- a/api/src/com/qode/qrew/v1/service/services/fraud/signals/base.py
+++ b/api/src/com/qode/qrew/v1/service/services/fraud/signals/base.py
@@ -1,0 +1,20 @@
+from dataclasses import dataclass
+from typing import Protocol, runtime_checkable
+
+from com.qode.qrew.v1.service.services.fraud.context import PurchaseContext
+
+
+@dataclass(frozen=True)
+class SignalResult:
+    name: str
+    score: int
+    reason: str
+
+
+@runtime_checkable
+class Signal(Protocol):
+    """Stateless, synchronous-or-async scoring fragment."""
+
+    name: str
+
+    async def evaluate(self, context: PurchaseContext) -> SignalResult: ...

--- a/api/src/com/qode/qrew/v1/service/services/fraud/signals/fingerprint_reuse.py
+++ b/api/src/com/qode/qrew/v1/service/services/fraud/signals/fingerprint_reuse.py
@@ -1,0 +1,39 @@
+from datetime import timedelta
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from com.qode.qrew.v1.service.models.device.fingerprint import DeviceFingerprint
+from com.qode.qrew.v1.service.services.fraud.context import PurchaseContext
+from com.qode.qrew.v1.service.services.fraud.signals.base import SignalResult
+from com.qode.qrew.v1.service.settings import settings
+
+
+class FingerprintReuseSignal:
+    """Count distinct accounts seen on the same fingerprint in the lookback."""
+
+    name = "fingerprint_reuse"
+
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+
+    async def evaluate(self, context: PurchaseContext) -> SignalResult:
+        fingerprint = context.device_fingerprint_hash
+        if fingerprint is None:
+            return SignalResult(name=self.name, score=0, reason="no_fingerprint")
+        cutoff = context.now - timedelta(
+            hours=settings.fraud_fingerprint_lookback_hours
+        )
+        result = await self._session.execute(
+            select(func.count(func.distinct(DeviceFingerprint.user_id)))
+            .where(DeviceFingerprint.fingerprint_hash == fingerprint)
+            .where(DeviceFingerprint.seen_at >= cutoff)
+        )
+        distinct_accounts = int(result.scalar_one() or 0)
+        if distinct_accounts > settings.fraud_fingerprint_threshold:
+            return SignalResult(
+                name=self.name,
+                score=settings.fraud_weight_fingerprint_reuse,
+                reason=f"distinct_accounts:{distinct_accounts}",
+            )
+        return SignalResult(name=self.name, score=0, reason=f"ok:{distinct_accounts}")

--- a/api/src/com/qode/qrew/v1/service/services/fraud/signals/ip_velocity.py
+++ b/api/src/com/qode/qrew/v1/service/services/fraud/signals/ip_velocity.py
@@ -1,0 +1,45 @@
+import time
+import uuid
+
+import redis.asyncio as aioredis
+import structlog
+
+from com.qode.qrew.v1.service.services.fraud.context import PurchaseContext
+from com.qode.qrew.v1.service.services.fraud.signals.base import SignalResult
+from com.qode.qrew.v1.service.settings import settings
+
+logger = structlog.get_logger(__name__)
+
+_KEY_PREFIX = "fraud:ip:velocity"
+
+
+class IpVelocitySignal:
+    """Count reservation attempts per IP over a sliding window."""
+
+    name = "ip_velocity"
+
+    def __init__(self, redis_client: aioredis.Redis) -> None:  # type: ignore[type-arg]
+        self._redis = redis_client
+
+    async def evaluate(self, context: PurchaseContext) -> SignalResult:
+        ip = context.ip_address
+        if ip is None:
+            return SignalResult(name=self.name, score=0, reason="no_ip")
+        key = f"{_KEY_PREFIX}:{ip}"
+        window_ms = settings.fraud_ip_velocity_window_seconds * 1000
+        now_ms = int(time.time() * 1000)
+        try:
+            await self._redis.zremrangebyscore(key, 0, now_ms - window_ms)  # type: ignore[misc]
+            await self._redis.zadd(key, {f"{now_ms}-{uuid.uuid4().hex}": now_ms})  # type: ignore[misc]
+            await self._redis.pexpire(key, window_ms * 2)  # type: ignore[misc]
+            count = int(await self._redis.zcard(key))  # type: ignore[misc]
+        except aioredis.RedisError as exc:
+            await logger.awarning("ip_velocity_unavailable", error=repr(exc))
+            return SignalResult(name=self.name, score=0, reason="redis_unavailable")
+        if count > settings.fraud_ip_velocity_threshold:
+            return SignalResult(
+                name=self.name,
+                score=settings.fraud_weight_ip_velocity,
+                reason=f"observed:{count}",
+            )
+        return SignalResult(name=self.name, score=0, reason=f"ok:{count}")

--- a/api/src/com/qode/qrew/v1/service/services/fraud/signals/time_to_purchase.py
+++ b/api/src/com/qode/qrew/v1/service/services/fraud/signals/time_to_purchase.py
@@ -1,0 +1,25 @@
+from com.qode.qrew.v1.service.services.fraud.context import PurchaseContext
+from com.qode.qrew.v1.service.services.fraud.signals.base import SignalResult
+from com.qode.qrew.v1.service.settings import settings
+
+
+class TimeToPurchaseSignal:
+    """A first purchase seconds after sign-up looks scripted."""
+
+    name = "time_to_purchase"
+
+    async def evaluate(self, context: PurchaseContext) -> SignalResult:
+        seconds = (context.now - context.user_created_at).total_seconds()
+        if seconds < 10:
+            return SignalResult(
+                name=self.name,
+                score=settings.fraud_weight_time_to_purchase_immediate,
+                reason="under_10_seconds",
+            )
+        if seconds < 60:
+            return SignalResult(
+                name=self.name,
+                score=settings.fraud_weight_time_to_purchase_fast,
+                reason="under_60_seconds",
+            )
+        return SignalResult(name=self.name, score=0, reason="ok")

--- a/api/src/com/qode/qrew/v1/service/services/fraud/signals/voip_phone.py
+++ b/api/src/com/qode/qrew/v1/service/services/fraud/signals/voip_phone.py
@@ -1,0 +1,22 @@
+from com.qode.qrew.v1.service.services.fraud.context import PurchaseContext
+from com.qode.qrew.v1.service.services.fraud.signals.base import SignalResult
+from com.qode.qrew.v1.service.settings import settings
+
+
+class VoipPhoneSignal:
+    """Phone numbers from known disposable/VoIP carriers add risk."""
+
+    name = "voip_phone"
+
+    async def evaluate(self, context: PurchaseContext) -> SignalResult:
+        phone = context.phone_number
+        if phone is None:
+            return SignalResult(name=self.name, score=0, reason="no_phone")
+        for prefix in settings.fraud_voip_phone_prefixes:
+            if phone.startswith(prefix):
+                return SignalResult(
+                    name=self.name,
+                    score=settings.fraud_weight_voip_phone,
+                    reason=f"voip_prefix:{prefix}",
+                )
+        return SignalResult(name=self.name, score=0, reason="ok")

--- a/api/src/com/qode/qrew/v1/service/services/reservation/reservation.py
+++ b/api/src/com/qode/qrew/v1/service/services/reservation/reservation.py
@@ -84,6 +84,8 @@ class ReservationService:
         event_id: uuid.UUID,
         ticket_type_id: uuid.UUID,
         quantity: int,
+        risk_score: int = 0,
+        requires_review: bool = False,
     ) -> Reservation:
         """Atomically reserve `quantity` seats; raise on capacity or limit breach."""
         if quantity < 1:
@@ -123,6 +125,8 @@ class ReservationService:
                 quantity=quantity,
                 status=ReservationStatus.reserved,
                 expires_at=expires_at,
+                risk_score=risk_score,
+                requires_review=requires_review,
             )
             reservation = await self._repo.insert(reservation)
             for _ in range(quantity):

--- a/api/src/com/qode/qrew/v1/service/settings.py
+++ b/api/src/com/qode/qrew/v1/service/settings.py
@@ -124,6 +124,28 @@ class Settings(BaseSettings):
     reservation_ttl_seconds: int = 600
     reservation_sweep_batch_size: int = 200
 
+    fraud_signals_enabled: bool = True
+    fraud_score_review_threshold: int = 40
+    fraud_score_block_threshold: int = 70
+    fraud_ip_velocity_window_seconds: int = 60
+    fraud_ip_velocity_threshold: int = 10
+    fraud_fingerprint_lookback_hours: int = 24
+    fraud_fingerprint_threshold: int = 2
+    fraud_weight_account_age_recent: int = 40
+    fraud_weight_account_age_young: int = 20
+    fraud_weight_voip_phone: int = 25
+    fraud_weight_time_to_purchase_immediate: int = 50
+    fraud_weight_time_to_purchase_fast: int = 30
+    fraud_weight_ip_velocity: int = 35
+    fraud_weight_fingerprint_reuse: int = 30
+    fraud_voip_phone_prefixes: list[str] = [
+        "+1844",
+        "+1855",
+        "+1866",
+        "+1877",
+        "+1888",
+    ]
+
     queue_redeem_window_seconds: int = 90
     queue_reservation_window_seconds: int = 120
     queue_admit_default_rate_per_minute: int = 60

--- a/api/tests/v1/fraud/engine_test.py
+++ b/api/tests/v1/fraud/engine_test.py
@@ -1,0 +1,171 @@
+import uuid
+from datetime import datetime, timedelta, timezone
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import fakeredis.aioredis
+import pytest
+import pytest_asyncio
+
+from com.qode.qrew.v1.service.services.fraud import (
+    FraudDecision,
+    FraudRuleEngine,
+    PurchaseContext,
+)
+from com.qode.qrew.v1.service.services.fraud.signals import (
+    AccountAgeSignal,
+    FingerprintReuseSignal,
+    IpVelocitySignal,
+    TimeToPurchaseSignal,
+    VoipPhoneSignal,
+)
+
+
+@pytest_asyncio.fixture
+async def redis_client() -> Any:
+    client = fakeredis.aioredis.FakeRedis(decode_responses=True)
+    try:
+        yield client
+    finally:
+        await client.aclose()
+
+
+def _context(
+    *,
+    age_minutes: float = 60,
+    phone: str | None = None,
+    ip: str | None = None,
+    fingerprint: str | None = None,
+) -> PurchaseContext:
+    now = datetime(2026, 7, 1, 12, 0, tzinfo=timezone.utc)
+    return PurchaseContext(
+        user_id=uuid.uuid4(),
+        user_created_at=now - timedelta(minutes=age_minutes),
+        phone_number=phone,
+        ip_address=ip,
+        device_fingerprint_hash=fingerprint,
+        now=now,
+    )
+
+
+async def test_account_age_brand_new_scores_high() -> None:
+    signal = AccountAgeSignal()
+    result = await signal.evaluate(_context(age_minutes=1))
+    assert result.score >= 40
+
+
+async def test_account_age_young_scores_medium() -> None:
+    signal = AccountAgeSignal()
+    result = await signal.evaluate(_context(age_minutes=30))
+    assert result.score == 20
+
+
+async def test_account_age_mature_is_zero() -> None:
+    signal = AccountAgeSignal()
+    result = await signal.evaluate(_context(age_minutes=600))
+    assert result.score == 0
+
+
+async def test_voip_phone_recognises_known_prefix() -> None:
+    signal = VoipPhoneSignal()
+    result = await signal.evaluate(_context(phone="+18445550199"))
+    assert result.score == 25
+
+
+async def test_voip_phone_unknown_is_zero() -> None:
+    signal = VoipPhoneSignal()
+    result = await signal.evaluate(_context(phone="+34666555444"))
+    assert result.score == 0
+
+
+async def test_time_to_purchase_under_10s_scores_max() -> None:
+    signal = TimeToPurchaseSignal()
+    now = datetime(2026, 7, 1, 12, 0, tzinfo=timezone.utc)
+    ctx = PurchaseContext(
+        user_id=uuid.uuid4(),
+        user_created_at=now - timedelta(seconds=5),
+        phone_number=None,
+        ip_address=None,
+        device_fingerprint_hash=None,
+        now=now,
+    )
+    result = await signal.evaluate(ctx)
+    assert result.score == 50
+
+
+async def test_ip_velocity_under_threshold_is_zero(redis_client: Any) -> None:
+    signal = IpVelocitySignal(redis_client)
+    result = await signal.evaluate(_context(ip="1.2.3.4"))
+    assert result.score == 0
+
+
+async def test_ip_velocity_over_threshold_scores(redis_client: Any) -> None:
+    signal = IpVelocitySignal(redis_client)
+    ip = "1.2.3.4"
+    for _ in range(12):
+        await signal.evaluate(_context(ip=ip))
+    final = await signal.evaluate(_context(ip=ip))
+    assert final.score == 35
+
+
+async def test_fingerprint_reuse_counts_distinct_users() -> None:
+    session = MagicMock()
+    fake_result = MagicMock()
+    fake_result.scalar_one.return_value = 3
+    session.execute = AsyncMock(return_value=fake_result)
+    signal = FingerprintReuseSignal(session)
+    result = await signal.evaluate(_context(fingerprint="abc"))
+    assert result.score == 30
+
+
+async def test_fingerprint_reuse_below_threshold_is_zero() -> None:
+    session = MagicMock()
+    fake_result = MagicMock()
+    fake_result.scalar_one.return_value = 1
+    session.execute = AsyncMock(return_value=fake_result)
+    signal = FingerprintReuseSignal(session)
+    result = await signal.evaluate(_context(fingerprint="abc"))
+    assert result.score == 0
+
+
+class _FixedSignal:
+    def __init__(self, name: str, score: int) -> None:
+        self.name = name
+        self._score = score
+
+    async def evaluate(self, context: PurchaseContext) -> Any:
+        from com.qode.qrew.v1.service.services.fraud.signals import SignalResult
+
+        del context
+        return SignalResult(name=self.name, score=self._score, reason="fixed")
+
+
+async def test_engine_classifies_block_at_or_above_threshold() -> None:
+    engine = FraudRuleEngine([_FixedSignal("a", 40), _FixedSignal("b", 30)])
+    evaluation = await engine.evaluate(_context())
+    assert evaluation.score == 70
+    assert evaluation.decision == FraudDecision.block
+
+
+async def test_engine_classifies_review_in_band() -> None:
+    engine = FraudRuleEngine([_FixedSignal("a", 50)])
+    evaluation = await engine.evaluate(_context())
+    assert evaluation.decision == FraudDecision.review
+
+
+async def test_engine_classifies_allow_below_review() -> None:
+    engine = FraudRuleEngine([_FixedSignal("a", 10)])
+    evaluation = await engine.evaluate(_context())
+    assert evaluation.decision == FraudDecision.allow
+
+
+async def test_engine_returns_allow_when_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from com.qode.qrew.v1.service.settings import settings
+
+    monkeypatch.setattr(settings, "fraud_signals_enabled", False)
+    engine = FraudRuleEngine([_FixedSignal("a", 100)])
+    evaluation = await engine.evaluate(_context())
+    assert evaluation.decision == FraudDecision.allow
+    assert evaluation.score == 0


### PR DESCRIPTION
## Summary

Adds a synchronous rule engine that scores each reservation attempt against a panel of stateless signals and blocks the request *before* any row lock opens.

The rate limiter handles brute-force, this handles intent.

Five signals ship in this PR, each its own file under `services/fraud/signals/`:

- **Account age**
- **VoIP / disposable phone**
- **Time-to-purchase**
- **IP velocity**
- **Device fingerprint reuse** 

## Verification

- `api/tests/v1/fraud/engine_test.py`

## Issue Reference

Closes [QRW-158](https://github.com/cristiangilsanz/qrew/issues/158)

## Checklist
- [x] I confirm that this PR follows the project's established coding standards.