### PR TITLE
feat: add rotating ES256 QR with geofence, attestation and reassertion gates

### DIFF
--- a/api/src/com/qode/qrew/v1/service/core/auth/jwt_keys.py
+++ b/api/src/com/qode/qrew/v1/service/core/auth/jwt_keys.py
@@ -16,7 +16,8 @@ SETUP: Final = "setup"
 RECOVERY: Final = "recovery"
 REFRESH: Final = "refresh"
 QUEUE: Final = "queue"
-PURPOSES: Final = (ACCESS, SETUP, RECOVERY, REFRESH, QUEUE)
+TICKET_QR: Final = "ticket_qr"  # noqa: S105
+PURPOSES: Final = (ACCESS, SETUP, RECOVERY, REFRESH, QUEUE, TICKET_QR)
 
 
 @dataclass(frozen=True)

--- a/api/src/com/qode/qrew/v1/service/models/audit/audit.py
+++ b/api/src/com/qode/qrew/v1/service/models/audit/audit.py
@@ -86,6 +86,8 @@ class AuditAction(enum.StrEnum):
     CHARGEBACK_CLOSED = "chargeback_closed"
     CHARGEBACK_ON_USED_TICKET = "chargeback_on_used_ticket"  # noqa: S105
     TICKET_STATE_CHANGED = "ticket_state_changed"  # noqa: S105
+    TICKET_QR_MINTED = "ticket_qr_minted"  # noqa: S105
+    TICKET_QR_DENIED = "ticket_qr_denied"  # noqa: S105
 
 
 class AuditEvent(Base):

--- a/api/src/com/qode/qrew/v1/service/routers/__init__.py
+++ b/api/src/com/qode/qrew/v1/service/routers/__init__.py
@@ -12,6 +12,7 @@ from com.qode.qrew.v1.service.routers.public_catalog import (
 )
 from com.qode.qrew.v1.service.routers.payment import router as payment_router
 from com.qode.qrew.v1.service.routers.queue import router as queue_router
+from com.qode.qrew.v1.service.routers.ticket_qr import router as ticket_qr_router
 from com.qode.qrew.v1.service.routers.reservation import (
     router as reservation_router,
 )
@@ -33,6 +34,7 @@ router.include_router(public_catalog_router)
 router.include_router(reservation_router)
 router.include_router(queue_router)
 router.include_router(payment_router)
+router.include_router(ticket_qr_router)
 
 if settings.debug:
     from com.qode.qrew.v1.service.routers.dev import router as dev_router

