### PR TITLE
feat: add entry validate endpoint with relay protection and FSM transition

### DIFF
--- a/api/src/com/qode/qrew/v1/service/models/audit/audit.py
+++ b/api/src/com/qode/qrew/v1/service/models/audit/audit.py
@@ -92,6 +92,8 @@ class AuditAction(enum.StrEnum):
     TICKET_RESTORED_AFTER_REENROL = "ticket_restored_after_reenrol"  # noqa: S105
     OUTBOX_ROW_DLQ = "outbox_row_dlq"
     SCANNER_REFRESH_FAILED = "scanner_refresh_failed"
+    ENTRY_VALIDATED = "entry_validated"
+    ENTRY_REJECTED = "entry_rejected"
 
 
 class AuditEvent(Base):

--- a/api/src/com/qode/qrew/v1/service/routers/__init__.py
+++ b/api/src/com/qode/qrew/v1/service/routers/__init__.py
@@ -19,6 +19,7 @@ from com.qode.qrew.v1.service.routers.ticket_restore import (
 from com.qode.qrew.v1.service.routers.reservation import (
     router as reservation_router,
 )
+from com.qode.qrew.v1.service.routers.entry import router as entry_router
 from com.qode.qrew.v1.service.routers.scanner import router as scanner_router
 from com.qode.qrew.v1.service.routers.ticket_type import router as ticket_type_router
 from com.qode.qrew.v1.service.routers.venue import router as venue_router
@@ -41,6 +42,7 @@ router.include_router(payment_router)
 router.include_router(ticket_qr_router)
 router.include_router(ticket_restore_router)
 router.include_router(scanner_router)
+router.include_router(entry_router)
 
 if settings.debug:
     from com.qode.qrew.v1.service.routers.dev import router as dev_router

--- a/api/src/com/qode/qrew/v1/service/routers/entry.py
+++ b/api/src/com/qode/qrew/v1/service/routers/entry.py
@@ -1,0 +1,87 @@
+import uuid
+from typing import Annotated
+
+import redis.asyncio as aioredis
+from fastapi import APIRouter, Depends, HTTPException, Request, status
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from jwt import InvalidTokenError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from com.qode.qrew.v1.service.core.auth.auth import get_scanner
+from com.qode.qrew.v1.service.core.infra.database import get_db
+from com.qode.qrew.v1.service.core.infra.limiter import limiter
+from com.qode.qrew.v1.service.core.infra.redis import get_redis
+from com.qode.qrew.v1.service.core.scanner.security import decode_scanner_token
+from com.qode.qrew.v1.service.models.scanner.scanner import Scanner
+from com.qode.qrew.v1.service.schemas.entry import (
+    EntryValidateRequest,
+    EntryValidateResponse,
+)
+from com.qode.qrew.v1.service.services.audit import AuditService
+from com.qode.qrew.v1.service.services.entry import validate_entry
+
+router = APIRouter(prefix="/entry", tags=["entry"])
+_bearer = HTTPBearer(auto_error=True)
+
+
+def _claims_or_401(token: str) -> tuple[uuid.UUID | None, uuid.UUID]:
+    """Return (event_id, venue_id) from the scanner JWT; raise 401 on malformed."""
+    try:
+        payload = decode_scanner_token(token)
+    except InvalidTokenError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail={"message": "Invalid scanner token", "field": None},
+        ) from exc
+    venue_raw = payload.get("venue_id")
+    event_raw = payload.get("event_id")
+    if not isinstance(venue_raw, str):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail={"message": "Scanner token missing venue_id", "field": None},
+        )
+    try:
+        venue_id = uuid.UUID(venue_raw)
+        event_id = uuid.UUID(event_raw) if isinstance(event_raw, str) else None
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail={"message": "Scanner token has invalid scoping", "field": None},
+        ) from exc
+    return event_id, venue_id
+
+
+@router.post(
+    "/validate",
+    response_model=EntryValidateResponse,
+    status_code=status.HTTP_200_OK,
+    summary="Validate a ticket QR at the gate",
+)
+@limiter.limit("600/minute")  # type: ignore[misc]
+async def validate_entry_endpoint(
+    request: Request,
+    body: EntryValidateRequest,
+    credentials: Annotated[HTTPAuthorizationCredentials, Depends(_bearer)],
+    scanner: Scanner = Depends(get_scanner),
+    db: AsyncSession = Depends(get_db),
+    redis: Annotated[aioredis.Redis, Depends(get_redis)] = ...,  # type: ignore[type-arg, assignment]
+) -> EntryValidateResponse:
+    """Verify the ticket JWT, defeat relays, and atomically finalise entry."""
+    del request
+    event_id, venue_id = _claims_or_401(credentials.credentials)
+    outcome = await validate_entry(
+        db,
+        redis,
+        ticket_jwt=body.ticket_jwt,
+        scanner=scanner,
+        scanner_event_id=event_id,
+        scanner_venue_id=venue_id,
+        audit=AuditService(),
+    )
+    return EntryValidateResponse(
+        allowed=outcome.allowed,
+        reason=outcome.reason.value if outcome.reason else None,
+        ticket_id=outcome.ticket_id,
+        holder_user_id=outcome.holder_user_id,
+        scanned_at=outcome.scanned_at,
+    )

