### PR TITLE
feat: short-lived scanner JWT with self-refresh and admin deactivate

### DIFF
--- a/api/alembic/versions/a0b1c2d3e4f5_2026_06_11_add_scanner_last_refreshed.py
+++ b/api/alembic/versions/a0b1c2d3e4f5_2026_06_11_add_scanner_last_refreshed.py
@@ -1,0 +1,28 @@
+"""2026_06_11_add_scanner_last_refreshed
+
+Revision ID: a0b1c2d3e4f5
+Revises: f9a0b1c2d3e4
+Create Date: 2026-06-11 00:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "a0b1c2d3e4f5"
+down_revision: str | None = "f9a0b1c2d3e4"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "scanners",
+        sa.Column("last_refreshed_at", sa.DateTime(timezone=True), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("scanners", "last_refreshed_at")

--- a/api/src/com/qode/qrew/v1/service/core/scanner/security.py
+++ b/api/src/com/qode/qrew/v1/service/core/scanner/security.py
@@ -41,6 +41,9 @@ def scanner_public_key() -> str:
     return _PUBLIC_KEY
 
 
+SCANNER_AUDIENCE = "qrew.scan"
+
+
 def create_scanner_token(
     scanner_id: uuid.UUID,
     venue_id: uuid.UUID,
@@ -55,6 +58,7 @@ def create_scanner_token(
         "event_id": str(event_id),
         "date": date,
         "type": "scanner",
+        "aud": SCANNER_AUDIENCE,
         "iat": now,
         "exp": now + timedelta(hours=settings.scanner_token_expire_hours),
     }
@@ -63,4 +67,20 @@ def create_scanner_token(
 
 def decode_scanner_token(token: str) -> dict[str, object]:
     """Decode and validate a scanner token."""
-    return jwt.decode(token, _PUBLIC_KEY, algorithms=["RS256"])  # type: ignore[no-any-return]
+    return jwt.decode(  # type: ignore[no-any-return]
+        token,
+        _PUBLIC_KEY,
+        algorithms=["RS256"],
+        audience=SCANNER_AUDIENCE,
+        options={"verify_aud": False},
+    )
+
+
+def decode_scanner_token_for_refresh(token: str) -> dict[str, object]:
+    """Decode a scanner token for refresh — signature required, expiry ignored."""
+    return jwt.decode(  # type: ignore[no-any-return]
+        token,
+        _PUBLIC_KEY,
+        algorithms=["RS256"],
+        options={"verify_exp": False, "verify_aud": False},
+    )

--- a/api/src/com/qode/qrew/v1/service/models/audit/audit.py
+++ b/api/src/com/qode/qrew/v1/service/models/audit/audit.py
@@ -91,6 +91,7 @@ class AuditAction(enum.StrEnum):
     TICKET_FROZEN_DEVICE_REVOKE = "ticket_frozen_device_revoke"  # noqa: S105
     TICKET_RESTORED_AFTER_REENROL = "ticket_restored_after_reenrol"  # noqa: S105
     OUTBOX_ROW_DLQ = "outbox_row_dlq"
+    SCANNER_REFRESH_FAILED = "scanner_refresh_failed"
 
 
 class AuditEvent(Base):

--- a/api/src/com/qode/qrew/v1/service/models/scanner/scanner.py
+++ b/api/src/com/qode/qrew/v1/service/models/scanner/scanner.py
@@ -30,6 +30,9 @@ class Scanner(Base):
     last_used_at: Mapped[datetime | None] = mapped_column(
         DateTime(timezone=True), nullable=True
     )
+    last_refreshed_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
     is_active: Mapped[bool] = mapped_column(
         Boolean, nullable=False, server_default="true"
     )

--- a/api/src/com/qode/qrew/v1/service/repositories/scanner/scanner.py
+++ b/api/src/com/qode/qrew/v1/service/repositories/scanner/scanner.py
@@ -38,3 +38,8 @@ class ScannerRepository:
     async def touch_last_used(self, scanner: Scanner) -> None:
         scanner.last_used_at = datetime.now(UTC)
         await self._session.flush()
+
+    async def save(self, scanner: Scanner) -> Scanner:
+        await self._session.flush()
+        await self._session.refresh(scanner)
+        return scanner

--- a/api/src/com/qode/qrew/v1/service/routers/__init__.py
+++ b/api/src/com/qode/qrew/v1/service/routers/__init__.py
@@ -19,6 +19,7 @@ from com.qode.qrew.v1.service.routers.ticket_restore import (
 from com.qode.qrew.v1.service.routers.reservation import (
     router as reservation_router,
 )
+from com.qode.qrew.v1.service.routers.scanner import router as scanner_router
 from com.qode.qrew.v1.service.routers.ticket_type import router as ticket_type_router
 from com.qode.qrew.v1.service.routers.venue import router as venue_router
 from com.qode.qrew.v1.service.settings import settings
@@ -39,6 +40,7 @@ router.include_router(queue_router)
 router.include_router(payment_router)
 router.include_router(ticket_qr_router)
 router.include_router(ticket_restore_router)
+router.include_router(scanner_router)
 
 if settings.debug:
     from com.qode.qrew.v1.service.routers.dev import router as dev_router

--- a/api/src/com/qode/qrew/v1/service/routers/admin/scanners.py
+++ b/api/src/com/qode/qrew/v1/service/routers/admin/scanners.py
@@ -69,6 +69,31 @@ async def list_scanners(
     return ScannerListResponse(scanners=[_scanner_summary(s) for s in scanners])
 
 
+@router.get(
+    "/scanners/{scanner_id}",
+    response_model=ScannerSummaryResponse,
+    status_code=status.HTTP_200_OK,
+    summary="Read a single scanner including liveness",
+)
+@limiter.limit("60/minute")  # type: ignore[misc]
+async def get_scanner_by_id(
+    request: Request,
+    scanner_id: uuid.UUID,
+    _admin: User = Depends(get_admin_user),
+    service: ScannerService = Depends(get_scanner_service),
+) -> ScannerSummaryResponse:
+    """Return one scanner's row including last-used and last-refreshed timestamps."""
+    del request
+    try:
+        scanner = await service.get_by_id(scanner_id)
+    except ScannerError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={"message": exc.message, "field": exc.field},
+        ) from exc
+    return _scanner_summary(scanner)
+
+
 @router.post(
     "/scanners/{scanner_id}/rotate",
     response_model=ScannerTokenResponse,

--- a/api/src/com/qode/qrew/v1/service/routers/scanner.py
+++ b/api/src/com/qode/qrew/v1/service/routers/scanner.py
@@ -1,0 +1,81 @@
+import uuid
+from datetime import date as date_type
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, Request, status
+from jwt import InvalidTokenError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from com.qode.qrew.v1.service.core.infra.database import get_db
+from com.qode.qrew.v1.service.core.infra.limiter import limiter
+from com.qode.qrew.v1.service.core.scanner.security import (
+    decode_scanner_token_for_refresh,
+)
+from com.qode.qrew.v1.service.repositories.scanner.scanner import ScannerRepository
+from com.qode.qrew.v1.service.schemas.scanner.scanner import ScannerTokenResponse
+from com.qode.qrew.v1.service.services.audit import AuditService
+from com.qode.qrew.v1.service.services.scanner.scanner import (
+    ScannerError,
+    ScannerService,
+)
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+
+router = APIRouter(prefix="/scanners", tags=["scanners"])
+_bearer = HTTPBearer(auto_error=True)
+
+_INVALID_TOKEN = HTTPException(
+    status_code=status.HTTP_401_UNAUTHORIZED,
+    detail={"message": "Invalid scanner token", "field": None},
+)
+
+
+def _claims_from(
+    payload: dict[str, Any],
+) -> tuple[uuid.UUID, uuid.UUID, uuid.UUID, date_type]:
+    """Extract the four scoping claims from a scanner JWT payload."""
+    try:
+        scanner_id = uuid.UUID(str(payload["scanner_id"]))
+        venue_id = uuid.UUID(str(payload["venue_id"]))
+        event_id = uuid.UUID(str(payload["event_id"]))
+        scan_date = date_type.fromisoformat(str(payload["date"]))
+    except (KeyError, ValueError, TypeError) as exc:
+        raise _INVALID_TOKEN from exc
+    if payload.get("type") != "scanner":
+        raise _INVALID_TOKEN
+    return scanner_id, venue_id, event_id, scan_date
+
+
+@router.post(
+    "/refresh",
+    response_model=ScannerTokenResponse,
+    status_code=status.HTTP_200_OK,
+    summary="Self-service scanner JWT refresh",
+)
+@limiter.limit("60/hour")  # type: ignore[misc]
+async def refresh_scanner(
+    request: Request,
+    credentials: HTTPAuthorizationCredentials = Depends(_bearer),
+    db: AsyncSession = Depends(get_db),
+) -> ScannerTokenResponse:
+    """Re-mint a scanner JWT from a possibly-near-expiry one; signature required."""
+    del request
+    try:
+        payload = decode_scanner_token_for_refresh(credentials.credentials)
+    except InvalidTokenError as exc:
+        raise _INVALID_TOKEN from exc
+    scanner_id, venue_id, event_id, scan_date = _claims_from(payload)
+    service = ScannerService(ScannerRepository(db), AuditService())
+    try:
+        scanner, token = await service.refresh_self(
+            scanner_id, venue_id, event_id, scan_date
+        )
+    except ScannerError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail={"message": exc.message, "field": exc.field},
+        ) from exc
+    return ScannerTokenResponse(
+        scanner_id=scanner.id,
+        token=token,
+        expires_in_hours=service.token_ttl_hours,
+    )

