### PR TITLE
feat: add stripe payment intent flow with 3DS2 webhook and idempotent transitions

### DIFF
--- a/api/alembic/versions/c6d7e8f9a0b1_2026_06_09_add_payments_table.py
+++ b/api/alembic/versions/c6d7e8f9a0b1_2026_06_09_add_payments_table.py
@@ -1,0 +1,77 @@
+"""2026_06_09_add_payments_table
+
+Revision ID: c6d7e8f9a0b1
+Revises: b5c6d7e8f9a0
+Create Date: 2026-06-09 03:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision: str = "c6d7e8f9a0b1"
+down_revision: str | None = "b5c6d7e8f9a0"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "payments",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column(
+            "reservation_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("reservations.id", ondelete="RESTRICT"),
+            nullable=False,
+            unique=True,
+        ),
+        sa.Column("provider", sa.String(32), nullable=False, server_default="stripe"),
+        sa.Column("provider_payment_intent_id", sa.String(255), nullable=True),
+        sa.Column("amount_cents", sa.Integer, nullable=False),
+        sa.Column("currency", sa.String(3), nullable=False),
+        sa.Column(
+            "status",
+            sa.String(20),
+            nullable=False,
+            server_default="requires_action",
+        ),
+        sa.Column("client_secret_ciphertext", sa.LargeBinary, nullable=True),
+        sa.Column("failure_code", sa.String(64), nullable=True),
+        sa.Column("failure_message", sa.Text, nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.CheckConstraint("amount_cents >= 0", name="ck_payments_amount"),
+        sa.CheckConstraint(
+            "status IN ('requires_action','processing','succeeded','failed','refunded')",
+            name="ck_payments_status",
+        ),
+    )
+    op.create_index(
+        "ix_payments_provider_payment_intent_id",
+        "payments",
+        ["provider_payment_intent_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_payments_provider_payment_intent_id", table_name="payments")
+    op.drop_table("payments")

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -46,6 +46,7 @@ dependencies = [
     "opencv-python-headless>=4.8",
     "cryptography>=42.0",
     "geoip2>=5.2.0",
+    "stripe>=15.2.0",
 ]
 
 [project.scripts]

--- a/api/src/com/qode/qrew/v1/service/core/payments/__init__.py
+++ b/api/src/com/qode/qrew/v1/service/core/payments/__init__.py
@@ -1,0 +1,7 @@
+from com.qode.qrew.v1.service.core.payments.stripe_client import (
+    CreatedIntent,
+    StripeClient,
+    StripeRealClient,
+)
+
+__all__ = ["CreatedIntent", "StripeClient", "StripeRealClient"]

--- a/api/src/com/qode/qrew/v1/service/core/payments/stripe_client.py
+++ b/api/src/com/qode/qrew/v1/service/core/payments/stripe_client.py
@@ -1,0 +1,68 @@
+from dataclasses import dataclass
+from typing import Any, Protocol
+
+import stripe
+import structlog
+
+from com.qode.qrew.v1.service.settings import settings
+
+logger = structlog.get_logger(__name__)
+
+
+@dataclass(frozen=True)
+class CreatedIntent:
+    intent_id: str
+    client_secret: str
+    status: str
+
+
+class StripeClient(Protocol):
+    """Narrow seam over Stripe so tests can inject a fake."""
+
+    async def create_payment_intent(
+        self,
+        *,
+        amount_cents: int,
+        currency: str,
+        idempotency_key: str,
+        metadata: dict[str, str],
+    ) -> CreatedIntent: ...
+
+    def verify_webhook(self, payload: bytes, signature: str) -> dict[str, Any]: ...
+
+
+class StripeRealClient:
+    """Production implementation backed by the official Stripe SDK."""
+
+    def __init__(self) -> None:
+        stripe.api_key = settings.stripe_secret_key
+        stripe.api_version = settings.stripe_api_version
+
+    async def create_payment_intent(
+        self,
+        *,
+        amount_cents: int,
+        currency: str,
+        idempotency_key: str,
+        metadata: dict[str, str],
+    ) -> CreatedIntent:
+        intent = stripe.PaymentIntent.create(
+            amount=amount_cents,
+            currency=currency.lower(),
+            automatic_payment_methods={"enabled": True},
+            metadata=metadata,
+            idempotency_key=idempotency_key,
+        )
+        client_secret = intent.client_secret or ""
+        return CreatedIntent(
+            intent_id=intent.id, client_secret=client_secret, status=intent.status
+        )
+
+    def verify_webhook(self, payload: bytes, signature: str) -> dict[str, Any]:
+        event = stripe.Webhook.construct_event(  # type: ignore[no-untyped-call]
+            payload=payload,
+            sig_header=signature,
+            secret=settings.stripe_webhook_signing_secret,
+        )
+        result: dict[str, Any] = dict(event.to_dict_recursive())  # type: ignore[no-untyped-call]
+        return result

--- a/api/src/com/qode/qrew/v1/service/core/payments/webhook_idempotency.py
+++ b/api/src/com/qode/qrew/v1/service/core/payments/webhook_idempotency.py
@@ -1,0 +1,36 @@
+import redis.asyncio as aioredis
+
+from com.qode.qrew.v1.service.settings import settings
+
+_KEY_PREFIX = "payments:webhook"
+
+
+class _ClientState:
+    client: aioredis.Redis | None = None  # type: ignore[type-arg]
+
+
+def _shared_redis() -> aioredis.Redis:  # type: ignore[type-arg]
+    if _ClientState.client is None:
+        _ClientState.client = aioredis.from_url(  # type: ignore[type-arg]
+            settings.redis_url, decode_responses=True
+        )
+    return _ClientState.client
+
+
+async def close_webhook_idempotency() -> None:
+    if _ClientState.client is not None:
+        await _ClientState.client.aclose()
+    _ClientState.client = None
+
+
+async def claim_event(event_id: str) -> bool:
+    """Return True if this is the first time we have seen this Stripe event."""
+    redis = _shared_redis()
+    key = f"{_KEY_PREFIX}:{event_id}"
+    result = await redis.set(  # type: ignore[misc]
+        key,
+        "1",
+        ex=settings.payments_webhook_idempotency_ttl_seconds,
+        nx=True,
+    )
+    return bool(result)

--- a/api/src/com/qode/qrew/v1/service/models/audit/audit.py
+++ b/api/src/com/qode/qrew/v1/service/models/audit/audit.py
@@ -76,6 +76,10 @@ class AuditAction(enum.StrEnum):
     QUEUE_REDEEM_FAILED = "queue_redeem_failed"
     RESERVATION_FLAGGED = "reservation_flagged"
     RESERVATION_BLOCKED = "reservation_blocked"
+    PAYMENT_INITIATED = "payment_initiated"  # noqa: S105
+    PAYMENT_SUCCEEDED = "payment_succeeded"  # noqa: S105
+    PAYMENT_FAILED = "payment_failed"  # noqa: S105
+    WEBHOOK_INVALID_SIGNATURE = "webhook_invalid_signature"
 
 
 class AuditEvent(Base):

--- a/api/src/com/qode/qrew/v1/service/models/payment/__init__.py
+++ b/api/src/com/qode/qrew/v1/service/models/payment/__init__.py
@@ -1,0 +1,3 @@
+from com.qode.qrew.v1.service.models.payment.payment import Payment, PaymentStatus
+
+__all__ = ["Payment", "PaymentStatus"]

--- a/api/src/com/qode/qrew/v1/service/models/payment/payment.py
+++ b/api/src/com/qode/qrew/v1/service/models/payment/payment.py
@@ -1,0 +1,72 @@
+import enum
+import uuid
+from datetime import datetime
+
+from sqlalchemy import (
+    CheckConstraint,
+    DateTime,
+    ForeignKey,
+    Index,
+    Integer,
+    LargeBinary,
+    String,
+    Text,
+    func,
+)
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from com.qode.qrew.v1.service.core.infra.database import Base
+
+
+class PaymentStatus(enum.StrEnum):
+    requires_action = "requires_action"
+    processing = "processing"
+    succeeded = "succeeded"
+    failed = "failed"
+    refunded = "refunded"
+
+
+class Payment(Base):
+    __tablename__ = "payments"
+    __table_args__ = (
+        CheckConstraint("amount_cents >= 0", name="ck_payments_amount"),
+        Index("ix_payments_provider_payment_intent_id", "provider_payment_intent_id"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    reservation_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("reservations.id", ondelete="RESTRICT"),
+        nullable=False,
+        unique=True,
+    )
+    provider: Mapped[str] = mapped_column(
+        String(32), nullable=False, server_default="stripe"
+    )
+    provider_payment_intent_id: Mapped[str | None] = mapped_column(
+        String(255), nullable=True
+    )
+    amount_cents: Mapped[int] = mapped_column(Integer, nullable=False)
+    currency: Mapped[str] = mapped_column(String(3), nullable=False)
+    status: Mapped[PaymentStatus] = mapped_column(
+        String(20),
+        nullable=False,
+        server_default=PaymentStatus.requires_action.value,
+    )
+    client_secret_ciphertext: Mapped[bytes | None] = mapped_column(
+        LargeBinary, nullable=True
+    )
+    failure_code: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    failure_message: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
+    )

--- a/api/src/com/qode/qrew/v1/service/repositories/payment/__init__.py
+++ b/api/src/com/qode/qrew/v1/service/repositories/payment/__init__.py
@@ -1,0 +1,3 @@
+from com.qode.qrew.v1.service.repositories.payment.payment import PaymentRepository
+
+__all__ = ["PaymentRepository"]

--- a/api/src/com/qode/qrew/v1/service/repositories/payment/payment.py
+++ b/api/src/com/qode/qrew/v1/service/repositories/payment/payment.py
@@ -1,0 +1,40 @@
+import uuid
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from com.qode.qrew.v1.service.models.payment import Payment
+
+
+class PaymentRepository:
+    """Data access for the payments table."""
+
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+
+    async def get_by_id(self, payment_id: uuid.UUID) -> Payment | None:
+        result = await self._session.execute(
+            select(Payment).where(Payment.id == payment_id)
+        )
+        return result.scalar_one_or_none()
+
+    async def get_by_reservation_id(self, reservation_id: uuid.UUID) -> Payment | None:
+        result = await self._session.execute(
+            select(Payment).where(Payment.reservation_id == reservation_id)
+        )
+        return result.scalar_one_or_none()
+
+    async def get_by_intent_id(self, intent_id: str) -> Payment | None:
+        result = await self._session.execute(
+            select(Payment).where(Payment.provider_payment_intent_id == intent_id)
+        )
+        return result.scalar_one_or_none()
+
+    async def insert(self, payment: Payment) -> Payment:
+        self._session.add(payment)
+        await self._session.flush()
+        await self._session.refresh(payment)
+        return payment
+
+    async def flush(self) -> None:
+        await self._session.flush()

--- a/api/src/com/qode/qrew/v1/service/routers/__init__.py
+++ b/api/src/com/qode/qrew/v1/service/routers/__init__.py
@@ -10,6 +10,7 @@ from com.qode.qrew.v1.service.routers.event import router as event_router
 from com.qode.qrew.v1.service.routers.public_catalog import (
     router as public_catalog_router,
 )
+from com.qode.qrew.v1.service.routers.payment import router as payment_router
 from com.qode.qrew.v1.service.routers.queue import router as queue_router
 from com.qode.qrew.v1.service.routers.reservation import (
     router as reservation_router,
@@ -31,6 +32,7 @@ router.include_router(ticket_type_router)
 router.include_router(public_catalog_router)
 router.include_router(reservation_router)
 router.include_router(queue_router)
+router.include_router(payment_router)
 
 if settings.debug:
     from com.qode.qrew.v1.service.routers.dev import router as dev_router

--- a/api/src/com/qode/qrew/v1/service/routers/payment.py
+++ b/api/src/com/qode/qrew/v1/service/routers/payment.py
@@ -1,0 +1,197 @@
+import uuid
+from typing import Any, cast
+
+import structlog
+from fastapi import APIRouter, Depends, Header, HTTPException, Request, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from com.qode.qrew.v1.service.core.auth.auth import get_current_user
+from com.qode.qrew.v1.service.core.idempotency import idempotent
+from com.qode.qrew.v1.service.core.infra.database import get_db
+from com.qode.qrew.v1.service.core.infra.limiter import limiter
+from com.qode.qrew.v1.service.core.locking.errors import LockUnavailableError
+from com.qode.qrew.v1.service.core.payments import StripeClient, StripeRealClient
+from com.qode.qrew.v1.service.core.payments.webhook_idempotency import claim_event
+from com.qode.qrew.v1.service.models.audit.audit import AuditAction
+from com.qode.qrew.v1.service.models.auth.user import User
+from com.qode.qrew.v1.service.repositories.payment import PaymentRepository
+from com.qode.qrew.v1.service.repositories.reservation import ReservationRepository
+from com.qode.qrew.v1.service.repositories.ticket_type import TicketTypeRepository
+from com.qode.qrew.v1.service.schemas.payment import PaymentInitiateResponse
+from com.qode.qrew.v1.service.services.audit import AuditService
+from com.qode.qrew.v1.service.services.payment import (
+    PaymentError,
+    PaymentExpiredError,
+    PaymentService,
+)
+
+logger = structlog.get_logger(__name__)
+
+router = APIRouter(tags=["payments"])
+
+_stripe_client: StripeClient = StripeRealClient()
+
+
+def get_stripe_client() -> StripeClient:
+    """FastAPI dependency override seam for tests."""
+    return _stripe_client
+
+
+def _service(db: AsyncSession, stripe: StripeClient) -> PaymentService:
+    return PaymentService(
+        db,
+        PaymentRepository(db),
+        ReservationRepository(db),
+        TicketTypeRepository(db),
+        stripe,
+        AuditService(),
+    )
+
+
+@router.post(
+    "/reservations/{reservation_id}/payment",
+    response_model=PaymentInitiateResponse,
+    status_code=status.HTTP_201_CREATED,
+    summary="Create or return the PaymentIntent for a reservation",
+)
+@limiter.limit("30/minute")  # type: ignore[misc]
+@idempotent(scope="user", ttl_seconds=600)
+async def initiate_payment(
+    request: Request,
+    reservation_id: uuid.UUID,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+    stripe_client: StripeClient = Depends(get_stripe_client),
+) -> PaymentInitiateResponse:
+    """Initiate a PaymentIntent for the caller's reservation."""
+    del request
+    service = _service(db, stripe_client)
+    try:
+        payment = await service.initiate(
+            actor_id=current_user.id, reservation_id=reservation_id
+        )
+    except PaymentExpiredError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_410_GONE,
+            detail={"message": exc.message, "field": exc.field},
+        ) from exc
+    except PaymentError as exc:
+        code = (
+            status.HTTP_404_NOT_FOUND
+            if exc.field in {"reservation_id", "ticket_type_id"}
+            else status.HTTP_400_BAD_REQUEST
+        )
+        raise HTTPException(
+            status_code=code,
+            detail={"message": exc.message, "field": exc.field},
+        ) from exc
+    client_secret = service.decrypt_client_secret(payment) or ""
+    return PaymentInitiateResponse(
+        id=payment.id,
+        reservation_id=payment.reservation_id,
+        amount_cents=payment.amount_cents,
+        currency=payment.currency,
+        status=payment.status,
+        client_secret=client_secret,
+        created_at=payment.created_at,
+    )
+
+
+@router.post(
+    "/payments/webhook",
+    status_code=status.HTTP_200_OK,
+    include_in_schema=False,
+)
+async def stripe_webhook(
+    request: Request,
+    stripe_signature: str | None = Header(default=None, alias="Stripe-Signature"),
+    db: AsyncSession = Depends(get_db),
+    stripe_client: StripeClient = Depends(get_stripe_client),
+) -> dict[str, str]:
+    """Stripe-Signature-verified webhook entry point."""
+    payload = await request.body()
+    audit = AuditService()
+    if stripe_signature is None:
+        try:
+            await audit.record(
+                action=AuditAction.WEBHOOK_INVALID_SIGNATURE,
+                actor_id=None,
+                entity_type="payment",
+                entity_id=None,
+                payload={"reason": "missing_signature"},
+            )
+        except Exception:
+            pass
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={"message": "Missing Stripe-Signature header", "field": None},
+        )
+    try:
+        event = stripe_client.verify_webhook(payload, stripe_signature)
+    except Exception as exc:
+        try:
+            await audit.record(
+                action=AuditAction.WEBHOOK_INVALID_SIGNATURE,
+                actor_id=None,
+                entity_type="payment",
+                entity_id=None,
+                payload={"reason": "verification_failed"},
+            )
+        except Exception:
+            pass
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={"message": "Invalid Stripe signature", "field": None},
+        ) from exc
+    event_id = str(event.get("id") or "")
+    if not event_id:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={"message": "Webhook payload missing id", "field": None},
+        )
+    if not await claim_event(event_id):
+        return {"status": "duplicate"}
+    await _dispatch_event(_service(db, stripe_client), event)
+    return {"status": "ok"}
+
+
+def _read_str(d: dict[str, Any], key: str) -> str | None:
+    value: Any = d.get(key)
+    return value if isinstance(value, str) else None
+
+
+def _read_dict(d: dict[str, Any], key: str) -> dict[str, Any]:
+    value: Any = d.get(key)
+    return cast(dict[str, Any], value) if isinstance(value, dict) else {}
+
+
+async def _dispatch_event(service: PaymentService, event: dict[str, Any]) -> None:
+    event_type = _read_str(event, "type") or ""
+    data_section = _read_dict(event, "data")
+    data_object = _read_dict(data_section, "object")
+    intent_id = _read_str(data_object, "id")
+    if intent_id is None:
+        return
+    try:
+        if event_type == "payment_intent.succeeded":
+            await service.apply_succeeded(intent_id=intent_id)
+        elif event_type == "payment_intent.payment_failed":
+            last_error = _read_dict(data_object, "last_payment_error")
+            await service.apply_failed(
+                intent_id=intent_id,
+                failure_code=_read_str(last_error, "code"),
+                failure_message=_read_str(last_error, "message"),
+            )
+        elif event_type in {
+            "payment_intent.requires_action",
+            "payment_intent.processing",
+        }:
+            stripe_status = _read_str(data_object, "status")
+            if stripe_status is not None:
+                await service.update_intermediate(
+                    intent_id=intent_id, status=stripe_status
+                )
+    except LockUnavailableError:
+        await logger.awarning(
+            "webhook_lock_unavailable", event_type=event_type, intent_id=intent_id
+        )