--- a/api/src/com/qode/qrew/v1/service/routers/ticket_qr.py
+++ b/api/src/com/qode/qrew/v1/service/routers/ticket_qr.py
@@ -1,0 +1,208 @@
+import asyncio
+import json
+import uuid
+from collections.abc import AsyncGenerator
+from datetime import UTC, datetime
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
+from fastapi.responses import StreamingResponse
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from com.qode.qrew.v1.service.core.auth.auth import (
+    get_current_session,
+    get_current_user,
+)
+from com.qode.qrew.v1.service.core.infra.database import get_db
+from com.qode.qrew.v1.service.core.infra.limiter import limiter
+from com.qode.qrew.v1.service.models.auth.session import Session
+from com.qode.qrew.v1.service.models.auth.user import User
+from com.qode.qrew.v1.service.schemas.ticket_qr import QrIssueRequest, QrResponse
+from com.qode.qrew.v1.service.services.audit import AuditService
+from com.qode.qrew.v1.service.services.ticket_qr import (
+    DenialReason,
+    GateInputs,
+    evaluate_gate,
+    load_inputs,
+    mint_qr,
+    record_denial,
+)
+from com.qode.qrew.v1.service.settings import settings
+
+router = APIRouter(tags=["ticket-qr"])
+
+_REASON_TO_STATUS: dict[DenialReason, int] = {
+    DenialReason.not_found: status.HTTP_404_NOT_FOUND,
+    DenialReason.not_owner: status.HTTP_404_NOT_FOUND,
+    DenialReason.state: status.HTTP_409_CONFLICT,
+    DenialReason.reassertion: status.HTTP_403_FORBIDDEN,
+    DenialReason.attestation: status.HTTP_403_FORBIDDEN,
+    DenialReason.geofence: status.HTTP_403_FORBIDDEN,
+}
+
+
+def _denied_exception(reason: DenialReason) -> HTTPException:
+    return HTTPException(
+        status_code=_REASON_TO_STATUS[reason],
+        detail={"message": "QR mint denied", "field": reason.value},
+    )
+
+
+async def _resolve_or_deny(
+    db: AsyncSession,
+    *,
+    ticket_id: uuid.UUID,
+    user_id: uuid.UUID,
+    auth_session: Session,
+    latitude: float,
+    longitude: float,
+    now: datetime,
+    audit: AuditService,
+) -> GateInputs:
+    device_id = auth_session.device_id
+    if device_id is None:
+        await record_denial(
+            audit=audit,
+            user_id=user_id,
+            ticket_id=ticket_id,
+            reason=DenialReason.attestation.value,
+            device_id=None,
+        )
+        raise _denied_exception(DenialReason.attestation)
+    resolved = await load_inputs(
+        db, ticket_id=ticket_id, user_id=user_id, device_id=device_id
+    )
+    if isinstance(resolved, DenialReason):
+        await record_denial(
+            audit=audit,
+            user_id=user_id,
+            ticket_id=ticket_id,
+            reason=resolved.value,
+            device_id=device_id,
+        )
+        raise _denied_exception(resolved)
+    reason = evaluate_gate(
+        resolved,
+        auth_session=auth_session,
+        latitude=latitude,
+        longitude=longitude,
+        now=now,
+    )
+    if reason is not None:
+        await record_denial(
+            audit=audit,
+            user_id=user_id,
+            ticket_id=ticket_id,
+            reason=reason.value,
+            device_id=device_id,
+        )
+        raise _denied_exception(reason)
+    return resolved
+
+
+@router.get(
+    "/tickets/{ticket_id}/qr",
+    response_model=QrResponse,
+    status_code=status.HTTP_200_OK,
+    summary="Mint a fresh rotating QR for a ticket",
+)
+@limiter.limit("30/minute")  # type: ignore[misc]
+async def issue_qr(
+    request: Request,
+    ticket_id: uuid.UUID,
+    latitude: float = Query(..., ge=-90.0, le=90.0),
+    longitude: float = Query(..., ge=-180.0, le=180.0),
+    current_user: User = Depends(get_current_user),
+    auth_session: Session = Depends(get_current_session),
+    db: AsyncSession = Depends(get_db),
+) -> QrResponse:
+    """Single-shot QR mint. Client polls just before `rotates_at`."""
+    del request
+    audit = AuditService()
+    now = datetime.now(UTC)
+    inputs = await _resolve_or_deny(
+        db,
+        ticket_id=ticket_id,
+        user_id=current_user.id,
+        auth_session=auth_session,
+        latitude=latitude,
+        longitude=longitude,
+        now=now,
+        audit=audit,
+    )
+    minted = await mint_qr(
+        inputs=inputs,
+        user_id=current_user.id,
+        device_id=inputs.device.id,
+        audit=audit,
+        now=now,
+    )
+    return QrResponse(
+        ticket_id=inputs.ticket.id,
+        jwt=minted.jwt,
+        jti=minted.jti,
+        issued_at=minted.issued_at,
+        expires_at=minted.expires_at,
+        rotates_at=minted.expires_at,
+    )
+
+
+@router.post(
+    "/tickets/{ticket_id}/qr/stream",
+    status_code=status.HTTP_200_OK,
+    summary="Server-sent stream of rotating QRs while the gate is open",
+)
+@limiter.limit("10/minute")  # type: ignore[misc]
+async def stream_qr(
+    request: Request,
+    ticket_id: uuid.UUID,
+    body: QrIssueRequest,
+    current_user: User = Depends(get_current_user),
+    auth_session: Session = Depends(get_current_session),
+    db: AsyncSession = Depends(get_db),
+) -> StreamingResponse:
+    """Stream a fresh JWT every TTL seconds; close when any gate fails."""
+    del request
+    audit = AuditService()
+    latitude = float(body.latitude)
+    longitude = float(body.longitude)
+    user_id = current_user.id
+
+    async def _events() -> AsyncGenerator[bytes, None]:
+        deadline = datetime.now(UTC).timestamp() + settings.ticket_qr_stream_max_seconds
+        while datetime.now(UTC).timestamp() < deadline:
+            now = datetime.now(UTC)
+            try:
+                inputs = await _resolve_or_deny(
+                    db,
+                    ticket_id=ticket_id,
+                    user_id=user_id,
+                    auth_session=auth_session,
+                    latitude=latitude,
+                    longitude=longitude,
+                    now=now,
+                    audit=audit,
+                )
+            except HTTPException as exc:
+                payload = json.dumps({"type": "denied", "detail": exc.detail})
+                yield f"event: denied\ndata: {payload}\n\n".encode()
+                return
+            minted = await mint_qr(
+                inputs=inputs,
+                user_id=user_id,
+                device_id=inputs.device.id,
+                audit=audit,
+                now=now,
+            )
+            payload = json.dumps(
+                {
+                    "ticket_id": str(inputs.ticket.id),
+                    "jwt": minted.jwt,
+                    "jti": minted.jti,
+                    "issued_at": minted.issued_at.isoformat(),
+                    "expires_at": minted.expires_at.isoformat(),
+                }
+            )
+            yield f"event: qr\ndata: {payload}\n\n".encode()
+            await asyncio.sleep(settings.ticket_qr_ttl_seconds)
+
+    return StreamingResponse(_events(), media_type="text/event-stream")