--- a/api/src/com/qode/qrew/v1/service/schemas/entry/__init__.py
+++ b/api/src/com/qode/qrew/v1/service/schemas/entry/__init__.py
@@ -1,0 +1,6 @@
+from com.qode.qrew.v1.service.schemas.entry.entry import (
+    EntryValidateRequest,
+    EntryValidateResponse,
+)
+
+__all__ = ["EntryValidateRequest", "EntryValidateResponse"]

--- a/api/src/com/qode/qrew/v1/service/schemas/entry/entry.py
+++ b/api/src/com/qode/qrew/v1/service/schemas/entry/entry.py
@@ -1,0 +1,16 @@
+import uuid
+from datetime import datetime
+
+from pydantic import BaseModel, Field
+
+
+class EntryValidateRequest(BaseModel):
+    ticket_jwt: str = Field(..., min_length=1)
+
+
+class EntryValidateResponse(BaseModel):
+    allowed: bool
+    reason: str | None
+    ticket_id: uuid.UUID | None
+    holder_user_id: uuid.UUID | None
+    scanned_at: datetime

--- a/api/src/com/qode/qrew/v1/service/services/entry/__init__.py
+++ b/api/src/com/qode/qrew/v1/service/services/entry/__init__.py
@@ -1,0 +1,7 @@
+from com.qode.qrew.v1.service.services.entry.entry import (
+    EntryOutcome,
+    EntryReason,
+    validate_entry,
+)
+
+__all__ = ["EntryOutcome", "EntryReason", "validate_entry"]