--- a/api/src/com/qode/qrew/v1/service/schemas/payment/__init__.py
+++ b/api/src/com/qode/qrew/v1/service/schemas/payment/__init__.py
@@ -1,0 +1,3 @@
+from com.qode.qrew.v1.service.schemas.payment.payment import PaymentInitiateResponse
+
+__all__ = ["PaymentInitiateResponse"]

--- a/api/src/com/qode/qrew/v1/service/schemas/payment/payment.py
+++ b/api/src/com/qode/qrew/v1/service/schemas/payment/payment.py
@@ -1,0 +1,16 @@
+import uuid
+from datetime import datetime
+
+from pydantic import BaseModel
+
+from com.qode.qrew.v1.service.models.payment import PaymentStatus
+
+
+class PaymentInitiateResponse(BaseModel):
+    id: uuid.UUID
+    reservation_id: uuid.UUID
+    amount_cents: int
+    currency: str
+    status: PaymentStatus
+    client_secret: str
+    created_at: datetime

--- a/api/src/com/qode/qrew/v1/service/services/payment/__init__.py
+++ b/api/src/com/qode/qrew/v1/service/services/payment/__init__.py
@@ -1,0 +1,7 @@
+from com.qode.qrew.v1.service.services.payment.payment import (
+    PaymentError,
+    PaymentExpiredError,
+    PaymentService,
+)
+
+__all__ = ["PaymentError", "PaymentExpiredError", "PaymentService"]