--- a/api/src/com/qode/qrew/v1/service/schemas/ticket_qr/__init__.py
+++ b/api/src/com/qode/qrew/v1/service/schemas/ticket_qr/__init__.py
@@ -1,0 +1,7 @@
+from com.qode.qrew.v1.service.schemas.ticket_qr.ticket_qr import (
+    QrDeniedResponse,
+    QrIssueRequest,
+    QrResponse,
+)
+
+__all__ = ["QrDeniedResponse", "QrIssueRequest", "QrResponse"]

--- a/api/src/com/qode/qrew/v1/service/schemas/ticket_qr/ticket_qr.py
+++ b/api/src/com/qode/qrew/v1/service/schemas/ticket_qr/ticket_qr.py
@@ -1,0 +1,23 @@
+import uuid
+from datetime import datetime
+from decimal import Decimal
+
+from pydantic import BaseModel, Field
+
+
+class QrIssueRequest(BaseModel):
+    latitude: Decimal = Field(..., ge=Decimal("-90"), le=Decimal("90"))
+    longitude: Decimal = Field(..., ge=Decimal("-180"), le=Decimal("180"))
+
+
+class QrResponse(BaseModel):
+    ticket_id: uuid.UUID
+    jwt: str
+    jti: str
+    issued_at: datetime
+    expires_at: datetime
+    rotates_at: datetime
+
+
+class QrDeniedResponse(BaseModel):
+    detail: dict[str, str | None]

--- a/api/src/com/qode/qrew/v1/service/services/ticket_qr/__init__.py
+++ b/api/src/com/qode/qrew/v1/service/services/ticket_qr/__init__.py
@@ -1,0 +1,25 @@
+from com.qode.qrew.v1.service.services.ticket_qr.gate import (
+    DenialReason,
+    GateInputs,
+    evaluate_gate,
+    haversine_metres,
+    load_inputs,
+)
+from com.qode.qrew.v1.service.services.ticket_qr.mint import (
+    MintedQr,
+    mint_qr,
+    record_denial,
+    utc_now,
+)
+
+__all__ = [
+    "DenialReason",
+    "GateInputs",
+    "MintedQr",
+    "evaluate_gate",
+    "haversine_metres",
+    "load_inputs",
+    "mint_qr",
+    "record_denial",
+    "utc_now",
+]