--- a/api/src/com/qode/qrew/v1/service/services/entry/entry.py
+++ b/api/src/com/qode/qrew/v1/service/services/entry/entry.py
@@ -1,0 +1,253 @@
+import time
+import uuid
+from dataclasses import dataclass
+from datetime import UTC, datetime, timezone
+from enum import StrEnum
+from typing import Any
+
+import jwt
+import redis.asyncio as aioredis
+import structlog
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from com.qode.qrew.v1.service.core.auth import jwt_keys
+from com.qode.qrew.v1.service.core.locking import redlock
+from com.qode.qrew.v1.service.core.locking.errors import LockUnavailableError
+from com.qode.qrew.v1.service.core.observability import traced
+from com.qode.qrew.v1.service.models.audit.audit import AuditAction
+from com.qode.qrew.v1.service.models.scanner.scanner import Scanner
+from com.qode.qrew.v1.service.models.ticket import Ticket, TicketState
+from com.qode.qrew.v1.service.services.audit import AuditService
+from com.qode.qrew.v1.service.services.ticket import (
+    TicketTransitionError,
+    transition_ticket,
+)
+from com.qode.qrew.v1.service.settings import settings
+
+logger = structlog.get_logger(__name__)
+
+_REPLAY_PREFIX = "entry:jti"
+
+
+class EntryReason(StrEnum):
+    """Typed reasons returned alongside `allowed=false`."""
+
+    signature = "signature"
+    audience = "audience"
+    expired = "expired"
+    wrong_event = "wrong_event"
+    wrong_venue = "wrong_venue"
+    replay = "replay"
+    not_found = "not_found"
+    wrong_owner = "wrong_owner"
+    state = "state"
+    busy = "busy"
+
+
+@dataclass(frozen=True)
+class EntryOutcome:
+    allowed: bool
+    reason: EntryReason | None
+    ticket_id: uuid.UUID | None
+    holder_user_id: uuid.UUID | None
+    scanned_at: datetime
+
+
+def _now() -> datetime:
+    return datetime.now(UTC)
+
+
+@traced("entry.validate")
+async def validate_entry(
+    session: AsyncSession,
+    redis: aioredis.Redis,  # type: ignore[type-arg]
+    *,
+    ticket_jwt: str,
+    scanner: Scanner,
+    scanner_event_id: uuid.UUID | None,
+    scanner_venue_id: uuid.UUID,
+    audit: AuditService,
+) -> EntryOutcome:
+    """Run the seven-step gate. Every outcome writes one audit row."""
+    started_at_ms = time.monotonic() * 1000
+    decision = await _evaluate(
+        session=session,
+        redis=redis,
+        ticket_jwt=ticket_jwt,
+        scanner=scanner,
+        scanner_event_id=scanner_event_id,
+        scanner_venue_id=scanner_venue_id,
+        audit=audit,
+    )
+    latency_ms = int(time.monotonic() * 1000 - started_at_ms)
+    await logger.ainfo(
+        "entry.scan.outcome",
+        reason=decision.reason.value if decision.reason else "ok",
+        ticket_id=str(decision.ticket_id) if decision.ticket_id else None,
+        event_id=str(scanner_event_id) if scanner_event_id else None,
+        scanner_id=str(scanner.id),
+        latency_ms=latency_ms,
+    )
+    return decision
+
+
+async def _evaluate(
+    *,
+    session: AsyncSession,
+    redis: aioredis.Redis,  # type: ignore[type-arg]
+    ticket_jwt: str,
+    scanner: Scanner,
+    scanner_event_id: uuid.UUID | None,
+    scanner_venue_id: uuid.UUID,
+    audit: AuditService,
+) -> EntryOutcome:
+    try:
+        header = jwt.get_unverified_header(ticket_jwt)
+        kid = header.get("kid")
+        public_pem = (
+            jwt_keys._KEYS[jwt_keys.TICKET_QR].verifiers.get(kid)  # pyright: ignore[reportPrivateUsage]
+            if isinstance(kid, str)
+            else None
+        )
+        if public_pem is None:
+            raise jwt.InvalidTokenError("Unknown signing key")
+        payload = jwt.decode(
+            ticket_jwt,
+            public_pem,
+            algorithms=["ES256"],
+            audience=settings.ticket_qr_audience,
+        )
+    except jwt.ExpiredSignatureError:
+        await _audit_reject(audit, scanner.id, None, EntryReason.expired)
+        return _denied(EntryReason.expired)
+    except jwt.InvalidAudienceError:
+        await _audit_reject(audit, scanner.id, None, EntryReason.audience)
+        return _denied(EntryReason.audience)
+    except jwt.InvalidTokenError:
+        await _audit_reject(audit, scanner.id, None, EntryReason.signature)
+        return _denied(EntryReason.signature)
+
+    ticket_id_raw = payload.get("ticket_id")
+    event_id_raw = payload.get("event_id")
+    venue_id_raw = payload.get("venue_id")
+    jti = payload.get("jti")
+    exp = payload.get("exp")
+    if not (
+        isinstance(ticket_id_raw, str)
+        and isinstance(event_id_raw, str)
+        and isinstance(venue_id_raw, str)
+        and isinstance(jti, str)
+        and isinstance(exp, int)
+    ):
+        await _audit_reject(audit, scanner.id, None, EntryReason.signature)
+        return _denied(EntryReason.signature)
+
+    try:
+        ticket_id = uuid.UUID(ticket_id_raw)
+        event_id = uuid.UUID(event_id_raw)
+        venue_id = uuid.UUID(venue_id_raw)
+    except ValueError:
+        await _audit_reject(audit, scanner.id, None, EntryReason.signature)
+        return _denied(EntryReason.signature)
+
+    if scanner_event_id is not None and scanner_event_id != event_id:
+        await _audit_reject(audit, scanner.id, ticket_id, EntryReason.wrong_event)
+        return _denied(EntryReason.wrong_event, ticket_id=ticket_id)
+    if scanner_venue_id != venue_id:
+        await _audit_reject(audit, scanner.id, ticket_id, EntryReason.wrong_venue)
+        return _denied(EntryReason.wrong_venue, ticket_id=ticket_id)
+
+    now_unix = int(_now().timestamp())
+    remaining_ttl = max(exp - now_unix, 0) + settings.entry_replay_grace_seconds
+    claimed = await redis.set(  # type: ignore[misc]
+        f"{_REPLAY_PREFIX}:{jti}",
+        str(ticket_id),
+        ex=remaining_ttl,
+        nx=True,
+    )
+    if not claimed:
+        await _audit_reject(audit, scanner.id, ticket_id, EntryReason.replay)
+        return _denied(EntryReason.replay, ticket_id=ticket_id)
+
+    ticket = await session.get(Ticket, ticket_id)
+    if ticket is None:
+        await _audit_reject(audit, scanner.id, ticket_id, EntryReason.not_found)
+        return _denied(EntryReason.not_found, ticket_id=ticket_id)
+    if ticket.event_id != event_id:
+        await _audit_reject(audit, scanner.id, ticket_id, EntryReason.wrong_owner)
+        return _denied(EntryReason.wrong_owner, ticket_id=ticket_id)
+    if ticket.state not in {TicketState.issued, TicketState.entry_pending}:
+        await _audit_reject(
+            audit,
+            scanner.id,
+            ticket_id,
+            EntryReason.state,
+            extra={"current_state": ticket.state.value},
+        )
+        return _denied(EntryReason.state, ticket_id=ticket_id)
+
+    try:
+        async with redlock(f"ticket:{ticket_id}:entry", ttl_seconds=10):
+            await transition_ticket(
+                session,
+                ticket_id=ticket_id,
+                to_state=TicketState.used,
+                reason="entry_validated",
+                actor_id=scanner.id,
+                audit=audit,
+            )
+    except (LockUnavailableError, TicketTransitionError):
+        await _audit_reject(audit, scanner.id, ticket_id, EntryReason.busy)
+        return _denied(EntryReason.busy, ticket_id=ticket_id)
+
+    await audit.record(
+        action=AuditAction.ENTRY_VALIDATED,
+        actor_id=scanner.id,
+        entity_type="ticket",
+        entity_id=str(ticket_id),
+        payload={
+            "event_id": str(event_id),
+            "venue_id": str(venue_id),
+            "scanner_id": str(scanner.id),
+        },
+    )
+    return EntryOutcome(
+        allowed=True,
+        reason=None,
+        ticket_id=ticket_id,
+        holder_user_id=ticket.owner_user_id,
+        scanned_at=_now(),
+    )
+
+
+def _denied(reason: EntryReason, *, ticket_id: uuid.UUID | None = None) -> EntryOutcome:
+    return EntryOutcome(
+        allowed=False,
+        reason=reason,
+        ticket_id=ticket_id,
+        holder_user_id=None,
+        scanned_at=datetime.now(timezone.utc),
+    )
+
+
+async def _audit_reject(
+    audit: AuditService,
+    scanner_id: uuid.UUID,
+    ticket_id: uuid.UUID | None,
+    reason: EntryReason,
+    *,
+    extra: dict[str, Any] | None = None,
+) -> None:
+    payload: dict[str, Any] = {"reason": reason.value, "scanner_id": str(scanner_id)}
+    if extra:
+        payload.update(extra)
+    try:
+        await audit.record(
+            action=AuditAction.ENTRY_REJECTED,
+            actor_id=scanner_id,
+            entity_type="ticket",
+            entity_id=str(ticket_id) if ticket_id else None,
+            payload=payload,
+        )
+    except Exception:
+        await logger.awarning("audit_write_failed", action=AuditAction.ENTRY_REJECTED)