--- a/api/src/com/qode/qrew/v1/service/services/payment/payment.py
+++ b/api/src/com/qode/qrew/v1/service/services/payment/payment.py
@@ -1,0 +1,226 @@
+import uuid
+from typing import Any
+
+import structlog
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from com.qode.qrew.v1.service.core.auth import pii_crypto
+from com.qode.qrew.v1.service.core.infra.errors import DomainError
+from com.qode.qrew.v1.service.core.locking import redlock
+from com.qode.qrew.v1.service.core.observability import traced
+from com.qode.qrew.v1.service.core.outbox import publish_via_outbox
+from com.qode.qrew.v1.service.core.payments import StripeClient
+from com.qode.qrew.v1.service.models.audit.audit import AuditAction
+from com.qode.qrew.v1.service.models.payment import Payment, PaymentStatus
+from com.qode.qrew.v1.service.models.reservation import (
+    Reservation,
+    ReservationStatus,
+)
+from com.qode.qrew.v1.service.models.ticket import TicketState
+from com.qode.qrew.v1.service.repositories.payment import PaymentRepository
+from com.qode.qrew.v1.service.repositories.reservation import ReservationRepository
+from com.qode.qrew.v1.service.repositories.ticket_type import TicketTypeRepository
+from com.qode.qrew.v1.service.services.audit import AuditService
+from com.qode.qrew.v1.service.settings import settings
+
+logger = structlog.get_logger(__name__)
+
+
+class PaymentError(DomainError):
+    """Raised when a payment operation fails a domain rule."""
+
+
+class PaymentExpiredError(DomainError):
+    """Raised when the reservation has already expired and cannot be paid."""
+
+
+class PaymentService:
+    """Business logic for the payment aggregate."""
+
+    def __init__(
+        self,
+        session: AsyncSession,
+        repo: PaymentRepository,
+        reservation_repo: ReservationRepository,
+        tier_repo: TicketTypeRepository,
+        stripe: StripeClient,
+        audit: AuditService,
+    ) -> None:
+        self._session = session
+        self._repo = repo
+        self._reservation_repo = reservation_repo
+        self._tier_repo = tier_repo
+        self._stripe = stripe
+        self._audit = audit
+
+    @traced("payment.initiate")
+    async def initiate(
+        self,
+        *,
+        actor_id: uuid.UUID,
+        reservation_id: uuid.UUID,
+    ) -> Payment:
+        """Create or return the PaymentIntent for a reservation."""
+        from datetime import datetime, timezone
+
+        reservation = await self._reservation_repo.get_by_id(reservation_id)
+        if reservation is None or reservation.user_id != actor_id:
+            raise PaymentError("Reservation not found", field="reservation_id")
+        if reservation.status != ReservationStatus.reserved:
+            raise PaymentError("Reservation is not pending payment", field="status")
+        if reservation.expires_at <= datetime.now(timezone.utc):
+            raise PaymentExpiredError("Reservation has expired", field="expires_at")
+        existing = await self._repo.get_by_reservation_id(reservation.id)
+        if existing is not None and existing.provider_payment_intent_id:
+            return existing
+        tier = await self._tier_repo.get_by_id(reservation.ticket_type_id)
+        if tier is None:
+            raise PaymentError("Ticket type not found", field="ticket_type_id")
+        amount_cents = tier.price_cents * reservation.quantity
+        currency = tier.currency or settings.payments_default_currency
+        intent = await self._stripe.create_payment_intent(
+            amount_cents=amount_cents,
+            currency=currency,
+            idempotency_key=f"reservation:{reservation.id}",
+            metadata={"reservation_id": str(reservation.id)},
+        )
+        payment = existing or Payment(
+            reservation_id=reservation.id,
+            amount_cents=amount_cents,
+            currency=currency,
+        )
+        payment.provider_payment_intent_id = intent.intent_id
+        payment.client_secret_ciphertext = pii_crypto.encrypt(intent.client_secret)
+        payment.status = _map_intent_status(intent.status)
+        if existing is None:
+            payment = await self._repo.insert(payment)
+        else:
+            await self._repo.flush()
+        await self._record(
+            AuditAction.PAYMENT_INITIATED,
+            actor_id=actor_id,
+            payment_id=payment.id,
+            payload={
+                "reservation_id": str(reservation.id),
+                "amount_cents": amount_cents,
+                "currency": currency,
+            },
+        )
+        return payment
+
+    def decrypt_client_secret(self, payment: Payment) -> str | None:
+        if payment.client_secret_ciphertext is None:
+            return None
+        return pii_crypto.decrypt(payment.client_secret_ciphertext)
+
+    @traced("payment.apply_succeeded")
+    async def apply_succeeded(self, *, intent_id: str) -> None:
+        payment = await self._repo.get_by_intent_id(intent_id)
+        if payment is None:
+            await logger.awarning("payment_intent_unknown", intent_id=intent_id)
+            return
+        reservation = await self._reservation_repo.get_by_id(payment.reservation_id)
+        if reservation is None:
+            return
+        async with redlock(f"reservation:{reservation.id}:lifecycle", ttl_seconds=10):
+            fresh = await self._reservation_repo.get_by_id(reservation.id)
+            if fresh is None or fresh.status != ReservationStatus.reserved:
+                payment.status = PaymentStatus.succeeded
+                await self._repo.flush()
+                return
+            fresh.status = ReservationStatus.paid
+            for ticket in await self._reservation_repo.list_tickets(fresh.id):
+                if ticket.state == TicketState.reserved:
+                    ticket.state = TicketState.issued
+            payment.status = PaymentStatus.succeeded
+            await self._repo.flush()
+            await publish_via_outbox(
+                self._session,
+                aggregate_type="payment",
+                aggregate_id=str(payment.id),
+                job_name="notifications.payment_succeeded",
+                payload={"reservation_id": str(fresh.id)},
+            )
+            await self._record(
+                AuditAction.PAYMENT_SUCCEEDED,
+                actor_id=fresh.user_id,
+                payment_id=payment.id,
+                payload={"reservation_id": str(fresh.id)},
+            )
+
+    @traced("payment.apply_failed")
+    async def apply_failed(
+        self,
+        *,
+        intent_id: str,
+        failure_code: str | None,
+        failure_message: str | None,
+    ) -> None:
+        payment = await self._repo.get_by_intent_id(intent_id)
+        if payment is None:
+            return
+        payment.status = PaymentStatus.failed
+        payment.failure_code = failure_code
+        payment.failure_message = failure_message
+        await self._repo.flush()
+        await publish_via_outbox(
+            self._session,
+            aggregate_type="payment",
+            aggregate_id=str(payment.id),
+            job_name="notifications.payment_failed",
+            payload={
+                "reservation_id": str(payment.reservation_id),
+                "failure_code": failure_code,
+            },
+        )
+        reservation = await self._reservation_repo.get_by_id(payment.reservation_id)
+        await self._record(
+            AuditAction.PAYMENT_FAILED,
+            actor_id=reservation.user_id if reservation else uuid.uuid4(),
+            payment_id=payment.id,
+            payload={"failure_code": failure_code},
+        )
+
+    async def update_intermediate(self, *, intent_id: str, status: str) -> None:
+        payment = await self._repo.get_by_intent_id(intent_id)
+        if payment is None:
+            return
+        new_status = _map_intent_status(status)
+        if new_status in {PaymentStatus.succeeded, PaymentStatus.failed}:
+            return
+        payment.status = new_status
+        await self._repo.flush()
+
+    async def _record(
+        self,
+        action: AuditAction,
+        *,
+        actor_id: uuid.UUID,
+        payment_id: uuid.UUID,
+        payload: dict[str, Any],
+    ) -> None:
+        try:
+            await self._audit.record(
+                action=action,
+                actor_id=actor_id,
+                entity_type="payment",
+                entity_id=str(payment_id),
+                payload=payload,
+            )
+        except Exception:
+            await logger.awarning("audit_write_failed", action=action)
+
+
+def _map_intent_status(stripe_status: str) -> PaymentStatus:
+    mapping = {
+        "succeeded": PaymentStatus.succeeded,
+        "processing": PaymentStatus.processing,
+        "requires_payment_method": PaymentStatus.requires_action,
+        "requires_confirmation": PaymentStatus.requires_action,
+        "requires_action": PaymentStatus.requires_action,
+        "canceled": PaymentStatus.failed,
+    }
+    return mapping.get(stripe_status, PaymentStatus.requires_action)
+
+
+_ = Reservation  # noqa: B018 keep import for type completeness