--- a/api/src/com/qode/qrew/v1/service/services/ticket_qr/gate.py
+++ b/api/src/com/qode/qrew/v1/service/services/ticket_qr/gate.py
@@ -1,0 +1,122 @@
+import math
+import uuid
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from enum import StrEnum
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from com.qode.qrew.v1.service.models.auth.session import Session
+from com.qode.qrew.v1.service.models.device.device import Device
+from com.qode.qrew.v1.service.models.event import Event
+from com.qode.qrew.v1.service.models.ticket import Ticket, TicketState
+from com.qode.qrew.v1.service.models.venue import Venue
+from com.qode.qrew.v1.service.settings import settings
+
+_EARTH_RADIUS_M = 6_371_000.0
+
+
+class DenialReason(StrEnum):
+    state = "state"
+    reassertion = "reassertion"
+    attestation = "attestation"
+    geofence = "geofence"
+    not_found = "not_found"
+    not_owner = "not_owner"
+
+
+@dataclass(frozen=True)
+class GateInputs:
+    ticket: Ticket
+    event: Event
+    venue: Venue
+    device: Device
+
+
+def haversine_metres(*, lat1: float, lon1: float, lat2: float, lon2: float) -> float:
+    """Great-circle distance in metres between two WGS-84 points."""
+    phi1, phi2 = math.radians(lat1), math.radians(lat2)
+    dphi = math.radians(lat2 - lat1)
+    dlambda = math.radians(lon2 - lon1)
+    a = (
+        math.sin(dphi / 2) ** 2
+        + math.cos(phi1) * math.cos(phi2) * math.sin(dlambda / 2) ** 2
+    )
+    return float(2 * _EARTH_RADIUS_M * math.asin(math.sqrt(a)))
+
+
+async def load_inputs(
+    session: AsyncSession,
+    *,
+    ticket_id: uuid.UUID,
+    user_id: uuid.UUID,
+    device_id: uuid.UUID,
+) -> GateInputs | DenialReason:
+    """Resolve the four aggregates the gate compares; or return a denial reason."""
+    ticket = await session.get(Ticket, ticket_id)
+    if ticket is None:
+        return DenialReason.not_found
+    if ticket.owner_user_id != user_id:
+        return DenialReason.not_owner
+    event = await session.get(Event, ticket.event_id)
+    if event is None:
+        return DenialReason.not_found
+    venue = await session.get(Venue, event.venue_id)
+    if venue is None:
+        return DenialReason.not_found
+    device = await session.get(Device, device_id)
+    if device is None:
+        return DenialReason.attestation
+    return GateInputs(ticket=ticket, event=event, venue=venue, device=device)
+
+
+def evaluate_gate(
+    inputs: GateInputs,
+    *,
+    auth_session: Session,
+    latitude: float,
+    longitude: float,
+    now: datetime,
+) -> DenialReason | None:
+    """Return the first failing gate, or None when every gate passes."""
+    if inputs.ticket.state not in {TicketState.issued, TicketState.entry_pending}:
+        return DenialReason.state
+    last_asserted = auth_session.last_asserted_at
+    if last_asserted is None:
+        return DenialReason.reassertion
+    if last_asserted.tzinfo is None:
+        last_asserted = last_asserted.replace(tzinfo=UTC)
+    if now - last_asserted > timedelta(
+        seconds=settings.ticket_qr_reassert_window_seconds
+    ):
+        return DenialReason.reassertion
+    if inputs.device.revoked_at is not None:
+        return DenialReason.attestation
+    if inputs.device.attested_at is None:
+        return DenialReason.attestation
+    attested = inputs.device.attested_at
+    if attested.tzinfo is None:
+        attested = attested.replace(tzinfo=UTC)
+    if now - attested > timedelta(hours=settings.ticket_qr_attestation_max_age_hours):
+        return DenialReason.attestation
+    distance = haversine_metres(
+        lat1=latitude,
+        lon1=longitude,
+        lat2=float(inputs.venue.latitude),
+        lon2=float(inputs.venue.longitude),
+    )
+    if distance > inputs.venue.geofence_radius_m:
+        return DenialReason.geofence
+    return None
+
+
+# keep the queries importable for the integration tests
+__all__ = [
+    "DenialReason",
+    "GateInputs",
+    "evaluate_gate",
+    "haversine_metres",
+    "load_inputs",
+    "select",
+]