--- a/api/src/com/qode/qrew/v1/service/settings.py
+++ b/api/src/com/qode/qrew/v1/service/settings.py
@@ -166,5 +166,7 @@ class Settings(BaseSettings):
     ticket_qr_audience: str = "qrew.scan"
     ticket_qr_stream_max_seconds: int = 1800
 
+    entry_replay_grace_seconds: int = 10
+
 
 settings = Settings()

--- a/api/tests/v1/conftest.py
+++ b/api/tests/v1/conftest.py
@@ -38,6 +38,7 @@ def _stub_ticket_transition(  # pyright: ignore[reportUnusedFunction]
         return None
 
     import com.qode.qrew.v1.service.services.device.device as device_mod
+    import com.qode.qrew.v1.service.services.entry.entry as entry_mod
     import com.qode.qrew.v1.service.services.payment.payment as payment_mod
     import com.qode.qrew.v1.service.services.reservation.reservation as reservation_mod
     import com.qode.qrew.v1.service.services.ticket.restore as restore_mod
@@ -46,10 +47,12 @@ def _stub_ticket_transition(  # pyright: ignore[reportUnusedFunction]
     original_reservation = reservation_mod.transition_ticket
     original_restore = restore_mod.transition_ticket
     original_device = device_mod.transition_ticket
+    original_entry = entry_mod.transition_ticket
     payment_mod.transition_ticket = _stub  # type: ignore[assignment]
     reservation_mod.transition_ticket = _stub  # type: ignore[assignment]
     restore_mod.transition_ticket = _stub  # type: ignore[assignment]
     device_mod.transition_ticket = _stub  # type: ignore[assignment]
+    entry_mod.transition_ticket = _stub  # type: ignore[assignment]
     try:
         yield
     finally:
@@ -57,4 +60,5 @@ def _stub_ticket_transition(  # pyright: ignore[reportUnusedFunction]
         reservation_mod.transition_ticket = original_reservation
         restore_mod.transition_ticket = original_restore
         device_mod.transition_ticket = original_device
+        entry_mod.transition_ticket = original_entry
         _REGISTRY.clear()

--- a/api/tests/v1/entry/validate_test.py
+++ b/api/tests/v1/entry/validate_test.py
@@ -1,0 +1,290 @@
+import uuid
+from datetime import UTC, datetime, timedelta
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import fakeredis.aioredis
+import jwt
+import pytest_asyncio
+
+from com.qode.qrew.v1.service.core.auth import jwt_keys
+from com.qode.qrew.v1.service.core.locking import lock as lock_module
+from com.qode.qrew.v1.service.models.audit.audit import AuditAction
+from com.qode.qrew.v1.service.models.ticket import Ticket, TicketState
+from com.qode.qrew.v1.service.services.audit import AuditService
+from com.qode.qrew.v1.service.services.entry import EntryReason, validate_entry
+from com.qode.qrew.v1.service.settings import settings
+
+
+@pytest_asyncio.fixture
+async def redis_client() -> Any:
+    client = fakeredis.aioredis.FakeRedis(decode_responses=True)
+    try:
+        yield client
+    finally:
+        await client.aclose()
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def _fake_redis_for_locks() -> Any:  # pyright: ignore[reportUnusedFunction]
+    fake = fakeredis.aioredis.FakeRedis()
+    previous = lock_module._ClientState.client  # pyright: ignore[reportPrivateUsage]
+    lock_module._ClientState.client = fake  # pyright: ignore[reportPrivateUsage]
+    try:
+        yield fake
+    finally:
+        await fake.aclose()
+        lock_module._ClientState.client = previous  # pyright: ignore[reportPrivateUsage]
+
+
+def _mint_ticket_jwt(
+    *,
+    ticket_id: uuid.UUID,
+    event_id: uuid.UUID,
+    venue_id: uuid.UUID,
+    aud: str | None = None,
+    expired: bool = False,
+    jti: str | None = None,
+) -> str:
+    now = datetime.now(UTC)
+    iat = now - timedelta(seconds=5)
+    exp = now - timedelta(seconds=1) if expired else now + timedelta(seconds=60)
+    claims: dict[str, Any] = {
+        "sub": str(uuid.uuid4()),
+        "ticket_id": str(ticket_id),
+        "event_id": str(event_id),
+        "venue_id": str(venue_id),
+        "device_id": str(uuid.uuid4()),
+        "jti": jti or uuid.uuid4().hex,
+        "iat": iat,
+        "exp": exp,
+        "aud": aud if aud is not None else settings.ticket_qr_audience,
+    }
+    return jwt_keys.sign(jwt_keys.TICKET_QR, claims)
+
+
+def _scanner(venue_id: uuid.UUID) -> MagicMock:
+    s = MagicMock()
+    s.id = uuid.uuid4()
+    s.venue_id = venue_id
+    s.is_active = True
+    return s
+
+
+def _ticket(
+    *,
+    ticket_id: uuid.UUID,
+    event_id: uuid.UUID,
+    state: TicketState = TicketState.issued,
+) -> Ticket:
+    return Ticket(
+        id=ticket_id,
+        reservation_id=uuid.uuid4(),
+        event_id=event_id,
+        ticket_type_id=uuid.uuid4(),
+        owner_user_id=uuid.uuid4(),
+        state=state,
+    )
+
+
+def _session(ticket: Ticket | None) -> MagicMock:
+    session = MagicMock()
+
+    async def _get(model: Any, key: Any) -> Any:
+        del model
+        if ticket is not None and ticket.id == key:
+            return ticket
+        return None
+
+    session.get = AsyncMock(side_effect=_get)
+
+    async def _execute(*_args: Any, **_kwargs: Any) -> Any:
+        result = MagicMock()
+        result.first.return_value = ({"id": ticket.id},) if ticket else None
+        return result
+
+    session.execute = AsyncMock(side_effect=_execute)
+    session.flush = AsyncMock()
+    session.refresh = AsyncMock()
+    return session
+
+
+def _audit() -> MagicMock:
+    a = MagicMock(spec=AuditService)
+    a.record = AsyncMock()
+    return a
+
+
+async def test_validate_happy_path_transitions_ticket(redis_client: Any) -> None:
+    event_id = uuid.uuid4()
+    venue_id = uuid.uuid4()
+    ticket = _ticket(ticket_id=uuid.uuid4(), event_id=event_id)
+    from tests.v1.conftest import register_test_tickets
+
+    register_test_tickets(ticket)
+    session = _session(ticket)
+    token = _mint_ticket_jwt(ticket_id=ticket.id, event_id=event_id, venue_id=venue_id)
+    audit = _audit()
+    outcome = await validate_entry(
+        session,
+        redis_client,
+        ticket_jwt=token,
+        scanner=_scanner(venue_id),
+        scanner_event_id=event_id,
+        scanner_venue_id=venue_id,
+        audit=audit,
+    )
+    assert outcome.allowed is True
+    assert outcome.ticket_id == ticket.id
+    actions = {c.kwargs["action"] for c in audit.record.await_args_list}
+    assert AuditAction.ENTRY_VALIDATED in actions
+
+
+async def test_validate_rejects_bad_signature(redis_client: Any) -> None:
+    audit = _audit()
+    outcome = await validate_entry(
+        _session(None),
+        redis_client,
+        ticket_jwt="not.a.valid.jwt",
+        scanner=_scanner(uuid.uuid4()),
+        scanner_event_id=uuid.uuid4(),
+        scanner_venue_id=uuid.uuid4(),
+        audit=audit,
+    )
+    assert outcome.allowed is False
+    assert outcome.reason == EntryReason.signature
+    actions = {c.kwargs["action"] for c in audit.record.await_args_list}
+    assert AuditAction.ENTRY_REJECTED in actions
+
+
+async def test_validate_rejects_wrong_audience(redis_client: Any) -> None:
+    event_id = uuid.uuid4()
+    venue_id = uuid.uuid4()
+    token = _mint_ticket_jwt(
+        ticket_id=uuid.uuid4(),
+        event_id=event_id,
+        venue_id=venue_id,
+        aud="qrew.something_else",
+    )
+    outcome = await validate_entry(
+        _session(None),
+        redis_client,
+        ticket_jwt=token,
+        scanner=_scanner(venue_id),
+        scanner_event_id=event_id,
+        scanner_venue_id=venue_id,
+        audit=_audit(),
+    )
+    assert outcome.reason == EntryReason.audience
+
+
+async def test_validate_rejects_expired_token(redis_client: Any) -> None:
+    event_id = uuid.uuid4()
+    venue_id = uuid.uuid4()
+    token = _mint_ticket_jwt(
+        ticket_id=uuid.uuid4(),
+        event_id=event_id,
+        venue_id=venue_id,
+        expired=True,
+    )
+    outcome = await validate_entry(
+        _session(None),
+        redis_client,
+        ticket_jwt=token,
+        scanner=_scanner(venue_id),
+        scanner_event_id=event_id,
+        scanner_venue_id=venue_id,
+        audit=_audit(),
+    )
+    assert outcome.reason == EntryReason.expired
+
+
+async def test_validate_rejects_wrong_event_for_scanner(redis_client: Any) -> None:
+    event_id = uuid.uuid4()
+    venue_id = uuid.uuid4()
+    token = _mint_ticket_jwt(
+        ticket_id=uuid.uuid4(), event_id=event_id, venue_id=venue_id
+    )
+    outcome = await validate_entry(
+        _session(None),
+        redis_client,
+        ticket_jwt=token,
+        scanner=_scanner(venue_id),
+        scanner_event_id=uuid.uuid4(),
+        scanner_venue_id=venue_id,
+        audit=_audit(),
+    )
+    assert outcome.reason == EntryReason.wrong_event
+
+
+async def test_validate_rejects_replay(redis_client: Any) -> None:
+    event_id = uuid.uuid4()
+    venue_id = uuid.uuid4()
+    ticket = _ticket(ticket_id=uuid.uuid4(), event_id=event_id)
+    from tests.v1.conftest import register_test_tickets
+
+    register_test_tickets(ticket)
+    token = _mint_ticket_jwt(
+        ticket_id=ticket.id, event_id=event_id, venue_id=venue_id, jti="fixed"
+    )
+    first = await validate_entry(
+        _session(ticket),
+        redis_client,
+        ticket_jwt=token,
+        scanner=_scanner(venue_id),
+        scanner_event_id=event_id,
+        scanner_venue_id=venue_id,
+        audit=_audit(),
+    )
+    assert first.allowed is True
+    second = await validate_entry(
+        _session(ticket),
+        redis_client,
+        ticket_jwt=token,
+        scanner=_scanner(venue_id),
+        scanner_event_id=event_id,
+        scanner_venue_id=venue_id,
+        audit=_audit(),
+    )
+    assert second.reason == EntryReason.replay
+
+
+async def test_validate_rejects_already_used_ticket(redis_client: Any) -> None:
+    event_id = uuid.uuid4()
+    venue_id = uuid.uuid4()
+    ticket = _ticket(ticket_id=uuid.uuid4(), event_id=event_id, state=TicketState.used)
+    token = _mint_ticket_jwt(ticket_id=ticket.id, event_id=event_id, venue_id=venue_id)
+    outcome = await validate_entry(
+        _session(ticket),
+        redis_client,
+        ticket_jwt=token,
+        scanner=_scanner(venue_id),
+        scanner_event_id=event_id,
+        scanner_venue_id=venue_id,
+        audit=_audit(),
+    )
+    assert outcome.reason == EntryReason.state
+
+
+async def test_validate_rejects_not_found(redis_client: Any) -> None:
+    event_id = uuid.uuid4()
+    venue_id = uuid.uuid4()
+    token = _mint_ticket_jwt(
+        ticket_id=uuid.uuid4(), event_id=event_id, venue_id=venue_id
+    )
+    outcome = await validate_entry(
+        _session(None),
+        redis_client,
+        ticket_jwt=token,
+        scanner=_scanner(venue_id),
+        scanner_event_id=event_id,
+        scanner_venue_id=venue_id,
+        audit=_audit(),
+    )
+    assert outcome.reason == EntryReason.not_found
+
+
+def test_jwt_exports_are_present() -> None:
+    # cover the import surface used by validate_entry
+    assert jwt.ExpiredSignatureError
+    assert jwt.InvalidTokenError


### PR DESCRIPTION
## Summary

Lands the gate endpoint.

A scanner sends `POST /v1/entry/validate` with a ticket JWT it just read off a phone screen and gets back `{allowed, reason}`.

Three independent layers stop a replay: Redis `SET NX` on the JWT's `jti`, redlock on the ticket id, and the FSM helper's `FOR UPDATE NOWAIT` plus DB trigger.

Validation is fail-fast and every outcome.

Writes one audit row with a typed `reason`.

Each failure is its own `ENTRY_REJECTED` action with `payload.reason` so post-event forensics can `GROUP BY reason` to spot a misbehaving scanner or a counterfeit QR drop.

The check order, in `services/entry/entry.py`:

1. **Signature**.
2. **Audience**.
3. **Expiry**.
4. **Wrong event**.
5. **Wrong venue**.
6. **Replay**.
7. **Ticket FSM**.
8. **Atomic transition**.

The endpoint returns HTTP 200 in both allow and deny cases (with `allowed: bool`).

A well-formed scan that fails business validation isn't a transport-level error and the gate device should stay on the happy network path. A malformed scanner token still returns 401 from the auth layer.

## Verification

- `api/tests/v1/entry/validate_test.py`

## Issue Reference

Closes [QRW-175](https://github.com/cristiangilsanz/qrew/issues/175)

## Checklist
- [x] I confirm that this PR follows the project's established coding standards.