### PR TITLE
feat: add stripe refund and chargeback webhook cancelling issued tickets

### DIFF
--- a/api/src/com/qode/qrew/v1/service/models/audit/audit.py
+++ b/api/src/com/qode/qrew/v1/service/models/audit/audit.py
@@ -80,6 +80,11 @@ class AuditAction(enum.StrEnum):
     PAYMENT_SUCCEEDED = "payment_succeeded"  # noqa: S105
     PAYMENT_FAILED = "payment_failed"  # noqa: S105
     WEBHOOK_INVALID_SIGNATURE = "webhook_invalid_signature"
+    PAYMENT_REFUNDED = "payment_refunded"  # noqa: S105
+    PAYMENT_PARTIAL_REFUND = "payment_partial_refund"  # noqa: S105
+    CHARGEBACK_OPENED = "chargeback_opened"
+    CHARGEBACK_CLOSED = "chargeback_closed"
+    CHARGEBACK_ON_USED_TICKET = "chargeback_on_used_ticket"  # noqa: S105
 
 
 class AuditEvent(Base):

--- a/api/src/com/qode/qrew/v1/service/routers/payment.py
+++ b/api/src/com/qode/qrew/v1/service/routers/payment.py
@@ -165,11 +165,16 @@ def _read_dict(d: dict[str, Any], key: str) -> dict[str, Any]:
     return cast(dict[str, Any], value) if isinstance(value, dict) else {}
 
 
+def _read_int(d: dict[str, Any], key: str) -> int | None:
+    value: Any = d.get(key)
+    return value if isinstance(value, int) else None
+
+
 async def _dispatch_event(service: PaymentService, event: dict[str, Any]) -> None:
     event_type = _read_str(event, "type") or ""
     data_section = _read_dict(event, "data")
     data_object = _read_dict(data_section, "object")
-    intent_id = _read_str(data_object, "id")
+    intent_id = _payment_intent_id_for(event_type, data_object)
     if intent_id is None:
         return
     try:
@@ -191,7 +196,26 @@ async def _dispatch_event(service: PaymentService, event: dict[str, Any]) -> Non
                 await service.update_intermediate(
                     intent_id=intent_id, status=stripe_status
                 )
+        elif event_type == "charge.refunded":
+            amount = _read_int(data_object, "amount") or 0
+            amount_refunded = _read_int(data_object, "amount_refunded") or 0
+            await service.apply_refund(
+                intent_id=intent_id,
+                amount_refunded=amount_refunded,
+                amount_total=amount,
+            )
+        elif event_type == "charge.dispute.created":
+            await service.apply_chargeback(intent_id=intent_id)
+        elif event_type == "charge.dispute.closed":
+            await service.record_chargeback_closed(intent_id=intent_id)
     except LockUnavailableError:
         await logger.awarning(
             "webhook_lock_unavailable", event_type=event_type, intent_id=intent_id
         )
+
+
+def _payment_intent_id_for(event_type: str, data_object: dict[str, Any]) -> str | None:
+    """Charge events carry the intent id on payment_intent; intent events on id."""
+    if event_type.startswith("charge."):
+        return _read_str(data_object, "payment_intent")
+    return _read_str(data_object, "id")

--- a/api/src/com/qode/qrew/v1/service/services/payment/payment.py
+++ b/api/src/com/qode/qrew/v1/service/services/payment/payment.py
@@ -181,6 +181,104 @@ class PaymentService:
             payload={"failure_code": failure_code},
         )
 