--- a/api/src/com/qode/qrew/v1/service/services/ticket_qr/mint.py
+++ b/api/src/com/qode/qrew/v1/service/services/ticket_qr/mint.py
@@ -1,0 +1,97 @@
+import secrets
+import uuid
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import structlog
+
+from com.qode.qrew.v1.service.core.auth import jwt_keys
+from com.qode.qrew.v1.service.core.observability import traced
+from com.qode.qrew.v1.service.models.audit.audit import AuditAction
+from com.qode.qrew.v1.service.services.audit import AuditService
+from com.qode.qrew.v1.service.services.ticket_qr.gate import GateInputs
+from com.qode.qrew.v1.service.settings import settings
+
+logger = structlog.get_logger(__name__)
+
+
+@dataclass(frozen=True)
+class MintedQr:
+    jwt: str
+    jti: str
+    issued_at: datetime
+    expires_at: datetime
+
+
+def _sample_audit(rate: int) -> bool:
+    if rate <= 1:
+        return True
+    return secrets.randbelow(rate) == 0
+
+
+@traced("ticket_qr.mint")
+async def mint_qr(
+    *,
+    inputs: GateInputs,
+    user_id: uuid.UUID,
+    device_id: uuid.UUID,
+    audit: AuditService,
+    now: datetime,
+) -> MintedQr:
+    """Mint a fresh short-lived QR JWT for an already-gated ticket."""
+    jti = uuid.uuid4().hex
+    exp = now + timedelta(seconds=settings.ticket_qr_ttl_seconds)
+    payload: dict[str, Any] = {
+        "sub": str(user_id),
+        "ticket_id": str(inputs.ticket.id),
+        "event_id": str(inputs.event.id),
+        "venue_id": str(inputs.venue.id),
+        "device_id": str(device_id),
+        "jti": jti,
+        "iat": now,
+        "exp": exp,
+        "aud": settings.ticket_qr_audience,
+    }
+    token = jwt_keys.sign(jwt_keys.TICKET_QR, payload)
+    if _sample_audit(settings.ticket_qr_mint_audit_sample_rate):
+        try:
+            await audit.record(
+                action=AuditAction.TICKET_QR_MINTED,
+                actor_id=user_id,
+                entity_type="ticket",
+                entity_id=str(inputs.ticket.id),
+                payload={"jti": jti, "device_id": str(device_id)},
+            )
+        except Exception:
+            await logger.awarning(
+                "audit_write_failed", action=AuditAction.TICKET_QR_MINTED
+            )
+    return MintedQr(jwt=token, jti=jti, issued_at=now, expires_at=exp)
+
+
+async def record_denial(
+    *,
+    audit: AuditService,
+    user_id: uuid.UUID,
+    ticket_id: uuid.UUID,
+    reason: str,
+    device_id: uuid.UUID | None,
+) -> None:
+    try:
+        await audit.record(
+            action=AuditAction.TICKET_QR_DENIED,
+            actor_id=user_id,
+            entity_type="ticket",
+            entity_id=str(ticket_id),
+            payload={
+                "reason": reason,
+                "device_id": str(device_id) if device_id else None,
+            },
+        )
+    except Exception:
+        await logger.awarning("audit_write_failed", action=AuditAction.TICKET_QR_DENIED)
+
+
+def utc_now() -> datetime:
+    return datetime.now(UTC)

--- a/api/src/com/qode/qrew/v1/service/settings.py
+++ b/api/src/com/qode/qrew/v1/service/settings.py
@@ -25,11 +25,13 @@ class Settings(BaseSettings):
     recovery_jwt_private_key: str = ""
     refresh_jwt_private_key: str = ""
     queue_jwt_private_key: str = ""
+    ticket_qr_jwt_private_key: str = ""
     access_jwt_previous_public_keys: str = ""
     setup_jwt_previous_public_keys: str = ""
     recovery_jwt_previous_public_keys: str = ""
     refresh_jwt_previous_public_keys: str = ""
     queue_jwt_previous_public_keys: str = ""
+    ticket_qr_jwt_previous_public_keys: str = ""
     access_token_expire_minutes: int = 30
     setup_token_expire_minutes: int = 15
     refresh_token_expire_days: int = 7
@@ -156,6 +158,13 @@ class Settings(BaseSettings):
     queue_reservation_window_seconds: int = 120
     queue_admit_default_rate_per_minute: int = 60
     queue_join_lead_seconds: int = 900
+
+    ticket_qr_ttl_seconds: int = 20
+    ticket_qr_reassert_window_seconds: int = 30
+    ticket_qr_mint_audit_sample_rate: int = 10
+    ticket_qr_attestation_max_age_hours: int = 24
+    ticket_qr_audience: str = "qrew.scan"
+    ticket_qr_stream_max_seconds: int = 1800
 
 
 settings = Settings()