--- a/api/src/com/qode/qrew/v1/service/settings.py
+++ b/api/src/com/qode/qrew/v1/service/settings.py
@@ -124,6 +124,12 @@ class Settings(BaseSettings):
     reservation_ttl_seconds: int = 600
     reservation_sweep_batch_size: int = 200
 
+    stripe_secret_key: str = ""
+    stripe_webhook_signing_secret: str = ""
+    stripe_api_version: str = "2024-06-20"
+    payments_default_currency: str = "EUR"
+    payments_webhook_idempotency_ttl_seconds: int = 86400
+
     fraud_signals_enabled: bool = True
     fraud_score_review_threshold: int = 40
     fraud_score_block_threshold: int = 70

--- a/api/tests/v1/payment/service_test.py
+++ b/api/tests/v1/payment/service_test.py
@@ -1,0 +1,253 @@
+import uuid
+from datetime import datetime, timedelta, timezone
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import fakeredis.aioredis
+import pytest
+import pytest_asyncio
+
+from com.qode.qrew.v1.service.core.locking import lock as lock_module
+from com.qode.qrew.v1.service.core.payments import CreatedIntent
+from com.qode.qrew.v1.service.models.payment import Payment, PaymentStatus
+from com.qode.qrew.v1.service.models.reservation import (
+    Reservation,
+    ReservationStatus,
+)
+from com.qode.qrew.v1.service.models.ticket import Ticket, TicketState
+from com.qode.qrew.v1.service.models.ticket_type import TicketType
+from com.qode.qrew.v1.service.services.payment import (
+    PaymentError,
+    PaymentExpiredError,
+    PaymentService,
+)
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def _fake_redis_for_locks() -> Any:  # pyright: ignore[reportUnusedFunction]
+    fake = fakeredis.aioredis.FakeRedis()
+    previous = lock_module._ClientState.client  # pyright: ignore[reportPrivateUsage]
+    lock_module._ClientState.client = fake  # pyright: ignore[reportPrivateUsage]
+    try:
+        yield fake
+    finally:
+        await fake.aclose()
+        lock_module._ClientState.client = previous  # pyright: ignore[reportPrivateUsage]
+
+
+def _reservation(
+    *,
+    user_id: uuid.UUID,
+    status: ReservationStatus = ReservationStatus.reserved,
+    expires_in: timedelta = timedelta(minutes=5),
+) -> Reservation:
+    res = Reservation(
+        id=uuid.uuid4(),
+        user_id=user_id,
+        event_id=uuid.uuid4(),
+        ticket_type_id=uuid.uuid4(),
+        quantity=2,
+        status=status,
+        expires_at=datetime.now(timezone.utc) + expires_in,
+    )
+    res.created_at = datetime.now(timezone.utc)
+    return res
+
+
+def _tier(reservation: Reservation) -> TicketType:
+    return TicketType(
+        id=reservation.ticket_type_id,
+        event_id=reservation.event_id,
+        name="general",
+        description=None,
+        capacity=100,
+        reserved_count=2,
+        price_cents=5000,
+        currency="EUR",
+        position=0,
+    )
+
+
+class _FakeStripe:
+    def __init__(self) -> None:
+        self.created: list[dict[str, Any]] = []
+
+    async def create_payment_intent(
+        self,
+        *,
+        amount_cents: int,
+        currency: str,
+        idempotency_key: str,
+        metadata: dict[str, str],
+    ) -> CreatedIntent:
+        self.created.append(
+            {
+                "amount_cents": amount_cents,
+                "currency": currency,
+                "idempotency_key": idempotency_key,
+                "metadata": metadata,
+            }
+        )
+        return CreatedIntent(
+            intent_id=f"pi_{len(self.created)}",
+            client_secret="cs_secret_123",
+            status="requires_action",
+        )
+
+    def verify_webhook(self, payload: bytes, signature: str) -> dict[str, Any]:
+        del payload, signature
+        return {}
+
+
+def _service(
+    *,
+    reservation: Reservation,
+    payment: Payment | None = None,
+    tickets: list[Ticket] | None = None,
+) -> tuple[PaymentService, _FakeStripe, MagicMock]:
+    tier = _tier(reservation)
+    session = MagicMock()
+
+    async def _flush() -> None:
+        return None
+
+    async def _refresh(_obj: Any) -> None:
+        return None
+
+    session.flush = AsyncMock(side_effect=_flush)
+    session.refresh = AsyncMock(side_effect=_refresh)
+    session.add = MagicMock()
+
+    payments_repo = MagicMock()
+    inserted: list[Payment] = []
+    if payment is not None:
+        payments_repo.get_by_reservation_id = AsyncMock(return_value=payment)
+    else:
+        payments_repo.get_by_reservation_id = AsyncMock(return_value=None)
+
+    async def _insert(new: Payment) -> Payment:
+        new.id = uuid.uuid4()
+        new.created_at = datetime.now(timezone.utc)
+        inserted.append(new)
+        return new
+
+    payments_repo.insert = AsyncMock(side_effect=_insert)
+    payments_repo.flush = AsyncMock()
+    payments_repo.get_by_intent_id = AsyncMock(return_value=payment)
+
+    reservation_repo = MagicMock()
+    reservation_repo.get_by_id = AsyncMock(return_value=reservation)
+    reservation_repo.list_tickets = AsyncMock(return_value=tickets or [])
+
+    tier_repo = MagicMock()
+    tier_repo.get_by_id = AsyncMock(return_value=tier)
+
+    stripe = _FakeStripe()
+    audit = MagicMock()
+    audit.record = AsyncMock()
+
+    service = PaymentService(
+        session, payments_repo, reservation_repo, tier_repo, stripe, audit
+    )
+    return service, stripe, payments_repo
+
+
+async def test_initiate_creates_payment_intent() -> None:
+    user_id = uuid.uuid4()
+    reservation = _reservation(user_id=user_id)
+    service, stripe, _ = _service(reservation=reservation)
+    payment = await service.initiate(actor_id=user_id, reservation_id=reservation.id)
+    assert payment.provider_payment_intent_id == "pi_1"
+    assert payment.status == PaymentStatus.requires_action
+    assert stripe.created[0]["idempotency_key"] == f"reservation:{reservation.id}"
+
+
+async def test_initiate_rejects_other_users_reservation() -> None:
+    reservation = _reservation(user_id=uuid.uuid4())
+    service, *_ = _service(reservation=reservation)
+    with pytest.raises(PaymentError, match="not found"):
+        await service.initiate(actor_id=uuid.uuid4(), reservation_id=reservation.id)
+
+
+async def test_initiate_rejects_expired_reservation() -> None:
+    user_id = uuid.uuid4()
+    reservation = _reservation(user_id=user_id, expires_in=timedelta(seconds=-1))
+    service, *_ = _service(reservation=reservation)
+    with pytest.raises(PaymentExpiredError):
+        await service.initiate(actor_id=user_id, reservation_id=reservation.id)
+
+
+async def test_initiate_returns_existing_payment_intent() -> None:
+    user_id = uuid.uuid4()
+    reservation = _reservation(user_id=user_id)
+    existing = Payment(
+        id=uuid.uuid4(),
+        reservation_id=reservation.id,
+        provider_payment_intent_id="pi_existing",
+        amount_cents=10000,
+        currency="EUR",
+        status=PaymentStatus.requires_action,
+    )
+    service, stripe, _ = _service(reservation=reservation, payment=existing)
+    payment = await service.initiate(actor_id=user_id, reservation_id=reservation.id)
+    assert payment.provider_payment_intent_id == "pi_existing"
+    assert not stripe.created
+
+
+async def test_apply_succeeded_transitions_reservation_and_tickets() -> None:
+    user_id = uuid.uuid4()
+    reservation = _reservation(user_id=user_id)
+    tickets = [
+        Ticket(
+            id=uuid.uuid4(),
+            reservation_id=reservation.id,
+            event_id=reservation.event_id,
+            ticket_type_id=reservation.ticket_type_id,
+            owner_user_id=user_id,
+            state=TicketState.reserved,
+        )
+        for _ in range(2)
+    ]
+    payment = Payment(
+        id=uuid.uuid4(),
+        reservation_id=reservation.id,
+        provider_payment_intent_id="pi_1",
+        amount_cents=10000,
+        currency="EUR",
+        status=PaymentStatus.requires_action,
+    )
+    service, _stripe, _ = _service(
+        reservation=reservation, payment=payment, tickets=tickets
+    )
+    await service.apply_succeeded(intent_id="pi_1")
+    assert reservation.status == ReservationStatus.paid
+    assert all(t.state == TicketState.issued for t in tickets)
+    assert payment.status == PaymentStatus.succeeded
+
+
+async def test_apply_failed_records_failure_and_keeps_reservation() -> None:
+    user_id = uuid.uuid4()
+    reservation = _reservation(user_id=user_id)
+    payment = Payment(
+        id=uuid.uuid4(),
+        reservation_id=reservation.id,
+        provider_payment_intent_id="pi_1",
+        amount_cents=10000,
+        currency="EUR",
+        status=PaymentStatus.requires_action,
+    )
+    service, *_ = _service(reservation=reservation, payment=payment)
+    await service.apply_failed(
+        intent_id="pi_1", failure_code="card_declined", failure_message="boom"
+    )
+    assert payment.status == PaymentStatus.failed
+    assert payment.failure_code == "card_declined"
+    assert reservation.status == ReservationStatus.reserved
+
+
+async def test_apply_succeeded_unknown_intent_is_noop() -> None:
+    user_id = uuid.uuid4()
+    reservation = _reservation(user_id=user_id)
+    service, *_ = _service(reservation=reservation, payment=None)
+    await service.apply_succeeded(intent_id="pi_unknown")
+    assert reservation.status == ReservationStatus.reserved

