### PR TITLE
feat: wire notification handlers and add outbox DLQ safety net

### DIFF
--- a/api/alembic/versions/f9a0b1c2d3e4_2026_06_10_add_outbox_dlq_reason.py
+++ b/api/alembic/versions/f9a0b1c2d3e4_2026_06_10_add_outbox_dlq_reason.py
@@ -1,0 +1,28 @@
+"""2026_06_10_add_outbox_dlq_reason
+
+Revision ID: f9a0b1c2d3e4
+Revises: e8f9a0b1c2d3
+Create Date: 2026-06-10 01:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "f9a0b1c2d3e4"
+down_revision: str | None = "e8f9a0b1c2d3"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "outbox",
+        sa.Column("dlq_reason", sa.String(64), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("outbox", "dlq_reason")

--- a/api/src/com/qode/qrew/v1/service/core/outbox/model.py
+++ b/api/src/com/qode/qrew/v1/service/core/outbox/model.py
@@ -31,3 +31,4 @@ class OutboxEvent(Base):
     next_attempt_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False
     )
+    dlq_reason: Mapped[str | None] = mapped_column(String(64), nullable=True)

--- a/api/src/com/qode/qrew/v1/service/core/outbox/sweeper.py
+++ b/api/src/com/qode/qrew/v1/service/core/outbox/sweeper.py
@@ -12,6 +12,8 @@ from com.qode.qrew.v1.service.core.observability import traced
 from com.qode.qrew.v1.service.core.outbox.model import OutboxEvent
 from com.qode.qrew.v1.service.settings import settings
 
+DLQ_UNKNOWN_JOB = "unknown_job_name"
+
 logger = structlog.get_logger(__name__)
 
 EnqueueFn = Callable[[str, dict[str, Any]], Awaitable[Any]]
@@ -57,6 +59,21 @@ async def drain_once(
                 row.dispatched_at = datetime.now(UTC)
                 row.last_error = None
                 drained += 1
+            except KeyError as exc:
+                row.attempt_count += 1
+                row.last_error = repr(exc)
+                if row.attempt_count >= settings.outbox_max_attempts:
+                    row.dispatched_at = datetime.now(UTC)
+                    row.dlq_reason = DLQ_UNKNOWN_JOB
+                    await logger.aerror(
+                        "outbox.dlq.unknown_job_name",
+                        outbox_id=str(row.id),
+                        job_name=row.job_name,
+                    )
+                else:
+                    row.next_attempt_at = datetime.now(UTC) + timedelta(
+                        seconds=_backoff_delay_seconds(row.attempt_count)
+                    )
             except Exception as exc:  # noqa: BLE001
                 row.attempt_count += 1
                 row.last_error = repr(exc)

--- a/api/src/com/qode/qrew/v1/service/jobs/__init__.py
+++ b/api/src/com/qode/qrew/v1/service/jobs/__init__.py
@@ -1,6 +1,7 @@
 from com.qode.qrew.v1.service.jobs import (
     audit_verify,
     auth_cleanup,
+    lifecycle_notifications,
     notification_delivery,
     outbox_drain,
     queue_admit,
@@ -12,6 +13,7 @@ from com.qode.qrew.v1.service.jobs import (
 __all__ = [
     "audit_verify",
     "auth_cleanup",
+    "lifecycle_notifications",
     "notification_delivery",
     "outbox_drain",
     "queue_admit",

--- a/api/src/com/qode/qrew/v1/service/jobs/lifecycle_notifications.py
+++ b/api/src/com/qode/qrew/v1/service/jobs/lifecycle_notifications.py
@@ -30,7 +30,7 @@ async def _payload_for_reservation(
 async def _payload_for_payment(  # pyright: ignore[reportUnusedFunction]
     payment_id: uuid.UUID,
 ) -> tuple[Any, str]:
-    """Reserved for future per-payment-only notifications; lookups via Payment."""
+    """Reserved for future per-payment-only notifications. Lookups via Payment."""
     async with AsyncSessionLocal() as session:
         payment = await session.get(Payment, payment_id)
         if payment is None:

--- a/api/src/com/qode/qrew/v1/service/jobs/lifecycle_notifications.py
+++ b/api/src/com/qode/qrew/v1/service/jobs/lifecycle_notifications.py
@@ -1,0 +1,147 @@
+import uuid
+from typing import Any
+
+import structlog
+
+from com.qode.qrew.v1.service.core.infra.database import AsyncSessionLocal
+from com.qode.qrew.v1.service.core.jobs import job
+from com.qode.qrew.v1.service.models.event import Event
+from com.qode.qrew.v1.service.models.payment import Payment
+from com.qode.qrew.v1.service.models.reservation import Reservation
+from com.qode.qrew.v1.service.repositories.auth.user import UserRepository
+from com.qode.qrew.v1.service.services.notification.service import NotificationService
+
+logger = structlog.get_logger(__name__)
+
+
+async def _payload_for_reservation(
+    reservation_id: uuid.UUID,
+) -> tuple[Any, str]:
+    """Return (user, event_name) for a reservation id, or (None, '') if missing."""
+    async with AsyncSessionLocal() as session:
+        reservation = await session.get(Reservation, reservation_id)
+        if reservation is None:
+            return None, ""
+        event = await session.get(Event, reservation.event_id)
+        user = await UserRepository(session).get_by_id(reservation.user_id)
+        return user, event.name if event else ""
+
+
+async def _payload_for_payment(  # pyright: ignore[reportUnusedFunction]
+    payment_id: uuid.UUID,
+) -> tuple[Any, str]:
+    """Reserved for future per-payment-only notifications; lookups via Payment."""
+    async with AsyncSessionLocal() as session:
+        payment = await session.get(Payment, payment_id)
+        if payment is None:
+            return None, ""
+        reservation = await session.get(Reservation, payment.reservation_id)
+        if reservation is None:
+            return None, ""
+        event = await session.get(Event, reservation.event_id)
+        user = await UserRepository(session).get_by_id(reservation.user_id)
+        return user, event.name if event else ""
+
+
+async def _send(template_key: str, user: Any, payload: dict[str, Any]) -> None:
+    if user is None:
+        await logger.awarning("notification_user_missing", template_key=template_key)
+        return
+    await NotificationService().send(
+        template_key=template_key,
+        payload={"full_name": user.full_name, **payload},
+        user=user,
+    )
+
+
+@job(name="notifications.payment_succeeded", max_attempts=3)
+async def payment_succeeded(ctx: dict[str, Any], payload: dict[str, Any]) -> None:
+    """Notify the buyer that their payment succeeded."""
+    del ctx
+    reservation_id = uuid.UUID(payload["reservation_id"])
+    user, event_name = await _payload_for_reservation(reservation_id)
+    await _send("payment_succeeded", user, {"event_name": event_name})
+
+
+@job(name="notifications.payment_failed", max_attempts=3)
+async def payment_failed(ctx: dict[str, Any], payload: dict[str, Any]) -> None:
+    """Notify the buyer that their payment failed."""
+    del ctx
+    reservation_id = uuid.UUID(payload["reservation_id"])
+    user, event_name = await _payload_for_reservation(reservation_id)
+    failure_code = payload.get("failure_code")
+    await _send(
+        "payment_failed",
+        user,
+        {"event_name": event_name, "failure_code": failure_code},
+    )
+
+
+@job(name="notifications.event_cancelled", max_attempts=3)
+async def event_cancelled(ctx: dict[str, Any], payload: dict[str, Any]) -> None:
+    """Phase 3 stub fan-out — Phase 4+ will iterate reservation holders."""
+    del ctx
+    event_id = uuid.UUID(payload["event_id"])
+    async with AsyncSessionLocal() as session:
+        event = await session.get(Event, event_id)
+    if event is None:
+        await logger.awarning("event_cancelled_event_missing", event_id=str(event_id))
+        return
+    await logger.ainfo(
+        "event_cancelled_notification_pending",
+        event_id=str(event_id),
+        event_name=event.name,
+    )
+
+
+@job(name="notifications.ticket_cancelled_chargeback", max_attempts=3)
+async def ticket_cancelled_chargeback(
+    ctx: dict[str, Any], payload: dict[str, Any]
+) -> None:
+    del ctx
+    reservation_id = uuid.UUID(payload["reservation_id"])
+    user, event_name = await _payload_for_reservation(reservation_id)
+    await _send("ticket_cancelled_chargeback", user, {"event_name": event_name})
+
+
+@job(name="notifications.ticket_cancelled_refund", max_attempts=3)
+async def ticket_cancelled_refund(ctx: dict[str, Any], payload: dict[str, Any]) -> None:
+    del ctx
+    reservation_id = uuid.UUID(payload["reservation_id"])
+    user, event_name = await _payload_for_reservation(reservation_id)
+    await _send("ticket_cancelled_refund", user, {"event_name": event_name})
+
+
+@job(name="notifications.tickets_frozen_device_revoke", max_attempts=3)
+async def tickets_frozen_device_revoke(
+    ctx: dict[str, Any], payload: dict[str, Any]
+) -> None:
+    del ctx
+    user_id = uuid.UUID(payload["user_id"])
+    async with AsyncSessionLocal() as session:
+        user = await UserRepository(session).get_by_id(user_id)
+    await _send(
+        "tickets_frozen_device_revoke",
+        user,
+        {"ticket_count": int(payload.get("ticket_count", 0))},
+    )
+
+
+@job(name="notifications.ticket_restored", max_attempts=3)
+async def ticket_restored(ctx: dict[str, Any], payload: dict[str, Any]) -> None:
+    del ctx
+    user_id = uuid.UUID(payload["user_id"])
+    async with AsyncSessionLocal() as session:
+        user = await UserRepository(session).get_by_id(user_id)
+    await _send("ticket_restored", user, {"ticket_id": payload.get("ticket_id")})
+
+
+_ = (
+    payment_succeeded,
+    payment_failed,
+    event_cancelled,
+    ticket_cancelled_chargeback,
+    ticket_cancelled_refund,
+    tickets_frozen_device_revoke,
+    ticket_restored,
+)

--- a/api/src/com/qode/qrew/v1/service/models/audit/audit.py
+++ b/api/src/com/qode/qrew/v1/service/models/audit/audit.py
@@ -90,6 +90,7 @@ class AuditAction(enum.StrEnum):
     TICKET_QR_DENIED = "ticket_qr_denied"  # noqa: S105
     TICKET_FROZEN_DEVICE_REVOKE = "ticket_frozen_device_revoke"  # noqa: S105
     TICKET_RESTORED_AFTER_REENROL = "ticket_restored_after_reenrol"  # noqa: S105
+    OUTBOX_ROW_DLQ = "outbox_row_dlq"
 
 
 class AuditEvent(Base):

--- a/api/src/com/qode/qrew/v1/service/routers/admin/__init__.py
+++ b/api/src/com/qode/qrew/v1/service/routers/admin/__init__.py
@@ -9,6 +9,7 @@ from ._deps import (
 from .audit import router as audit_router
 from .fingerprints import router as fingerprints_router
 from .kyc import router as kyc_router
+from .outbox_dlq import router as outbox_dlq_router
 from .scanners import router as scanners_router
 from .users import router as users_router
 
@@ -18,6 +19,7 @@ router.include_router(kyc_router)
 router.include_router(fingerprints_router)
 router.include_router(users_router)
 router.include_router(scanners_router)
+router.include_router(outbox_dlq_router)
 
 __all__ = [
     "get_fingerprint_service",

--- a/api/src/com/qode/qrew/v1/service/routers/admin/outbox_dlq.py
+++ b/api/src/com/qode/qrew/v1/service/routers/admin/outbox_dlq.py
@@ -1,0 +1,73 @@
+import uuid
+from datetime import datetime
+
+from fastapi import APIRouter, Depends, Request, status
+from pydantic import BaseModel
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from com.qode.qrew.v1.service.core.api import Page, clamp_limit, cursor_paginate
+from com.qode.qrew.v1.service.core.auth.auth import get_admin_user
+from com.qode.qrew.v1.service.core.infra.database import get_db
+from com.qode.qrew.v1.service.core.infra.limiter import limiter
+from com.qode.qrew.v1.service.core.outbox.model import OutboxEvent
+from com.qode.qrew.v1.service.models.auth.user import User
+
+router = APIRouter(prefix="/outbox", tags=["admin-outbox"])
+
+
+class OutboxDlqItem(BaseModel):
+    id: uuid.UUID
+    aggregate_type: str
+    aggregate_id: str
+    job_name: str
+    attempt_count: int
+    last_error: str | None
+    dlq_reason: str | None
+    created_at: datetime
+    dispatched_at: datetime | None
+
+
+@router.get(
+    "/dlq",
+    response_model=Page[OutboxDlqItem],
+    status_code=status.HTTP_200_OK,
+    summary="Paginate outbox rows the drainer parked in the DLQ",
+)
+@limiter.limit("30/minute")  # type: ignore[misc]
+async def list_dlq(
+    request: Request,
+    cursor: str | None = None,
+    limit: int = 20,
+    _admin: User = Depends(get_admin_user),
+    db: AsyncSession = Depends(get_db),
+) -> Page[OutboxDlqItem]:
+    """Return outbox rows that were parked in the DLQ."""
+    del request
+    page_limit = clamp_limit(limit, default=20)
+    stmt = select(OutboxEvent).where(OutboxEvent.dlq_reason.is_not(None))
+    rows, next_cursor = await cursor_paginate(
+        db,
+        stmt,
+        sort_column=OutboxEvent.created_at,
+        id_column=OutboxEvent.id,
+        limit=page_limit,
+        cursor=cursor,
+    )
+    return Page[OutboxDlqItem](
+        items=[
+            OutboxDlqItem(
+                id=row.id,
+                aggregate_type=row.aggregate_type,
+                aggregate_id=row.aggregate_id,
+                job_name=row.job_name,
+                attempt_count=row.attempt_count,
+                last_error=row.last_error,
+                dlq_reason=row.dlq_reason,
+                created_at=row.created_at,
+                dispatched_at=row.dispatched_at,
+            )
+            for row in rows
+        ],
+        next_cursor=next_cursor,
+    )

--- a/api/src/com/qode/qrew/v1/service/services/notification/templates.py
+++ b/api/src/com/qode/qrew/v1/service/services/notification/templates.py
@@ -7,6 +7,14 @@ from com.qode.qrew.v1.service.settings import settings
 from com.qode.qrew.v1.service.templates.email_change_alert_email import (
     email_change_alert_email,
 )
+from com.qode.qrew.v1.service.templates.lifecycle_emails import (
+    event_cancelled_email,
+    payment_failed_email,
+    payment_succeeded_email,
+    ticket_cancelled_email,
+    ticket_restored_email,
+    tickets_frozen_email,
+)
 from com.qode.qrew.v1.service.templates.email_change_verify_email import (
     email_change_verify_email,
 )
@@ -111,6 +119,76 @@ def _phone_otp(payload: dict[str, Any]) -> RenderedSms:
     )
 
 
+def _payment_succeeded(payload: dict[str, Any]) -> RenderedEmail:
+    return RenderedEmail(
+        subject="Your Qrew payment succeeded",
+        body_html=payment_succeeded_email(
+            full_name=payload.get("full_name", "there"),
+            event_name=payload.get("event_name", "your event"),
+        ),
+    )
+
+
+def _payment_failed(payload: dict[str, Any]) -> RenderedEmail:
+    return RenderedEmail(
+        subject="Your Qrew payment failed",
+        body_html=payment_failed_email(
+            full_name=payload.get("full_name", "there"),
+            event_name=payload.get("event_name", "your event"),
+            reason=payload.get("failure_code"),
+        ),
+    )
+
+
+def _event_cancelled(payload: dict[str, Any]) -> RenderedEmail:
+    return RenderedEmail(
+        subject="An event you reserved has been cancelled",
+        body_html=event_cancelled_email(
+            full_name=payload.get("full_name", "there"),
+            event_name=payload.get("event_name", "your event"),
+        ),
+    )
+
+
+def _ticket_cancelled_chargeback(payload: dict[str, Any]) -> RenderedEmail:
+    return RenderedEmail(
+        subject="Your Qrew ticket was cancelled (chargeback)",
+        body_html=ticket_cancelled_email(
+            full_name=payload.get("full_name", "there"),
+            event_name=payload.get("event_name", "your event"),
+            reason="chargeback opened",
+        ),
+    )
+
+
+def _ticket_cancelled_refund(payload: dict[str, Any]) -> RenderedEmail:
+    return RenderedEmail(
+        subject="Your Qrew ticket was refunded",
+        body_html=ticket_cancelled_email(
+            full_name=payload.get("full_name", "there"),
+            event_name=payload.get("event_name", "your event"),
+            reason="refund",
+        ),
+    )
+
+
+def _tickets_frozen_device_revoke(payload: dict[str, Any]) -> RenderedEmail:
+    return RenderedEmail(
+        subject="Tickets frozen on revoked device",
+        body_html=tickets_frozen_email(
+            full_name=payload.get("full_name", "there"),
+            ticket_count=int(payload.get("ticket_count", 0)),
+        ),
+    )
+
+
+def _ticket_restored(payload: dict[str, Any]) -> RenderedEmail:
+    return RenderedEmail(
+        subject="Your Qrew ticket is restored",
+        body_html=ticket_restored_email(full_name=payload.get("full_name", "there")),
+    )
+
+
 EMAIL_TEMPLATES: dict[str, Callable[[dict[str, Any]], RenderedEmail]] = {
     "email_verification_link": _verification_link,
     "kyc_status_email": _kyc_status,
@@ -118,6 +196,13 @@ EMAIL_TEMPLATES: dict[str, Callable[[dict[str, Any]], RenderedEmail]] = {
     "email_change_alert": _email_change_alert,
     "account_recovery": _account_recovery,
     "login_anomaly_alert": _login_anomaly_alert,
+    "payment_succeeded": _payment_succeeded,
+    "payment_failed": _payment_failed,
+    "event_cancelled": _event_cancelled,
+    "ticket_cancelled_chargeback": _ticket_cancelled_chargeback,
+    "ticket_cancelled_refund": _ticket_cancelled_refund,
+    "tickets_frozen_device_revoke": _tickets_frozen_device_revoke,
+    "ticket_restored": _ticket_restored,
 }
 
 SMS_TEMPLATES: dict[str, Callable[[dict[str, Any]], RenderedSms]] = {

--- a/api/src/com/qode/qrew/v1/service/templates/lifecycle_emails.py
+++ b/api/src/com/qode/qrew/v1/service/templates/lifecycle_emails.py
@@ -1,0 +1,48 @@
+def payment_succeeded_email(*, full_name: str, event_name: str) -> str:
+    """Render the payment-succeeded confirmation body."""
+    return (
+        f"<p>Hi {full_name},</p>"
+        f"<p>Your payment for <b>{event_name}</b> succeeded. "
+        "Your tickets are now issued and ready to display.</p>"
+    )
+
+
+def payment_failed_email(*, full_name: str, event_name: str, reason: str | None) -> str:
+    detail = f" Reason: {reason}." if reason else ""
+    return (
+        f"<p>Hi {full_name},</p>"
+        f"<p>Your payment for <b>{event_name}</b> did not complete.{detail} "
+        "Please retry within your reservation window.</p>"
+    )
+
+
+def event_cancelled_email(*, full_name: str, event_name: str) -> str:
+    return (
+        f"<p>Hi {full_name},</p>"
+        f"<p><b>{event_name}</b> has been cancelled by the organiser. "
+        "If you held a ticket, it will be refunded automatically.</p>"
+    )
+
+
+def ticket_cancelled_email(*, full_name: str, event_name: str, reason: str) -> str:
+    return (
+        f"<p>Hi {full_name},</p>"
+        f"<p>Your ticket for <b>{event_name}</b> was cancelled ({reason}). "
+        "If you believe this is in error, contact support.</p>"
+    )
+
+
+def tickets_frozen_email(*, full_name: str, ticket_count: int) -> str:
+    return (
+        f"<p>Hi {full_name},</p>"
+        f"<p>We have frozen {ticket_count} ticket(s) bound to a device you "
+        "just revoked. Re-enrol a new device and use the restore endpoint to "
+        "use them again.</p>"
+    )
+
+
+def ticket_restored_email(*, full_name: str) -> str:
+    return (
+        f"<p>Hi {full_name},</p>"
+        "<p>Your ticket is restored and ready to display on your new device.</p>"
+    )

--- a/api/tests/v1/notification/templates_test.py
+++ b/api/tests/v1/notification/templates_test.py
@@ -30,6 +30,32 @@ def _sample_payload(template_key: str) -> dict[str, object]:
             "ip_address": "127.0.0.1",
         },
         "phone_otp": {"otp": "123456"},
+        "payment_succeeded": {
+            "full_name": "Ada Lovelace",
+            "event_name": "Wembley Show",
+        },
+        "payment_failed": {
+            "full_name": "Ada Lovelace",
+            "event_name": "Wembley Show",
+            "failure_code": "card_declined",
+        },
+        "event_cancelled": {
+            "full_name": "Ada Lovelace",
+            "event_name": "Wembley Show",
+        },
+        "ticket_cancelled_chargeback": {
+            "full_name": "Ada Lovelace",
+            "event_name": "Wembley Show",
+        },
+        "ticket_cancelled_refund": {
+            "full_name": "Ada Lovelace",
+            "event_name": "Wembley Show",
+        },
+        "tickets_frozen_device_revoke": {
+            "full_name": "Ada Lovelace",
+            "ticket_count": 2,
+        },
+        "ticket_restored": {"full_name": "Ada Lovelace"},
     }
     return samples[template_key]
 

--- a/api/tests/v1/outbox/dlq_test.py
+++ b/api/tests/v1/outbox/dlq_test.py
@@ -1,0 +1,110 @@
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import pytest
+
+from com.qode.qrew.v1.service.core.outbox import drain_once
+from com.qode.qrew.v1.service.core.outbox import sweeper as sweeper_module
+from com.qode.qrew.v1.service.core.outbox.model import OutboxEvent
+from com.qode.qrew.v1.service.core.outbox.sweeper import DLQ_UNKNOWN_JOB
+from com.qode.qrew.v1.service.settings import settings
+
+
+class _FakeSession:
+    def __init__(self, rows: list[OutboxEvent]) -> None:
+        self._rows = rows
+
+    async def __aenter__(self) -> "_FakeSession":
+        return self
+
+    async def __aexit__(self, *_args: object) -> None:
+        return None
+
+    def begin(self) -> "_FakeSession":
+        return self
+
+    async def execute(self, *_args: object, **_kwargs: object) -> Any:
+        class _R:
+            def __init__(self, rows: list[OutboxEvent]) -> None:
+                self._rows = rows
+
+            def scalars(self) -> Any:
+                rows = self._rows
+
+                class _S:
+                    def all(self) -> list[OutboxEvent]:
+                        return rows
+
+                return _S()
+
+        return _R(self._rows)
+
+    async def flush(self) -> None:
+        return None
+
+    async def commit(self) -> None:
+        return None
+
+
+def _row(job_name: str, attempts: int = 0) -> OutboxEvent:
+    row = OutboxEvent(
+        aggregate_type="agg", aggregate_id="x", job_name=job_name, payload={}
+    )
+    row.attempt_count = attempts
+    row.next_attempt_at = datetime.now(UTC) - timedelta(seconds=1)
+    return row
+
+
+async def test_unknown_job_dlqs_after_max_attempts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    row = _row(
+        "notifications.does_not_exist", attempts=settings.outbox_max_attempts - 1
+    )
+    session = _FakeSession([row])
+    monkeypatch.setattr(sweeper_module, "AsyncSessionLocal", lambda: session)
+
+    async def _enqueue(name: str, _payload: dict[str, Any]) -> None:
+        # mirror the real enqueue() — raises KeyError on unknown job names.
+        from com.qode.qrew.v1.service.core.jobs.registry import get_spec
+
+        get_spec(name)
+
+    await drain_once(enqueue_fn=_enqueue)
+    assert row.dispatched_at is not None
+    assert row.dlq_reason == DLQ_UNKNOWN_JOB
+
+
+async def test_unknown_job_retries_before_max_attempts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    row = _row("notifications.does_not_exist", attempts=0)
+    session = _FakeSession([row])
+    monkeypatch.setattr(sweeper_module, "AsyncSessionLocal", lambda: session)
+
+    async def _enqueue(name: str, _payload: dict[str, Any]) -> None:
+        from com.qode.qrew.v1.service.core.jobs.registry import get_spec
+
+        get_spec(name)
+
+    await drain_once(enqueue_fn=_enqueue)
+    assert row.dispatched_at is None
+    assert row.dlq_reason is None
+    assert row.attempt_count == 1
+
+
+async def test_known_job_unaffected_by_dlq(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    row = _row("notifications.payment_succeeded")
+    session = _FakeSession([row])
+    monkeypatch.setattr(sweeper_module, "AsyncSessionLocal", lambda: session)
+
+    async def _enqueue(name: str, _payload: dict[str, Any]) -> None:
+        del name
+        return None
+
+    drained = await drain_once(enqueue_fn=_enqueue)
+    assert drained == 1
+    assert row.dispatched_at is not None
+    assert row.dlq_reason is None


### PR DESCRIPTION
## Summary

Seven distinct `notifications.*` job names are being published through the outbox but no Arq handler was registered for any of them.

The drainer would retry indefinitely on `KeyError("unknown_job_name")`, leaving outbox rows accumulating in pending state forever. This PR ships the handlers AND a DLQ safety net so a future typo in a job name can't accumulate either.

Seven handlers added under `jobs/lifecycle_notifications.py`, registered via `@job(...)` so they show up in the central registry:

- `notifications.payment_succeeded`
- `notifications.payment_failed`
- `notifications.event_cancelled`
- `notifications.ticket_cancelled_chargeback`
- `notifications.ticket_cancelled_refund`
- `notifications.tickets_frozen_device_revoke`
- `notifications.ticket_restored`

## Verification

- `api/tests/v1/outbox/dlq_test.py`

## Issue Reference

Closes [QRW-169](https://github.com/cristiangilsanz/qrew/issues/169)

## Checklist
- [x] I confirm that this PR follows the project's established coding standards.