+    @traced("payment.apply_refund")
+    async def apply_refund(
+        self, *, intent_id: str, amount_refunded: int, amount_total: int
+    ) -> None:
+        """Handle charge.refunded; full refund cancels reservation and tickets."""
+        payment = await self._repo.get_by_intent_id(intent_id)
+        if payment is None:
+            return
+        if amount_refunded < amount_total:
+            await self._record(
+                AuditAction.PAYMENT_PARTIAL_REFUND,
+                actor_id=uuid.uuid4(),
+                payment_id=payment.id,
+                payload={
+                    "amount_refunded": amount_refunded,
+                    "amount_total": amount_total,
+                },
+            )
+            return
+        await self._cancel_for_payment(payment, reason=AuditAction.PAYMENT_REFUNDED)
+
+    @traced("payment.apply_chargeback")
+    async def apply_chargeback(self, *, intent_id: str) -> None:
+        """Handle charge.dispute.created; cancel issued tickets immediately."""
+        payment = await self._repo.get_by_intent_id(intent_id)
+        if payment is None:
+            return
+        await self._cancel_for_payment(payment, reason=AuditAction.CHARGEBACK_OPENED)
+
+    @traced("payment.record_chargeback_closed")
+    async def record_chargeback_closed(self, *, intent_id: str) -> None:
+        """Log the dispute closing; the FSM has already moved."""
+        payment = await self._repo.get_by_intent_id(intent_id)
+        if payment is None:
+            return
+        reservation = await self._reservation_repo.get_by_id(payment.reservation_id)
+        actor_id = reservation.user_id if reservation else uuid.uuid4()
+        await self._record(
+            AuditAction.CHARGEBACK_CLOSED,
+            actor_id=actor_id,
+            payment_id=payment.id,
+            payload={},
+        )
+
+    async def _cancel_for_payment(
+        self, payment: Payment, *, reason: AuditAction
+    ) -> None:
+        reservation = await self._reservation_repo.get_by_id(payment.reservation_id)
+        if reservation is None:
+            return
+        async with redlock(f"reservation:{reservation.id}:lifecycle", ttl_seconds=10):
+            tickets = await self._reservation_repo.list_tickets(reservation.id)
+            used = [t for t in tickets if t.state == TicketState.used]
+            if used:
+                await self._record(
+                    AuditAction.CHARGEBACK_ON_USED_TICKET,
+                    actor_id=reservation.user_id,
+                    payment_id=payment.id,
+                    payload={
+                        "used_ticket_ids": [str(t.id) for t in used],
+                        "reason": reason.value,
+                    },
+                )
+            cancellable_states = {TicketState.reserved, TicketState.issued}
+            qty_to_release = 0
+            for ticket in tickets:
+                if ticket.state in cancellable_states:
+                    ticket.state = TicketState.cancelled
+                    qty_to_release += 1
+            if qty_to_release > 0:
+                tier = await self._tier_repo.get_by_id(reservation.ticket_type_id)
+                if tier is not None:
+                    tier.reserved_count = max(0, tier.reserved_count - qty_to_release)
+            reservation.status = ReservationStatus.cancelled
+            payment.status = PaymentStatus.refunded
+            await self._repo.flush()
+            job_name = (
+                "notifications.ticket_cancelled_chargeback"
+                if reason == AuditAction.CHARGEBACK_OPENED
+                else "notifications.ticket_cancelled_refund"
+            )
+            await publish_via_outbox(
+                self._session,
+                aggregate_type="payment",
+                aggregate_id=str(payment.id),
+                job_name=job_name,
+                payload={
+                    "reservation_id": str(reservation.id),
+                    "reason": reason.value,
+                },
+            )
+            await self._record(
+                reason,
+                actor_id=reservation.user_id,
+                payment_id=payment.id,
+                payload={"reservation_id": str(reservation.id)},
+            )
+
     async def update_intermediate(self, *, intent_id: str, status: str) -> None:
         payment = await self._repo.get_by_intent_id(intent_id)
         if payment is None:

--- a/api/tests/v1/payment/refund_test.py
+++ b/api/tests/v1/payment/refund_test.py
@@ -1,0 +1,184 @@
+import uuid
+from datetime import datetime, timedelta, timezone
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import fakeredis.aioredis
+import pytest_asyncio
+
+from com.qode.qrew.v1.service.core.locking import lock as lock_module
+from com.qode.qrew.v1.service.models.audit.audit import AuditAction
+from com.qode.qrew.v1.service.models.payment import Payment, PaymentStatus
+from com.qode.qrew.v1.service.models.reservation import (
+    Reservation,
+    ReservationStatus,
+)
+from com.qode.qrew.v1.service.models.ticket import Ticket, TicketState
+from com.qode.qrew.v1.service.models.ticket_type import TicketType
+from com.qode.qrew.v1.service.services.payment import PaymentService
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def _fake_redis_for_locks() -> Any:  # pyright: ignore[reportUnusedFunction]
+    fake = fakeredis.aioredis.FakeRedis()
+    previous = lock_module._ClientState.client  # pyright: ignore[reportPrivateUsage]
+    lock_module._ClientState.client = fake  # pyright: ignore[reportPrivateUsage]
+    try:
+        yield fake
+    finally:
+        await fake.aclose()
+        lock_module._ClientState.client = previous  # pyright: ignore[reportPrivateUsage]
+
+
+def _setup(
+    *,
+    ticket_states: list[TicketState],
+    reservation_status: ReservationStatus = ReservationStatus.paid,
+    tier_reserved_count: int = 5,
+) -> tuple[PaymentService, MagicMock, Reservation, Payment, list[Ticket], TicketType]:
+    user_id = uuid.uuid4()
+    reservation = Reservation(
+        id=uuid.uuid4(),
+        user_id=user_id,
+        event_id=uuid.uuid4(),
+        ticket_type_id=uuid.uuid4(),
+        quantity=len(ticket_states),
+        status=reservation_status,
+        expires_at=datetime.now(timezone.utc) + timedelta(minutes=5),
+    )
+    reservation.created_at = datetime.now(timezone.utc)
+    tier = TicketType(
+        id=reservation.ticket_type_id,
+        event_id=reservation.event_id,
+        name="general",
+        description=None,
+        capacity=100,
+        reserved_count=tier_reserved_count,
+        price_cents=5000,
+        currency="EUR",
+        position=0,
+    )
+    tickets = [
+        Ticket(
+            id=uuid.uuid4(),
+            reservation_id=reservation.id,
+            event_id=reservation.event_id,
+            ticket_type_id=reservation.ticket_type_id,
+            owner_user_id=user_id,
+            state=state,
+        )
+        for state in ticket_states
+    ]
+    payment = Payment(
+        id=uuid.uuid4(),
+        reservation_id=reservation.id,
+        provider_payment_intent_id="pi_1",
+        amount_cents=10000,
+        currency="EUR",
+        status=PaymentStatus.succeeded,
+    )
+
+    session = MagicMock()
+
+    async def _flush() -> None:
+        return None
+
+    async def _refresh(_obj: Any) -> None:
+        return None
+
+    session.flush = AsyncMock(side_effect=_flush)
+    session.refresh = AsyncMock(side_effect=_refresh)
+    session.add = MagicMock()
+
+    payments_repo = MagicMock()
+    payments_repo.get_by_intent_id = AsyncMock(return_value=payment)
+    payments_repo.flush = AsyncMock()
+
+    reservation_repo = MagicMock()
+    reservation_repo.get_by_id = AsyncMock(return_value=reservation)
+    reservation_repo.list_tickets = AsyncMock(return_value=tickets)
+
+    tier_repo = MagicMock()
+    tier_repo.get_by_id = AsyncMock(return_value=tier)
+
+    audit = MagicMock()
+    audit.record = AsyncMock()
+
+    stripe = MagicMock()
+    service = PaymentService(
+        session, payments_repo, reservation_repo, tier_repo, stripe, audit
+    )
+    return service, audit, reservation, payment, tickets, tier
+
+
+async def test_full_refund_cancels_reservation_and_tickets() -> None:
+    service, audit, reservation, payment, tickets, tier = _setup(
+        ticket_states=[TicketState.issued, TicketState.issued],
+        tier_reserved_count=5,
+    )
+    await service.apply_refund(
+        intent_id="pi_1", amount_refunded=10000, amount_total=10000
+    )
+    assert reservation.status == ReservationStatus.cancelled
+    assert all(t.state == TicketState.cancelled for t in tickets)
+    assert payment.status == PaymentStatus.refunded
+    assert tier.reserved_count == 3
+    audited = {c.kwargs["action"] for c in audit.record.await_args_list}
+    assert AuditAction.PAYMENT_REFUNDED in audited
+
+
+async def test_partial_refund_does_not_flip_state() -> None:
+    service, audit, reservation, payment, tickets, _ = _setup(
+        ticket_states=[TicketState.issued]
+    )
+    await service.apply_refund(
+        intent_id="pi_1", amount_refunded=2000, amount_total=10000
+    )
+    assert reservation.status == ReservationStatus.paid
+    assert all(t.state == TicketState.issued for t in tickets)
+    assert payment.status == PaymentStatus.succeeded
+    audited = {c.kwargs["action"] for c in audit.record.await_args_list}
+    assert AuditAction.PAYMENT_PARTIAL_REFUND in audited
+    assert AuditAction.PAYMENT_REFUNDED not in audited
+
+
+async def test_chargeback_cancels_immediately() -> None:
+    service, audit, reservation, payment, tickets, _ = _setup(
+        ticket_states=[TicketState.issued, TicketState.issued]
+    )
+    await service.apply_chargeback(intent_id="pi_1")
+    assert reservation.status == ReservationStatus.cancelled
+    assert all(t.state == TicketState.cancelled for t in tickets)
+    assert payment.status == PaymentStatus.refunded
+    audited = {c.kwargs["action"] for c in audit.record.await_args_list}
+    assert AuditAction.CHARGEBACK_OPENED in audited
+
+
+async def test_chargeback_on_used_ticket_does_not_regress_state() -> None:
+    service, audit, reservation, payment, tickets, tier = _setup(
+        ticket_states=[TicketState.used, TicketState.issued],
+        tier_reserved_count=5,
+    )
+    await service.apply_chargeback(intent_id="pi_1")
+    assert tickets[0].state == TicketState.used
+    assert tickets[1].state == TicketState.cancelled
+    assert reservation.status == ReservationStatus.cancelled
+    assert payment.status == PaymentStatus.refunded
+    assert tier.reserved_count == 4
+    audited = {c.kwargs["action"] for c in audit.record.await_args_list}
+    assert AuditAction.CHARGEBACK_ON_USED_TICKET in audited
+
+
+async def test_unknown_intent_for_refund_is_noop() -> None:
+    service, _audit, _, _, _, _ = _setup(ticket_states=[TicketState.issued])
+    service._repo.get_by_intent_id = AsyncMock(return_value=None)  # pyright: ignore[reportPrivateUsage]
+    await service.apply_refund(
+        intent_id="pi_unknown", amount_refunded=10000, amount_total=10000
+    )
+
+
+async def test_chargeback_closed_records_audit_only() -> None:
+    service, audit, _, _, _, _ = _setup(ticket_states=[TicketState.cancelled])
+    await service.record_chargeback_closed(intent_id="pi_1")
+    audited = {c.kwargs["action"] for c in audit.record.await_args_list}
+    assert AuditAction.CHARGEBACK_CLOSED in audited


### PR DESCRIPTION
## Summary

Resale-after-purchase via chargeback by reacting to Stripe's refund and dispute events the moment they arrive: the matching tickets transition out of `issued` and the buyer can no longer use them at the gate.

Three more Stripe event types are now handled by `POST /v1/payments/webhook`.

They piggyback on every primitive the success path already uses `Stripe-Signature` verification, Redis `SET NX` event-id idempotency for 24 hours, and the `redlock("reservation:{id}:lifecycle")` mutex that guards every FSM transition.

The charge events also need a different way to find the matching payment: their `data.object.id` is the charge id, not the intent id.

A small `_payment_intent_id_for(event_type, data_object)` helper reads `payment_intent` on `charge.*` events and `id` on `payment_intent.*` events, keeping the dispatcher symmetrical.

All payment-side mutations remain inside the existing webhook idempotency boundary, so a Stripe retry of any of these events is a no-op.

## Verification

- `api/tests/v1/payment/refund_test.py`

## Issue Reference

Closes [QRW-160](https://github.com/cristiangilsanz/qrew/issues/160)

## Checklist
- [x] I confirm that this PR follows the project's established coding standards.