--- a/uv.lock
+++ b/uv.lock
@@ -209,6 +209,7 @@ dependencies = [
     { name = "redis", extra = ["hiredis"] },
     { name = "slowapi" },
     { name = "sqlalchemy", extra = ["asyncio"] },
+    { name = "stripe" },
     { name = "structlog" },
     { name = "uvicorn", extra = ["standard"] },
     { name = "webauthn" },
@@ -261,6 +262,7 @@ requires-dist = [
     { name = "redis", extras = ["hiredis"], specifier = ">=5.0" },
     { name = "slowapi", specifier = ">=0.1.9" },
     { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0" },
+    { name = "stripe", specifier = ">=15.2.0" },
     { name = "structlog", specifier = ">=24.1" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.30" },
     { name = "webauthn", specifier = ">=2.0" },
@@ -2524,6 +2526,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/81/69/17425771797c36cded50b7fe44e850315d039f28b15901ab44839e70b593/starlette-1.0.0.tar.gz", hash = "sha256:6a4beaf1f81bb472fd19ea9b918b50dc3a77a6f2e190a12954b25e6ed5eea149", size = 2655289, upload-time = "2026-03-22T18:29:46.779Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0b/c9/584bc9651441b4ba60cc4d557d8a547b5aff901af35bda3a4ee30c819b82/starlette-1.0.0-py3-none-any.whl", hash = "sha256:d3ec55e0bb321692d275455ddfd3df75fff145d009685eb40dc91fc66b03d38b", size = 72651, upload-time = "2026-03-22T18:29:45.111Z" },
+]
+
+[[package]]
+name = "stripe"
+version = "15.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "requests" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d0/28/c3550f39d9e258c21bcba81a89ef3ca7af352ad2cb14fe16b80248841644/stripe-15.2.0.tar.gz", hash = "sha256:f795d8a8ff27433e9ab03099afc0f5c4e992a8a6f92b9f839dc0048bb12f76f6", size = 1520207, upload-time = "2026-05-27T20:34:44.256Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d8/2b/697003ba6349058b65a5cb6b0bd8a8b0e909ed35911f7beebfc24b0563ee/stripe-15.2.0-py3-none-any.whl", hash = "sha256:e74d45bb07bb912fdc4ce81ffbdf184bcb92ce6e210cb7939966e537021c1842", size = 2168459, upload-time = "2026-05-27T20:34:42.312Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Lands the payment leg of the purchase pipeline. A reservation that already passed the fraud rule engine and capacity guard now becomes a Stripe PaymentIntent.

3DS2 challenges are handled by the frontend with the returned `client_secret`.

The backend transitions the reservation to `paid` and its tickets to `issued` only on a signature-verified webhook.

Test mode only (no real money for the demo).

The new `payments` table has a **unique** `reservation_id` foreign key so a reservation cannot be charged twice at the database level.

The `client_secret` is encrypted at rest with the same Fernet pool used for KYC documents and only ever returned to the caller who initiated the payment.

Status is one of `requires_action | processing | succeeded | failed | refunded`, enforced by a CHECK constraint.

The Stripe SDK call is wrapped behind a narrow `StripeClient` protocol with a `StripeRealClient` implementation, exposed as a FastAPI dependency.

Tests can inject a fake without touching the network.

## Verification

- `api/tests/v1/payment/service_test.py`

## Issue Reference

Closes [QRW-159](https://github.com/cristiangilsanz/qrew/issues/159)

## Checklist
- [x] I confirm that this PR follows the project's established coding standards.