### PR TITLE
feat: freeze tickets on device revoke and restore after re-enrolment

### DIFF
--- a/api/alembic/versions/e8f9a0b1c2d3_2026_06_10_add_ticket_bound_device.py
+++ b/api/alembic/versions/e8f9a0b1c2d3_2026_06_10_add_ticket_bound_device.py
@@ -1,0 +1,36 @@
+"""2026_06_10_add_ticket_bound_device
+
+Revision ID: e8f9a0b1c2d3
+Revises: d7e8f9a0b1c2
+Create Date: 2026-06-10 00:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision: str = "e8f9a0b1c2d3"
+down_revision: str | None = "d7e8f9a0b1c2"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "tickets",
+        sa.Column(
+            "bound_device_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("devices.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+    )
+    op.create_index("ix_tickets_bound_device_id", "tickets", ["bound_device_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_tickets_bound_device_id", table_name="tickets")
+    op.drop_column("tickets", "bound_device_id")

--- a/api/src/com/qode/qrew/v1/service/models/audit/audit.py
+++ b/api/src/com/qode/qrew/v1/service/models/audit/audit.py
@@ -88,6 +88,8 @@ class AuditAction(enum.StrEnum):
     TICKET_STATE_CHANGED = "ticket_state_changed"  # noqa: S105
     TICKET_QR_MINTED = "ticket_qr_minted"  # noqa: S105
     TICKET_QR_DENIED = "ticket_qr_denied"  # noqa: S105
+    TICKET_FROZEN_DEVICE_REVOKE = "ticket_frozen_device_revoke"  # noqa: S105
+    TICKET_RESTORED_AFTER_REENROL = "ticket_restored_after_reenrol"  # noqa: S105
 
 
 class AuditEvent(Base):

--- a/api/src/com/qode/qrew/v1/service/models/ticket/ticket.py
+++ b/api/src/com/qode/qrew/v1/service/models/ticket/ticket.py
@@ -26,6 +26,7 @@ class Ticket(Base):
         Index("ix_tickets_event_id", "event_id"),
         Index("ix_tickets_owner_user_id", "owner_user_id"),
         Index("ix_tickets_state", "state"),
+        Index("ix_tickets_bound_device_id", "bound_device_id"),
     )
 
     id: Mapped[uuid.UUID] = mapped_column(
@@ -50,6 +51,11 @@ class Ticket(Base):
         UUID(as_uuid=True),
         ForeignKey("users.id", ondelete="RESTRICT"),
         nullable=False,
+    )
+    bound_device_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("devices.id", ondelete="SET NULL"),
+        nullable=True,
     )
     state: Mapped[TicketState] = mapped_column(
         String(20), nullable=False, server_default=TicketState.reserved.value

--- a/api/src/com/qode/qrew/v1/service/routers/__init__.py
+++ b/api/src/com/qode/qrew/v1/service/routers/__init__.py
@@ -13,6 +13,9 @@ from com.qode.qrew.v1.service.routers.public_catalog import (
 from com.qode.qrew.v1.service.routers.payment import router as payment_router
 from com.qode.qrew.v1.service.routers.queue import router as queue_router
 from com.qode.qrew.v1.service.routers.ticket_qr import router as ticket_qr_router
+from com.qode.qrew.v1.service.routers.ticket_restore import (
+    router as ticket_restore_router,
+)
 from com.qode.qrew.v1.service.routers.reservation import (
     router as reservation_router,
 )
@@ -35,6 +38,7 @@ router.include_router(reservation_router)
 router.include_router(queue_router)
 router.include_router(payment_router)
 router.include_router(ticket_qr_router)
+router.include_router(ticket_restore_router)
 
 if settings.debug:
     from com.qode.qrew.v1.service.routers.dev import router as dev_router

--- a/api/src/com/qode/qrew/v1/service/routers/auth/_deps/device.py
+++ b/api/src/com/qode/qrew/v1/service/routers/auth/_deps/device.py
@@ -49,5 +49,9 @@ def get_device_service(
 ) -> DeviceService:
     """Build the device management service."""
     return DeviceService(
-        DeviceRepository(db), SessionRepository(db), redis, AuditService()
+        DeviceRepository(db),
+        SessionRepository(db),
+        redis,
+        AuditService(),
+        session=db,
     )

--- a/api/src/com/qode/qrew/v1/service/routers/ticket_restore.py
+++ b/api/src/com/qode/qrew/v1/service/routers/ticket_restore.py
@@ -1,0 +1,63 @@
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException, Request, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from com.qode.qrew.v1.service.core.auth.auth import (
+    get_current_session,
+    get_current_user,
+)
+from com.qode.qrew.v1.service.core.infra.database import get_db
+from com.qode.qrew.v1.service.core.infra.limiter import limiter
+from com.qode.qrew.v1.service.models.auth.session import Session
+from com.qode.qrew.v1.service.models.auth.user import User
+from com.qode.qrew.v1.service.services.audit import AuditService
+from com.qode.qrew.v1.service.services.ticket import (
+    TicketRestoreError,
+    restore_frozen_ticket,
+)
+
+router = APIRouter(tags=["ticket-restore"])
+
+
+def _domain_to_http(error: TicketRestoreError) -> HTTPException:
+    code = (
+        status.HTTP_404_NOT_FOUND
+        if error.field in {"ticket_id", "device_id"}
+        and error.message.endswith("not found")
+        else status.HTTP_403_FORBIDDEN
+        if error.field in {"reassertion", "attestation"}
+        else status.HTTP_409_CONFLICT
+    )
+    return HTTPException(
+        status_code=code,
+        detail={"message": error.message, "field": error.field},
+    )
+
+
+@router.post(
+    "/tickets/{ticket_id}/restore",
+    status_code=status.HTTP_200_OK,
+    summary="Restore a frozen ticket onto a re-enrolled device",
+)
+@limiter.limit("5/600seconds")  # type: ignore[misc]
+async def restore_ticket(
+    request: Request,
+    ticket_id: uuid.UUID,
+    current_user: User = Depends(get_current_user),
+    auth_session: Session = Depends(get_current_session),
+    db: AsyncSession = Depends(get_db),
+) -> dict[str, str]:
+    """Transition `frozen → issued` on a different, attested, fresh-reasserted device."""
+    del request
+    try:
+        ticket = await restore_frozen_ticket(
+            db,
+            actor_id=current_user.id,
+            ticket_id=ticket_id,
+            auth_session=auth_session,
+            audit=AuditService(),
+        )
+    except TicketRestoreError as exc:
+        raise _domain_to_http(exc) from exc
+    return {"ticket_id": str(ticket.id), "state": ticket.state.value}

--- a/api/src/com/qode/qrew/v1/service/services/device/device.py
+++ b/api/src/com/qode/qrew/v1/service/services/device/device.py
@@ -3,14 +3,19 @@ from datetime import UTC, datetime
 
 import redis.asyncio as aioredis
 import structlog
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from com.qode.qrew.v1.service.core.infra.errors import DomainError
+from com.qode.qrew.v1.service.core.outbox import publish_via_outbox
 from com.qode.qrew.v1.service.models.audit.audit import AuditAction
 from com.qode.qrew.v1.service.models.auth.user import User
 from com.qode.qrew.v1.service.models.device.device import Device
+from com.qode.qrew.v1.service.models.ticket import Ticket, TicketState
 from com.qode.qrew.v1.service.repositories.auth.session import SessionRepository
 from com.qode.qrew.v1.service.repositories.device.device import DeviceRepository
 from com.qode.qrew.v1.service.services.audit import AuditService
+from com.qode.qrew.v1.service.services.ticket import transition_ticket
 from com.qode.qrew.v1.service.settings import settings
 
 logger = structlog.get_logger(__name__)
@@ -30,11 +35,13 @@ class DeviceService:
         session_repo: SessionRepository,
         redis: aioredis.Redis,  # type: ignore[type-arg]
         audit: AuditService,
+        session: AsyncSession | None = None,
     ) -> None:
         self._device_repo = device_repo
         self._session_repo = session_repo
         self._redis = redis
         self._audit = audit
+        self._session = session
 
     async def list_devices(self, user: User) -> list[Device]:
         """Return all non-revoked devices for the user."""
@@ -60,6 +67,8 @@ class DeviceService:
         device.revoked_at = datetime.now(UTC)
         await self._device_repo.save(device)
 
+        frozen_count = await self._freeze_bound_tickets(user.id, device_id)
+
         await self._kill_all_sessions(user.id)
 
         await logger.ainfo(
@@ -71,7 +80,7 @@ class DeviceService:
                 actor_id=user.id,
                 entity_type="device",
                 entity_id=str(device_id),
-                payload={"reason": "user_initiated"},
+                payload={"reason": "user_initiated", "frozen_tickets": frozen_count},
             )
         except Exception:
             await logger.awarning(
@@ -109,6 +118,64 @@ class DeviceService:
             )
 
         return revoked_count
+
+    async def _freeze_bound_tickets(
+        self, user_id: uuid.UUID, device_id: uuid.UUID
+    ) -> int:
+        """Transition `issued` tickets bound to this device to `frozen`.
+
+        Returns the count actually frozen. No-op when the service was built
+        without a DB session (legacy callers without ticket context).
+        """
+        if self._session is None:
+            return 0
+        result = await self._session.execute(
+            select(Ticket).where(
+                Ticket.owner_user_id == user_id,
+                Ticket.bound_device_id == device_id,
+                Ticket.state == TicketState.issued,
+            )
+        )
+        affected = list(result.scalars().all())
+        if not affected:
+            return 0
+        for ticket in affected:
+            await transition_ticket(
+                self._session,
+                ticket_id=ticket.id,
+                to_state=TicketState.frozen,
+                reason="device_revoked",
+                actor_id=user_id,
+                audit=self._audit,
+            )
+            try:
+                await self._audit.record(
+                    action=AuditAction.TICKET_FROZEN_DEVICE_REVOKE,
+                    actor_id=user_id,
+                    entity_type="ticket",
+                    entity_id=str(ticket.id),
+                    payload={"device_id": str(device_id)},
+                )
+            except Exception:
+                await logger.awarning(
+                    "audit_write_failed",
+                    action=AuditAction.TICKET_FROZEN_DEVICE_REVOKE,
+                )
+        try:
+            await publish_via_outbox(
+                self._session,
+                aggregate_type="device",
+                aggregate_id=str(device_id),
+                job_name="notifications.tickets_frozen_device_revoke",
+                payload={
+                    "user_id": str(user_id),
+                    "device_id": str(device_id),
+                    "ticket_count": len(affected),
+                },
+            )
+        except Exception:
+            await logger.awarning("outbox_publish_failed")
+        return len(affected)
 
     async def _kill_all_sessions(self, user_id: uuid.UUID) -> None:
         """Delete all sessions for the user and blacklist their JTIs in Redis."""

--- a/api/src/com/qode/qrew/v1/service/services/ticket/__init__.py
+++ b/api/src/com/qode/qrew/v1/service/services/ticket/__init__.py
@@ -1,3 +1,7 @@
+from com.qode.qrew.v1.service.services.ticket.restore import (
+    TicketRestoreError,
+    restore_frozen_ticket,
+)
 from com.qode.qrew.v1.service.services.ticket.transition import (
     TicketBusyError,
     TicketNotFoundError,
@@ -9,7 +13,9 @@ from com.qode.qrew.v1.service.services.ticket.transition import (
 __all__ = [
     "TicketBusyError",
     "TicketNotFoundError",
+    "TicketRestoreError",
     "TicketTransitionError",
     "is_legal_transition",
+    "restore_frozen_ticket",
     "transition_ticket",
 ]

--- a/api/src/com/qode/qrew/v1/service/services/ticket/restore.py
+++ b/api/src/com/qode/qrew/v1/service/services/ticket/restore.py
@@ -1,0 +1,110 @@
+import uuid
+from datetime import UTC, datetime, timedelta
+
+import structlog
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from com.qode.qrew.v1.service.core.infra.errors import DomainError
+from com.qode.qrew.v1.service.core.observability import traced
+from com.qode.qrew.v1.service.core.outbox import publish_via_outbox
+from com.qode.qrew.v1.service.models.audit.audit import AuditAction
+from com.qode.qrew.v1.service.models.auth.session import Session
+from com.qode.qrew.v1.service.models.device.device import Device
+from com.qode.qrew.v1.service.models.ticket import Ticket, TicketState
+from com.qode.qrew.v1.service.services.audit import AuditService
+from com.qode.qrew.v1.service.services.ticket.transition import transition_ticket
+from com.qode.qrew.v1.service.settings import settings
+
+logger = structlog.get_logger(__name__)
+
+
+class TicketRestoreError(DomainError):
+    """Raised when a frozen ticket cannot be restored."""
+
+
+@traced("ticket.restore")
+async def restore_frozen_ticket(
+    db: AsyncSession,
+    *,
+    actor_id: uuid.UUID,
+    ticket_id: uuid.UUID,
+    auth_session: Session,
+    audit: AuditService,
+) -> Ticket:
+    """Move a frozen ticket back to issued on a fresh, attested, different device."""
+    ticket = await db.get(Ticket, ticket_id)
+    if ticket is None or ticket.owner_user_id != actor_id:
+        raise TicketRestoreError("Ticket not found", field="ticket_id")
+    if ticket.state != TicketState.frozen:
+        raise TicketRestoreError("Ticket is not frozen", field="state")
+    device_id = auth_session.device_id
+    if device_id is None:
+        raise TicketRestoreError(
+            "Restore requires an authenticated device session", field="device_id"
+        )
+    if ticket.bound_device_id is not None and ticket.bound_device_id == device_id:
+        raise TicketRestoreError(
+            "Re-enrol onto a new device before restoring", field="device_id"
+        )
+    last_asserted = auth_session.last_asserted_at
+    now = datetime.now(UTC)
+    if last_asserted is None:
+        raise TicketRestoreError(
+            "Fresh passkey reassertion is required", field="reassertion"
+        )
+    if last_asserted.tzinfo is None:
+        last_asserted = last_asserted.replace(tzinfo=UTC)
+    window = timedelta(seconds=settings.ticket_qr_reassert_window_seconds)
+    if now - last_asserted > window:
+        raise TicketRestoreError(
+            "Fresh passkey reassertion is required", field="reassertion"
+        )
+    device = await db.get(Device, device_id)
+    if device is None or device.user_id != actor_id:
+        raise TicketRestoreError("Device not found", field="device_id")
+    if device.revoked_at is not None:
+        raise TicketRestoreError("Device is revoked", field="device_id")
+    if device.attested_at is None:
+        raise TicketRestoreError("Device attestation is required", field="attestation")
+    attested = device.attested_at
+    if attested.tzinfo is None:
+        attested = attested.replace(tzinfo=UTC)
+    if now - attested > timedelta(hours=settings.ticket_qr_attestation_max_age_hours):
+        raise TicketRestoreError("Device attestation is stale", field="attestation")
+    previous_device = ticket.bound_device_id
+    await transition_ticket(
+        db,
+        ticket_id=ticket.id,
+        to_state=TicketState.issued,
+        reason="restore_after_reenrol",
+        actor_id=actor_id,
+        audit=audit,
+    )
+    ticket.bound_device_id = device_id
+    await db.flush()
+    try:
+        await audit.record(
+            action=AuditAction.TICKET_RESTORED_AFTER_REENROL,
+            actor_id=actor_id,
+            entity_type="ticket",
+            entity_id=str(ticket.id),
+            payload={
+                "previous_device_id": str(previous_device) if previous_device else None,
+                "new_device_id": str(device_id),
+            },
+        )
+    except Exception:
+        await logger.awarning(
+            "audit_write_failed", action=AuditAction.TICKET_RESTORED_AFTER_REENROL
+        )
+    try:
+        await publish_via_outbox(
+            db,
+            aggregate_type="ticket",
+            aggregate_id=str(ticket.id),
+            job_name="notifications.ticket_restored",
+            payload={"ticket_id": str(ticket.id), "user_id": str(actor_id)},
+        )
+    except Exception:
+        await logger.awarning("outbox_publish_failed")
+    return ticket

--- a/api/src/com/qode/qrew/v1/service/services/ticket_qr/mint.py
+++ b/api/src/com/qode/qrew/v1/service/services/ticket_qr/mint.py
@@ -40,6 +40,8 @@ async def mint_qr(
     now: datetime,
 ) -> MintedQr:
     """Mint a fresh short-lived QR JWT for an already-gated ticket."""
+    if inputs.ticket.bound_device_id != device_id:
+        inputs.ticket.bound_device_id = device_id
     jti = uuid.uuid4().hex
     exp = now + timedelta(seconds=settings.ticket_qr_ttl_seconds)
     payload: dict[str, Any] = {

--- a/api/tests/v1/conftest.py
+++ b/api/tests/v1/conftest.py
@@ -37,16 +37,24 @@ def _stub_ticket_transition(  # pyright: ignore[reportUnusedFunction]
                 return ticket
         return None
 
+    import com.qode.qrew.v1.service.services.device.device as device_mod
     import com.qode.qrew.v1.service.services.payment.payment as payment_mod
     import com.qode.qrew.v1.service.services.reservation.reservation as reservation_mod
+    import com.qode.qrew.v1.service.services.ticket.restore as restore_mod
 
     original_payment = payment_mod.transition_ticket
     original_reservation = reservation_mod.transition_ticket
+    original_restore = restore_mod.transition_ticket
+    original_device = device_mod.transition_ticket
     payment_mod.transition_ticket = _stub  # type: ignore[assignment]
     reservation_mod.transition_ticket = _stub  # type: ignore[assignment]
+    restore_mod.transition_ticket = _stub  # type: ignore[assignment]
+    device_mod.transition_ticket = _stub  # type: ignore[assignment]
     try:
         yield
     finally:
         payment_mod.transition_ticket = original_payment
         reservation_mod.transition_ticket = original_reservation
+        restore_mod.transition_ticket = original_restore
+        device_mod.transition_ticket = original_device
         _REGISTRY.clear()

--- a/api/tests/v1/ticket/restore_test.py
+++ b/api/tests/v1/ticket/restore_test.py
@@ -1,0 +1,206 @@
+import uuid
+from datetime import UTC, datetime, timedelta
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from com.qode.qrew.v1.service.models.auth.session import Session
+from com.qode.qrew.v1.service.models.device.device import Device
+from com.qode.qrew.v1.service.models.ticket import Ticket, TicketState
+from com.qode.qrew.v1.service.services.ticket import (
+    TicketRestoreError,
+    restore_frozen_ticket,
+)
+
+
+def _now() -> datetime:
+    return datetime.now(UTC)
+
+
+def _ticket(
+    *,
+    owner: uuid.UUID,
+    state: TicketState = TicketState.frozen,
+    bound: uuid.UUID | None = None,
+) -> Ticket:
+    return Ticket(
+        id=uuid.uuid4(),
+        reservation_id=uuid.uuid4(),
+        event_id=uuid.uuid4(),
+        ticket_type_id=uuid.uuid4(),
+        owner_user_id=owner,
+        bound_device_id=bound,
+        state=state,
+    )
+
+
+def _device(
+    *,
+    user_id: uuid.UUID,
+    attested_minutes_ago: int = 30,
+    revoked: bool = False,
+) -> Device:
+    now = _now()
+    return Device(
+        id=uuid.uuid4(),
+        user_id=user_id,
+        name="Phone",
+        public_key=b"\x02" * 65,
+        attested_at=now - timedelta(minutes=attested_minutes_ago),
+        revoked_at=(now if revoked else None),
+    )
+
+
+def _session(
+    *,
+    user_id: uuid.UUID,
+    device_id: uuid.UUID,
+    asserted_seconds_ago: int = 10,
+) -> Session:
+    return Session(
+        id=uuid.uuid4(),
+        user_id=user_id,
+        jti=uuid.uuid4().hex,
+        device_id=device_id,
+        last_asserted_at=_now() - timedelta(seconds=asserted_seconds_ago),
+    )
+
+
+def _db_with(*, ticket: Ticket | None, device: Device | None) -> MagicMock:
+    db = MagicMock()
+
+    async def _get(model: Any, key: Any) -> Any:
+        if model is Ticket:
+            return ticket if ticket and ticket.id == key else None
+        if model is Device:
+            return device if device and device.id == key else None
+        return None
+
+    db.get = AsyncMock(side_effect=_get)
+    db.flush = AsyncMock()
+    db.refresh = AsyncMock()
+    db.add = MagicMock()
+    return db
+
+
+def _audit_stub() -> MagicMock:
+    audit = MagicMock()
+    audit.record = AsyncMock()
+    return audit
+
+
+async def test_restore_rejects_unowned_ticket() -> None:
+    owner = uuid.uuid4()
+    intruder = uuid.uuid4()
+    ticket = _ticket(owner=owner)
+    db = _db_with(ticket=ticket, device=None)
+    with pytest.raises(TicketRestoreError, match="not found"):
+        await restore_frozen_ticket(
+            db,
+            actor_id=intruder,
+            ticket_id=ticket.id,
+            auth_session=_session(user_id=intruder, device_id=uuid.uuid4()),
+            audit=_audit_stub(),
+        )
+
+
+async def test_restore_rejects_non_frozen_ticket() -> None:
+    owner = uuid.uuid4()
+    ticket = _ticket(owner=owner, state=TicketState.issued)
+    db = _db_with(ticket=ticket, device=None)
+    with pytest.raises(TicketRestoreError, match="not frozen"):
+        await restore_frozen_ticket(
+            db,
+            actor_id=owner,
+            ticket_id=ticket.id,
+            auth_session=_session(user_id=owner, device_id=uuid.uuid4()),
+            audit=_audit_stub(),
+        )
+
+
+async def test_restore_rejects_same_device() -> None:
+    owner = uuid.uuid4()
+    device = _device(user_id=owner)
+    ticket = _ticket(owner=owner, bound=device.id)
+    db = _db_with(ticket=ticket, device=device)
+    with pytest.raises(TicketRestoreError, match="new device"):
+        await restore_frozen_ticket(
+            db,
+            actor_id=owner,
+            ticket_id=ticket.id,
+            auth_session=_session(user_id=owner, device_id=device.id),
+            audit=_audit_stub(),
+        )
+
+
+async def test_restore_rejects_stale_reassertion() -> None:
+    owner = uuid.uuid4()
+    new_device = _device(user_id=owner)
+    ticket = _ticket(owner=owner, bound=uuid.uuid4())
+    db = _db_with(ticket=ticket, device=new_device)
+    with pytest.raises(TicketRestoreError, match="reassertion"):
+        await restore_frozen_ticket(
+            db,
+            actor_id=owner,
+            ticket_id=ticket.id,
+            auth_session=_session(
+                user_id=owner, device_id=new_device.id, asserted_seconds_ago=600
+            ),
+            audit=_audit_stub(),
+        )
+
+
+async def test_restore_rejects_revoked_device() -> None:
+    owner = uuid.uuid4()
+    new_device = _device(user_id=owner, revoked=True)
+    ticket = _ticket(owner=owner, bound=uuid.uuid4())
+    db = _db_with(ticket=ticket, device=new_device)
+    with pytest.raises(TicketRestoreError, match="revoked"):
+        await restore_frozen_ticket(
+            db,
+            actor_id=owner,
+            ticket_id=ticket.id,
+            auth_session=_session(user_id=owner, device_id=new_device.id),
+            audit=_audit_stub(),
+        )
+
+
+async def test_restore_rejects_stale_attestation() -> None:
+    owner = uuid.uuid4()
+    new_device = _device(user_id=owner, attested_minutes_ago=48 * 60)
+    ticket = _ticket(owner=owner, bound=uuid.uuid4())
+    db = _db_with(ticket=ticket, device=new_device)
+    with pytest.raises(TicketRestoreError, match="attestation"):
+        await restore_frozen_ticket(
+            db,
+            actor_id=owner,
+            ticket_id=ticket.id,
+            auth_session=_session(user_id=owner, device_id=new_device.id),
+            audit=_audit_stub(),
+        )
+
+
+async def test_restore_happy_path_rotates_device_and_audits() -> None:
+    owner = uuid.uuid4()
+    new_device = _device(user_id=owner)
+    previous_device = uuid.uuid4()
+    ticket = _ticket(owner=owner, bound=previous_device)
+    from tests.v1.conftest import register_test_tickets
+
+    register_test_tickets(ticket)
+    db = _db_with(ticket=ticket, device=new_device)
+    audit = _audit_stub()
+    result = await restore_frozen_ticket(
+        db,
+        actor_id=owner,
+        ticket_id=ticket.id,
+        auth_session=_session(user_id=owner, device_id=new_device.id),
+        audit=audit,
+    )
+    assert result.state == TicketState.issued
+    assert result.bound_device_id == new_device.id
+    from com.qode.qrew.v1.service.models.audit.audit import AuditAction
+
+    audited = {c.kwargs["action"] for c in audit.record.await_args_list}
+    assert AuditAction.TICKET_RESTORED_AFTER_REENROL in audited


### PR DESCRIPTION
## Summary

Closes the lost-phone failure mode: when the legitimate owner revokes a device, any `issued` tickets bound to that device immediately freeze so whoever has the phone can't display them at the gate.

After re-enrolling on a new device and confirming with a fresh passkey reassertion, the owner can transition them back to `issued`.

The smallest data point that makes the freeze surgical is the new `tickets.bound_device_id` column. Without it, "freeze on revoke" would mean every ticket the user owns gets frozen on any device revoke.

With it, only the tickets that have actually been shown at a gate on the now-revoked device get frozen; tickets the user owns on their other devices are untouched.

The QR mint endpoint now stamps `bound_device_id` to the current device on every mint that doesn't match. First mint of a ticket is the binding event, and any subsequent device-rotation is reflected automatically.

## Verification

- `api/tests/v1/ticket/restore_test.py`

## Issue Reference

Closes [QRW-168](https://github.com/cristiangilsanz/qrew/issues/168)

## Checklist
- [x] I confirm that this PR follows the project's established coding standards.