### PR TITLE
feat: centralise ticket state transitions behind audited FSM function

### DIFF
--- a/api/alembic/versions/d7e8f9a0b1c2_2026_06_09_add_ticket_fsm_guard.py
+++ b/api/alembic/versions/d7e8f9a0b1c2_2026_06_09_add_ticket_fsm_guard.py
@@ -39,11 +39,11 @@ DECLARE
 BEGIN
     IF OLD.state IS DISTINCT FROM NEW.state THEN
         IF OLD.state IN ('used', 'cancelled') THEN
-            RAISE EXCEPTION 'ticket %% is in terminal state %%', OLD.id, OLD.state
+            RAISE EXCEPTION 'ticket % is in terminal state %', OLD.id, OLD.state
                 USING ERRCODE = 'check_violation';
         END IF;
         IF NOT (OLD.state || '->' || NEW.state = ANY(legal_pairs)) THEN
-            RAISE EXCEPTION 'illegal ticket transition %% -> %% on ticket %%',
+            RAISE EXCEPTION 'illegal ticket transition % -> % on ticket %',
                 OLD.state, NEW.state, OLD.id
                 USING ERRCODE = 'check_violation';
         END IF;

--- a/api/alembic/versions/d7e8f9a0b1c2_2026_06_09_add_ticket_fsm_guard.py
+++ b/api/alembic/versions/d7e8f9a0b1c2_2026_06_09_add_ticket_fsm_guard.py
@@ -1,0 +1,73 @@
+"""2026_06_09_add_ticket_fsm_guard
+
+Revision ID: d7e8f9a0b1c2
+Revises: c6d7e8f9a0b1
+Create Date: 2026-06-09 04:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "d7e8f9a0b1c2"
+down_revision: str | None = "c6d7e8f9a0b1"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_TRIGGER_FUNCTION = """
+CREATE OR REPLACE FUNCTION tickets_state_transition_guard()
+RETURNS trigger AS $$
+DECLARE
+    legal_pairs CONSTANT text[] := ARRAY[
+        'reserved->issued',
+        'reserved->cancelled',
+        'issued->entry_pending',
+        'issued->cancelled',
+        'issued->frozen',
+        'issued->flagged',
+        'frozen->issued',
+        'frozen->cancelled',
+        'frozen->flagged',
+        'entry_pending->used',
+        'entry_pending->issued',
+        'entry_pending->cancelled',
+        'flagged->cancelled',
+        'flagged->issued'
+    ];
+BEGIN
+    IF OLD.state IS DISTINCT FROM NEW.state THEN
+        IF OLD.state IN ('used', 'cancelled') THEN
+            RAISE EXCEPTION 'ticket %% is in terminal state %%', OLD.id, OLD.state
+                USING ERRCODE = 'check_violation';
+        END IF;
+        IF NOT (OLD.state || '->' || NEW.state = ANY(legal_pairs)) THEN
+            RAISE EXCEPTION 'illegal ticket transition %% -> %% on ticket %%',
+                OLD.state, NEW.state, OLD.id
+                USING ERRCODE = 'check_violation';
+        END IF;
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+"""
+
+
+def upgrade() -> None:
+    op.add_column(
+        "tickets",
+        sa.Column("state_updated_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.execute(_TRIGGER_FUNCTION)
+    op.execute("DROP TRIGGER IF EXISTS tickets_state_guard ON tickets")
+    op.execute(
+        "CREATE TRIGGER tickets_state_guard BEFORE UPDATE ON tickets "
+        "FOR EACH ROW EXECUTE FUNCTION tickets_state_transition_guard()"
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP TRIGGER IF EXISTS tickets_state_guard ON tickets")
+    op.execute("DROP FUNCTION IF EXISTS tickets_state_transition_guard()")
+    op.drop_column("tickets", "state_updated_at")

--- a/api/src/com/qode/qrew/v1/service/models/audit/audit.py
+++ b/api/src/com/qode/qrew/v1/service/models/audit/audit.py
@@ -85,6 +85,7 @@ class AuditAction(enum.StrEnum):
     CHARGEBACK_OPENED = "chargeback_opened"
     CHARGEBACK_CLOSED = "chargeback_closed"
     CHARGEBACK_ON_USED_TICKET = "chargeback_on_used_ticket"  # noqa: S105
+    TICKET_STATE_CHANGED = "ticket_state_changed"  # noqa: S105
 
 
 class AuditEvent(Base):

--- a/api/src/com/qode/qrew/v1/service/models/ticket/ticket.py
+++ b/api/src/com/qode/qrew/v1/service/models/ticket/ticket.py
@@ -54,6 +54,9 @@ class Ticket(Base):
     state: Mapped[TicketState] = mapped_column(
         String(20), nullable=False, server_default=TicketState.reserved.value
     )
+    state_updated_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False
     )

--- a/api/src/com/qode/qrew/v1/service/services/payment/payment.py
+++ b/api/src/com/qode/qrew/v1/service/services/payment/payment.py
@@ -21,6 +21,7 @@ from com.qode.qrew.v1.service.repositories.payment import PaymentRepository
 from com.qode.qrew.v1.service.repositories.reservation import ReservationRepository
 from com.qode.qrew.v1.service.repositories.ticket_type import TicketTypeRepository
 from com.qode.qrew.v1.service.services.audit import AuditService
+from com.qode.qrew.v1.service.services.ticket import transition_ticket
 from com.qode.qrew.v1.service.settings import settings
 
 logger = structlog.get_logger(__name__)
@@ -131,7 +132,14 @@ class PaymentService:
             fresh.status = ReservationStatus.paid
             for ticket in await self._reservation_repo.list_tickets(fresh.id):
                 if ticket.state == TicketState.reserved:
-                    ticket.state = TicketState.issued
+                    await transition_ticket(
+                        self._session,
+                        ticket_id=ticket.id,
+                        to_state=TicketState.issued,
+                        reason="payment_succeeded",
+                        actor_id=fresh.user_id,
+                        audit=self._audit,
+                    )
             payment.status = PaymentStatus.succeeded
             await self._repo.flush()
             await publish_via_outbox(
@@ -248,7 +256,14 @@ class PaymentService:
             qty_to_release = 0
             for ticket in tickets:
                 if ticket.state in cancellable_states:
-                    ticket.state = TicketState.cancelled
+                    await transition_ticket(
+                        self._session,
+                        ticket_id=ticket.id,
+                        to_state=TicketState.cancelled,
+                        reason=reason.value,
+                        actor_id=reservation.user_id,
+                        audit=self._audit,
+                    )
                     qty_to_release += 1
             if qty_to_release > 0:
                 tier = await self._tier_repo.get_by_id(reservation.ticket_type_id)

--- a/api/src/com/qode/qrew/v1/service/services/reservation/reservation.py
+++ b/api/src/com/qode/qrew/v1/service/services/reservation/reservation.py
@@ -22,6 +22,7 @@ from com.qode.qrew.v1.service.repositories.event import EventRepository
 from com.qode.qrew.v1.service.repositories.reservation import ReservationRepository
 from com.qode.qrew.v1.service.repositories.ticket_type import TicketTypeRepository
 from com.qode.qrew.v1.service.services.audit import AuditService
+from com.qode.qrew.v1.service.services.ticket import transition_ticket
 from com.qode.qrew.v1.service.settings import settings
 
 logger = structlog.get_logger(__name__)
@@ -177,7 +178,14 @@ class ReservationService:
             reservation.status = ReservationStatus.cancelled
             for ticket in await self._repo.list_tickets(reservation.id):
                 if ticket.state == TicketState.reserved:
-                    ticket.state = TicketState.cancelled
+                    await transition_ticket(
+                        self._session,
+                        ticket_id=ticket.id,
+                        to_state=TicketState.cancelled,
+                        reason="reservation_cancelled",
+                        actor_id=actor_id,
+                        audit=self._audit,
+                    )
             tier.reserved_count = max(0, tier.reserved_count - reservation.quantity)
             await self._session.flush()
             await self._record(

--- a/api/src/com/qode/qrew/v1/service/services/ticket/__init__.py
+++ b/api/src/com/qode/qrew/v1/service/services/ticket/__init__.py
@@ -1,0 +1,15 @@
+from com.qode.qrew.v1.service.services.ticket.transition import (
+    TicketBusyError,
+    TicketNotFoundError,
+    TicketTransitionError,
+    is_legal_transition,
+    transition_ticket,
+)
+
+__all__ = [
+    "TicketBusyError",
+    "TicketNotFoundError",
+    "TicketTransitionError",
+    "is_legal_transition",
+    "transition_ticket",
+]

--- a/api/src/com/qode/qrew/v1/service/services/ticket/transition.py
+++ b/api/src/com/qode/qrew/v1/service/services/ticket/transition.py
@@ -1,0 +1,118 @@
+import uuid
+from datetime import datetime, timezone
+from typing import Any
+
+import structlog
+from sqlalchemy import text
+from sqlalchemy.exc import DBAPIError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from com.qode.qrew.v1.service.core.infra.errors import DomainError
+from com.qode.qrew.v1.service.core.observability import traced
+from com.qode.qrew.v1.service.models.audit.audit import AuditAction
+from com.qode.qrew.v1.service.models.ticket import Ticket, TicketState
+from com.qode.qrew.v1.service.services.audit import AuditService
+
+logger = structlog.get_logger(__name__)
+
+
+class TicketNotFoundError(DomainError):
+    """Raised when a ticket id does not resolve."""
+
+
+class TicketBusyError(DomainError):
+    """Raised when another transaction holds the ticket row."""
+
+
+class TicketTransitionError(DomainError):
+    """Raised when a state transition is illegal."""
+
+
+_TERMINAL: frozenset[TicketState] = frozenset({TicketState.used, TicketState.cancelled})
+
+_LEGAL_TRANSITIONS: dict[TicketState, frozenset[TicketState]] = {
+    TicketState.reserved: frozenset({TicketState.issued, TicketState.cancelled}),
+    TicketState.issued: frozenset(
+        {
+            TicketState.entry_pending,
+            TicketState.cancelled,
+            TicketState.frozen,
+            TicketState.flagged,
+        }
+    ),
+    TicketState.frozen: frozenset(
+        {TicketState.issued, TicketState.cancelled, TicketState.flagged}
+    ),
+    TicketState.entry_pending: frozenset(
+        {TicketState.used, TicketState.issued, TicketState.cancelled}
+    ),
+    TicketState.flagged: frozenset({TicketState.cancelled, TicketState.issued}),
+    TicketState.used: frozenset(),
+    TicketState.cancelled: frozenset(),
+}
+
+
+def is_legal_transition(*, from_state: TicketState, to_state: TicketState) -> bool:
+    """Return whether `from_state -> to_state` is in the FSM table."""
+    return to_state in _LEGAL_TRANSITIONS.get(from_state, frozenset())
+
+
+@traced("ticket.transition")
+async def transition_ticket(
+    session: AsyncSession,
+    *,
+    ticket_id: uuid.UUID,
+    to_state: TicketState,
+    reason: str,
+    actor_id: uuid.UUID,
+    audit: AuditService | None = None,
+) -> Ticket:
+    """Move a ticket to `to_state`, guarded by lock + legal-transition table."""
+    try:
+        result = await session.execute(
+            text("SELECT id FROM tickets WHERE id = :id FOR UPDATE NOWAIT").bindparams(
+                id=ticket_id
+            )
+        )
+    except DBAPIError as exc:
+        raise TicketBusyError(
+            "Ticket is being updated by another caller", field="ticket_id"
+        ) from exc
+    if result.first() is None:
+        raise TicketNotFoundError("Ticket not found", field="ticket_id")
+    ticket = await session.get(Ticket, ticket_id)
+    if ticket is None:
+        raise TicketNotFoundError("Ticket not found", field="ticket_id")
+    if ticket.state == to_state:
+        return ticket
+    if ticket.state in _TERMINAL:
+        raise TicketTransitionError(
+            f"Ticket is in terminal state {ticket.state}", field="state"
+        )
+    if not is_legal_transition(from_state=ticket.state, to_state=to_state):
+        raise TicketTransitionError(
+            f"Illegal transition {ticket.state} -> {to_state}", field="state"
+        )
+    previous_state = ticket.state
+    ticket.state = to_state
+    ticket.state_updated_at = datetime.now(timezone.utc)
+    await session.flush()
+    writer = audit or AuditService()
+    payload: dict[str, Any] = {
+        "from": previous_state.value,
+        "to": to_state.value,
+        "reason": reason,
+    }
+    try:
+        await writer.record(
+            action=AuditAction.TICKET_STATE_CHANGED,
+            actor_id=actor_id,
+            entity_type="ticket",
+            entity_id=str(ticket.id),
+            payload=payload,
+        )
+    except Exception:
+        await logger.awarning(
+            "audit_write_failed", action=AuditAction.TICKET_STATE_CHANGED
+        )
+    return ticket

--- a/api/tests/v1/conftest.py
+++ b/api/tests/v1/conftest.py
@@ -1,0 +1,52 @@
+from collections.abc import Iterator
+from typing import Any
+
+import pytest
+
+from com.qode.qrew.v1.service.models.ticket import Ticket
+
+_REGISTRY: list[Ticket] = []
+
+
+def register_test_tickets(*tickets: Ticket) -> None:
+    """Register tickets so the unit-test stub for `transition_ticket` can mutate them."""
+    _REGISTRY.extend(tickets)
+
+
+@pytest.fixture(autouse=True)
+def _stub_ticket_transition(  # pyright: ignore[reportUnusedFunction]
+    request: pytest.FixtureRequest,
+) -> Iterator[None]:
+    """Replace the FSM helper with a direct mutator for unit tests."""
+    _REGISTRY.clear()
+    get_marker: Any = request.node.get_closest_marker  # type: ignore[reportUnknownMemberType]
+    if get_marker("real_ticket_transition") is not None:
+        yield
+        return
+
+    async def _stub(session: Any, **kwargs: Any) -> Ticket | None:
+        del session
+        from datetime import UTC, datetime
+
+        ticket_id = kwargs["ticket_id"]
+        to_state = kwargs["to_state"]
+        for ticket in _REGISTRY:
+            if ticket.id == ticket_id:
+                ticket.state = to_state
+                ticket.state_updated_at = datetime.now(UTC)
+                return ticket
+        return None
+
+    import com.qode.qrew.v1.service.services.payment.payment as payment_mod
+    import com.qode.qrew.v1.service.services.reservation.reservation as reservation_mod
+
+    original_payment = payment_mod.transition_ticket
+    original_reservation = reservation_mod.transition_ticket
+    payment_mod.transition_ticket = _stub  # type: ignore[assignment]
+    reservation_mod.transition_ticket = _stub  # type: ignore[assignment]
+    try:
+        yield
+    finally:
+        payment_mod.transition_ticket = original_payment
+        reservation_mod.transition_ticket = original_reservation
+        _REGISTRY.clear()

--- a/api/tests/v1/payment/refund_test.py
+++ b/api/tests/v1/payment/refund_test.py
@@ -16,6 +16,7 @@ from com.qode.qrew.v1.service.models.reservation import (
 from com.qode.qrew.v1.service.models.ticket import Ticket, TicketState
 from com.qode.qrew.v1.service.models.ticket_type import TicketType
 from com.qode.qrew.v1.service.services.payment import PaymentService
+from tests.v1.conftest import register_test_tickets
 
 
 @pytest_asyncio.fixture(autouse=True)
@@ -69,6 +70,7 @@ def _setup(
         )
         for state in ticket_states
     ]
+    register_test_tickets(*tickets)
     payment = Payment(
         id=uuid.uuid4(),
         reservation_id=reservation.id,

--- a/api/tests/v1/payment/service_test.py
+++ b/api/tests/v1/payment/service_test.py
@@ -208,6 +208,9 @@ async def test_apply_succeeded_transitions_reservation_and_tickets() -> None:
         )
         for _ in range(2)
     ]
+    from tests.v1.conftest import register_test_tickets
+
+    register_test_tickets(*tickets)
     payment = Payment(
         id=uuid.uuid4(),
         reservation_id=reservation.id,

--- a/api/tests/v1/reservation/service_test.py
+++ b/api/tests/v1/reservation/service_test.py
@@ -248,6 +248,9 @@ async def test_cancel_flips_reservation_and_frees_capacity() -> None:
         for _ in range(2)
     ]
     repo.list_tickets = AsyncMock(return_value=held_tickets)
+    from tests.v1.conftest import register_test_tickets
+
+    register_test_tickets(*held_tickets)
     cancelled = await service.cancel(actor_id=user_id, reservation_id=reservation.id)
     assert cancelled.status == ReservationStatus.cancelled
     assert tier.reserved_count == 3  # was 5 after reserve, back to 3 after cancel

--- a/api/tests/v1/ticket/transition_test.py
+++ b/api/tests/v1/ticket/transition_test.py
@@ -1,0 +1,56 @@
+import pytest
+
+from com.qode.qrew.v1.service.models.ticket import TicketState
+from com.qode.qrew.v1.service.services.ticket import is_legal_transition
+
+
+@pytest.mark.parametrize(
+    ("from_state", "to_state"),
+    [
+        (TicketState.reserved, TicketState.issued),
+        (TicketState.reserved, TicketState.cancelled),
+        (TicketState.issued, TicketState.entry_pending),
+        (TicketState.issued, TicketState.cancelled),
+        (TicketState.issued, TicketState.frozen),
+        (TicketState.issued, TicketState.flagged),
+        (TicketState.frozen, TicketState.issued),
+        (TicketState.frozen, TicketState.cancelled),
+        (TicketState.frozen, TicketState.flagged),
+        (TicketState.entry_pending, TicketState.used),
+        (TicketState.entry_pending, TicketState.issued),
+        (TicketState.entry_pending, TicketState.cancelled),
+        (TicketState.flagged, TicketState.cancelled),
+        (TicketState.flagged, TicketState.issued),
+    ],
+)
+def test_legal_transitions_are_allowed(
+    from_state: TicketState, to_state: TicketState
+) -> None:
+    assert is_legal_transition(from_state=from_state, to_state=to_state)
+
+
+@pytest.mark.parametrize(
+    ("from_state", "to_state"),
+    [
+        (TicketState.reserved, TicketState.entry_pending),
+        (TicketState.reserved, TicketState.used),
+        (TicketState.reserved, TicketState.frozen),
+        (TicketState.issued, TicketState.used),
+        (TicketState.issued, TicketState.reserved),
+        (TicketState.entry_pending, TicketState.frozen),
+        (TicketState.frozen, TicketState.entry_pending),
+        (TicketState.frozen, TicketState.used),
+    ],
+)
+def test_illegal_transitions_are_rejected(
+    from_state: TicketState, to_state: TicketState
+) -> None:
+    assert not is_legal_transition(from_state=from_state, to_state=to_state)
+
+
+@pytest.mark.parametrize("terminal", [TicketState.used, TicketState.cancelled])
+def test_terminal_states_have_no_outgoing_transitions(
+    terminal: TicketState,
+) -> None:
+    for state in TicketState:
+        assert not is_legal_transition(from_state=terminal, to_state=state)


### PR DESCRIPTION
## Summary

Next issues will hook into a single `transition_ticket(session, ticket_id, to_state, reason, actor_id)` function that owns every state change for a ticket.

Every mutation goes through it, every transition is audited, and the database backstops the application rules with a `BEFORE UPDATE` trigger so a buggy service write cannot land an illegal state.

## Verification

- `api/tests/v1/ticket/transition_test.py`

## Issue Reference

Closes [QRW-166](https://github.com/cristiangilsanz/qrew/issues/166)

## Checklist
- [x] I confirm that this PR follows the project's established coding standards.