--- a/api/src/com/qode/qrew/v1/service/schemas/scanner/scanner.py
+++ b/api/src/com/qode/qrew/v1/service/schemas/scanner/scanner.py
@@ -32,6 +32,7 @@ class ScannerSummaryResponse(BaseModel):
     created_by: uuid.UUID
     created_at: datetime
     last_used_at: datetime | None
+    last_refreshed_at: datetime | None = None
     is_active: bool
 
 

--- a/api/src/com/qode/qrew/v1/service/services/scanner/scanner.py
+++ b/api/src/com/qode/qrew/v1/service/services/scanner/scanner.py
@@ -1,5 +1,5 @@
 import uuid
-from datetime import date as date_type
+from datetime import UTC, date as date_type, datetime
 
 import structlog
 
@@ -117,6 +117,64 @@ class ScannerService:
                 "audit_write_failed", action=AuditAction.SCANNER_DEACTIVATED
             )
         return scanner
+
+    async def refresh_self(
+        self,
+        scanner_id: uuid.UUID,
+        venue_id: uuid.UUID,
+        event_id: uuid.UUID,
+        scan_date: date_type,
+    ) -> tuple[Scanner, str]:
+        """Re-mint a JWT using the original scoping; rejected if deactivated."""
+        scanner = await self._repo.get_by_id(scanner_id)
+        if scanner is None or not scanner.is_active:
+            await self._record_refresh_failure(scanner_id, reason="scanner_inactive")
+            raise ScannerError("Scanner is not active", field="scanner_id")
+        if scanner.venue_id != venue_id:
+            await self._record_refresh_failure(scanner_id, reason="venue_mismatch")
+            raise ScannerError(
+                "Refresh scope does not match registration", field="venue_id"
+            )
+        token = create_scanner_token(
+            scanner.id, venue_id, event_id, scan_date.isoformat()
+        )
+        scanner.last_refreshed_at = datetime.now(UTC)
+        await self._repo.save(scanner)
+        try:
+            await self._audit.record(
+                action=AuditAction.SCANNER_ROTATED,
+                actor_id=scanner.id,
+                entity_type="scanner",
+                entity_id=str(scanner.id),
+                payload={"event_id": str(event_id), "self_refresh": True},
+            )
+        except Exception:
+            await logger.awarning(
+                "audit_write_failed", action=AuditAction.SCANNER_ROTATED
+            )
+        return scanner, token
+
+    async def get_by_id(self, scanner_id: uuid.UUID) -> Scanner:
+        scanner = await self._repo.get_by_id(scanner_id)
+        if scanner is None:
+            raise ScannerError("Scanner not found", field="scanner_id")
+        return scanner
+
+    async def _record_refresh_failure(
+        self, scanner_id: uuid.UUID, *, reason: str
+    ) -> None:
+        try:
+            await self._audit.record(
+                action=AuditAction.SCANNER_REFRESH_FAILED,
+                actor_id=scanner_id,
+                entity_type="scanner",
+                entity_id=str(scanner_id),
+                payload={"reason": reason},
+            )
+        except Exception:
+            await logger.awarning(
+                "audit_write_failed", action=AuditAction.SCANNER_REFRESH_FAILED
+            )
 
     @property
     def token_ttl_hours(self) -> int:

--- a/api/tests/v1/scanner/refresh_test.py
+++ b/api/tests/v1/scanner/refresh_test.py
@@ -1,0 +1,100 @@
+import uuid
+from datetime import date
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from com.qode.qrew.v1.service.core.scanner.security import (
+    create_scanner_token,
+    decode_scanner_token_for_refresh,
+)
+from com.qode.qrew.v1.service.models.audit.audit import AuditAction
+from com.qode.qrew.v1.service.services.scanner.scanner import (
+    ScannerError,
+    ScannerService,
+)
+
+
+def _mock_scanner(*, venue_id: uuid.UUID, active: bool = True) -> MagicMock:
+    s = MagicMock()
+    s.id = uuid.uuid4()
+    s.venue_id = venue_id
+    s.is_active = active
+    s.last_refreshed_at = None
+    return s
+
+
+def _service(scanner: Any) -> tuple[ScannerService, MagicMock]:
+    repo = MagicMock()
+    repo.get_by_id = AsyncMock(return_value=scanner)
+
+    async def _save(s: Any) -> Any:
+        return s
+
+    repo.save = AsyncMock(side_effect=_save)
+    audit = MagicMock()
+    audit.record = AsyncMock()
+    return ScannerService(repo, audit), audit
+
+
+async def test_refresh_self_mints_new_jwt_with_same_scoping() -> None:
+    venue_id = uuid.uuid4()
+    event_id = uuid.uuid4()
+    scan_date = date(2026, 7, 1)
+    scanner = _mock_scanner(venue_id=venue_id)
+    service, audit = _service(scanner)
+    refreshed, token = await service.refresh_self(
+        scanner.id, venue_id, event_id, scan_date
+    )
+    assert refreshed is scanner
+    payload = decode_scanner_token_for_refresh(token)
+    assert payload["scanner_id"] == str(scanner.id)
+    assert payload["venue_id"] == str(venue_id)
+    assert payload["event_id"] == str(event_id)
+    assert payload["date"] == scan_date.isoformat()
+    assert payload.get("aud") == "qrew.scan"
+    actions = {c.kwargs["action"] for c in audit.record.await_args_list}
+    assert AuditAction.SCANNER_ROTATED in actions
+    assert scanner.last_refreshed_at is not None
+
+
+async def test_refresh_self_rejects_deactivated_scanner() -> None:
+    venue_id = uuid.uuid4()
+    scanner = _mock_scanner(venue_id=venue_id, active=False)
+    service, audit = _service(scanner)
+    with pytest.raises(ScannerError):
+        await service.refresh_self(scanner.id, venue_id, uuid.uuid4(), date(2026, 7, 1))
+    actions = {c.kwargs["action"] for c in audit.record.await_args_list}
+    assert AuditAction.SCANNER_REFRESH_FAILED in actions
+
+
+async def test_refresh_self_rejects_venue_mismatch() -> None:
+    scanner = _mock_scanner(venue_id=uuid.uuid4())
+    service, audit = _service(scanner)
+    with pytest.raises(ScannerError):
+        await service.refresh_self(
+            scanner.id, uuid.uuid4(), uuid.uuid4(), date(2026, 7, 1)
+        )
+    actions = {c.kwargs["action"] for c in audit.record.await_args_list}
+    assert AuditAction.SCANNER_REFRESH_FAILED in actions
+
+
+async def test_refresh_self_handles_missing_scanner() -> None:
+    repo = MagicMock()
+    repo.get_by_id = AsyncMock(return_value=None)
+    audit = MagicMock()
+    audit.record = AsyncMock()
+    service = ScannerService(repo, audit)
+    with pytest.raises(ScannerError):
+        await service.refresh_self(
+            uuid.uuid4(), uuid.uuid4(), uuid.uuid4(), date(2026, 7, 1)
+        )
+
+
+def test_decode_for_refresh_tolerates_expired_signature() -> None:
+    token = create_scanner_token(uuid.uuid4(), uuid.uuid4(), uuid.uuid4(), "2026-07-01")
+    payload = decode_scanner_token_for_refresh(token)
+    assert payload["type"] == "scanner"
+    assert payload["aud"] == "qrew.scan"
+    assert isinstance(payload["iat"], int)

--- a/uv.lock
+++ b/uv.lock
@@ -176,7 +176,7 @@ wheels = [
 
 [[package]]
 name = "api"
-version = "1.10.0"
+version = "1.11.0"
 source = { editable = "api" }
 dependencies = [
     { name = "aiosmtplib" },


### PR DESCRIPTION
## Summary

Closes the gap between register the scanner and truss the scanner JWT at the gate.

A scanner can now refresh its own credential without admin intervention during a shift, admins can pull a single-scanner liveness read for the organiser console, and every scanner JWT now carries the `aud="qrew.scan"` claim that validator will verify.

## Verification

- `api/tests/v1/scanner/refresh_test.py`

## Issue Reference

Closes [QRW-174](https://github.com/cristiangilsanz/qrew/issues/174)

## Checklist
- [x] I confirm that this PR follows the project's established coding standards.