--- a/api/tests/v1/ticket_qr/gate_test.py
+++ b/api/tests/v1/ticket_qr/gate_test.py
@@ -1,0 +1,251 @@
+import uuid
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+from typing import Any
+
+import jwt
+
+from com.qode.qrew.v1.service.core.auth import jwt_keys
+from com.qode.qrew.v1.service.models.auth.session import Session
+from com.qode.qrew.v1.service.models.device.device import Device
+from com.qode.qrew.v1.service.models.event import Event, EventStatus
+from com.qode.qrew.v1.service.models.ticket import Ticket, TicketState
+from com.qode.qrew.v1.service.models.venue import Venue
+from com.qode.qrew.v1.service.services.audit import AuditService
+from com.qode.qrew.v1.service.services.ticket_qr import (
+    DenialReason,
+    GateInputs,
+    evaluate_gate,
+    haversine_metres,
+    mint_qr,
+)
+from com.qode.qrew.v1.service.settings import settings
+
+WEMBLEY_LAT = 51.555973
+WEMBLEY_LON = -0.279672
+
+
+def _now() -> datetime:
+    return datetime(2026, 7, 1, 19, 0, tzinfo=UTC)
+
+
+def _ticket(state: TicketState = TicketState.issued) -> Ticket:
+    return Ticket(
+        id=uuid.uuid4(),
+        reservation_id=uuid.uuid4(),
+        event_id=uuid.uuid4(),
+        ticket_type_id=uuid.uuid4(),
+        owner_user_id=uuid.uuid4(),
+        state=state,
+    )
+
+
+def _event(ticket: Ticket) -> Event:
+    return Event(
+        id=ticket.event_id,
+        organisation_id=uuid.uuid4(),
+        venue_id=uuid.uuid4(),
+        name="Concert",
+        description=None,
+        starts_at=_now(),
+        ends_at=_now() + timedelta(hours=3),
+        sale_starts_at=_now() - timedelta(days=10),
+        sale_ends_at=_now() - timedelta(hours=1),
+        max_tickets_per_user=4,
+        status=EventStatus.published,
+        organiser_name="Live",
+        venue_city="London",
+    )
+
+
+def _venue(event: Event, radius: int = 200) -> Venue:
+    return Venue(
+        id=event.venue_id,
+        name="Wembley",
+        address_line="Olympic Way",
+        city="London",
+        country="GB",
+        latitude=Decimal(str(WEMBLEY_LAT)),
+        longitude=Decimal(str(WEMBLEY_LON)),
+        geofence_radius_m=radius,
+        timezone="Europe/London",
+        description=None,
+    )
+
+
+def _device(*, attested_minutes_ago: int = 30, revoked: bool = False) -> Device:
+    now = _now()
+    return Device(
+        id=uuid.uuid4(),
+        user_id=uuid.uuid4(),
+        name="Phone",
+        public_key=b"\x01" * 65,
+        attested_at=now - timedelta(minutes=attested_minutes_ago),
+        revoked_at=(now if revoked else None),
+    )
+
+
+def _session(*, asserted_seconds_ago: int = 10) -> Session:
+    return Session(
+        id=uuid.uuid4(),
+        user_id=uuid.uuid4(),
+        jti=uuid.uuid4().hex,
+        device_id=uuid.uuid4(),
+        last_asserted_at=_now() - timedelta(seconds=asserted_seconds_ago),
+    )
+
+
+def _inputs(
+    *,
+    state: TicketState = TicketState.issued,
+    radius: int = 200,
+    device: Device | None = None,
+) -> GateInputs:
+    ticket = _ticket(state=state)
+    event = _event(ticket)
+    venue = _venue(event, radius=radius)
+    return GateInputs(
+        ticket=ticket,
+        event=event,
+        venue=venue,
+        device=device or _device(),
+    )
+
+
+def test_haversine_matches_known_distance() -> None:
+    # Wembley to Wembley Park station ~ 700m
+    d = haversine_metres(
+        lat1=WEMBLEY_LAT,
+        lon1=WEMBLEY_LON,
+        lat2=51.5635,
+        lon2=-0.2795,
+    )
+    assert 600 < d < 900
+
+
+def test_gate_passes_when_all_conditions_satisfied() -> None:
+    inputs = _inputs()
+    result = evaluate_gate(
+        inputs,
+        auth_session=_session(),
+        latitude=WEMBLEY_LAT,
+        longitude=WEMBLEY_LON,
+        now=_now(),
+    )
+    assert result is None
+
+
+def test_gate_rejects_unissued_ticket() -> None:
+    inputs = _inputs(state=TicketState.reserved)
+    result = evaluate_gate(
+        inputs,
+        auth_session=_session(),
+        latitude=WEMBLEY_LAT,
+        longitude=WEMBLEY_LON,
+        now=_now(),
+    )
+    assert result == DenialReason.state
+
+
+def test_gate_rejects_stale_reassertion() -> None:
+    inputs = _inputs()
+    stale_session = _session(asserted_seconds_ago=600)
+    result = evaluate_gate(
+        inputs,
+        auth_session=stale_session,
+        latitude=WEMBLEY_LAT,
+        longitude=WEMBLEY_LON,
+        now=_now(),
+    )
+    assert result == DenialReason.reassertion
+
+
+def test_gate_rejects_revoked_device() -> None:
+    inputs = _inputs(device=_device(revoked=True))
+    result = evaluate_gate(
+        inputs,
+        auth_session=_session(),
+        latitude=WEMBLEY_LAT,
+        longitude=WEMBLEY_LON,
+        now=_now(),
+    )
+    assert result == DenialReason.attestation
+
+
+def test_gate_rejects_stale_attestation() -> None:
+    inputs = _inputs(device=_device(attested_minutes_ago=48 * 60))
+    result = evaluate_gate(
+        inputs,
+        auth_session=_session(),
+        latitude=WEMBLEY_LAT,
+        longitude=WEMBLEY_LON,
+        now=_now(),
+    )
+    assert result == DenialReason.attestation
+
+
+def test_gate_rejects_outside_geofence() -> None:
+    inputs = _inputs(radius=100)
+    # Big Ben is ~13 km from Wembley
+    result = evaluate_gate(
+        inputs,
+        auth_session=_session(),
+        latitude=51.5007,
+        longitude=-0.1246,
+        now=_now(),
+    )
+    assert result == DenialReason.geofence
+
+
+async def test_mint_includes_expected_claims() -> None:
+    class _Audit(AuditService):
+        recorded: list[Any] = []
+
+        async def record(self, **kwargs: Any) -> None:  # type: ignore[override]
+            self.recorded.append(kwargs)
+
+    inputs = _inputs()
+    user_id = inputs.ticket.owner_user_id
+    settings.ticket_qr_mint_audit_sample_rate = 1
+    minted = await mint_qr(
+        inputs=inputs,
+        user_id=user_id,
+        device_id=inputs.device.id,
+        audit=_Audit(),
+        now=_now(),
+    )
+    payload = jwt.decode(
+        minted.jwt,
+        options={"verify_signature": False, "verify_aud": False},
+    )
+    assert payload["ticket_id"] == str(inputs.ticket.id)
+    assert payload["event_id"] == str(inputs.event.id)
+    assert payload["venue_id"] == str(inputs.venue.id)
+    assert payload["device_id"] == str(inputs.device.id)
+    assert payload["aud"] == settings.ticket_qr_audience
+    assert payload["jti"] == minted.jti
+    assert (
+        minted.expires_at - minted.issued_at
+    ).total_seconds() == settings.ticket_qr_ttl_seconds
+
+
+async def test_jwt_signature_verifies_under_ticket_qr_purpose() -> None:
+    class _Audit:
+        async def record(self, **_kwargs: Any) -> None:
+            return None
+
+    inputs = _inputs()
+    minted = await mint_qr(
+        inputs=inputs,
+        user_id=inputs.ticket.owner_user_id,
+        device_id=inputs.device.id,
+        audit=_Audit(),  # type: ignore[arg-type]
+        now=datetime.now(UTC) - timedelta(seconds=1),
+    )
+    decoded = jwt.decode(
+        minted.jwt,
+        jwt_keys._KEYS[jwt_keys.TICKET_QR].public_pem,  # pyright: ignore[reportPrivateUsage]
+        algorithms=["ES256"],
+        options={"verify_aud": False},
+    )
+    assert decoded["sub"] == str(inputs.ticket.owner_user_id)


### PR DESCRIPTION
## Summary

Lands the QR shown at the gate: a short-lived ES256 JWT minted every ~20 seconds, gated by four pre-conditions checked on every mint.

The four together make a screenshot economically pointless. The JWT has a 20-second shelf life, it's bound to the device that minted it, and the gate fails on stale reassertion or off-venue location.

A new `TICKET_QR` purpose joins the JWT key registry (same pattern as `QUEUE`), with its own private key and previous-key roster for rotation. JWT claims: `sub` (owner), `ticket_id`, `event_id`, `venue_id`, `device_id`, `jti`, `iat`, `exp = iat + ttl`, `aud = "qrew.scan"`.

## Verification

- `api/tests/v1/ticket_qr/gate_test.py`

## Issue Reference

Closes [QRW-167](https://github.com/cristiangilsanz/qrew/issues/167)

## Checklist
- [x] I confirm that this PR follows the project's established coding standards.