### PR TITLE
feat: add entry stats endpoint and realtime entry channel for organisers

### DIFF
--- a/api/src/com/qode/qrew/v1/service/main.py
+++ b/api/src/com/qode/qrew/v1/service/main.py
@@ -17,6 +17,7 @@ from com.qode.qrew.v1.service.core.observability import add_trace_context, setup
 from com.qode.qrew.v1.service.core.ws import router as ws_router
 from com.qode.qrew.v1.service.lifespan import lifespan
 from com.qode.qrew.v1.service.realtime import me_channel as _me_channel
+from com.qode.qrew.v1.service.realtime import entry_channel as _entry_channel
 from com.qode.qrew.v1.service.realtime import queue_channel as _queue_channel
 from com.qode.qrew.v1.service.routers import router as v1_router
 from com.qode.qrew.v1.service.settings import settings
@@ -47,6 +48,7 @@ app = FastAPI(
 
 _ = _me_channel  # ensure the @channel decorator runs at import time
 _ = _queue_channel  # ensure the queue @channel decorator runs at import time
+_ = _entry_channel  # ensure the entry @channel decorator runs at import time
 
 setup_tracing(app)
 

--- a/api/src/com/qode/qrew/v1/service/realtime/entry_channel.py
+++ b/api/src/com/qode/qrew/v1/service/realtime/entry_channel.py
@@ -1,0 +1,40 @@
+import uuid
+
+from com.qode.qrew.v1.service.core.ws import channel
+from com.qode.qrew.v1.service.models.auth.session import Session
+from com.qode.qrew.v1.service.models.auth.user import User
+from com.qode.qrew.v1.service.repositories.event import EventRepository
+from com.qode.qrew.v1.service.repositories.organisation import (
+    OrganisationMemberRepository,
+)
+from com.qode.qrew.v1.service.core.infra.database import AsyncSessionLocal
+
+_PATTERN = "entry.{event_id}"
+
+
+@channel(key_pattern=_PATTERN)
+async def can_subscribe_entry(
+    user: User, params: dict[str, str], session: Session
+) -> bool:
+    """Only members of the organisation that owns the event may subscribe."""
+    del session
+    event_id_raw = params.get("event_id")
+    if not event_id_raw:
+        return False
+    try:
+        event_id = uuid.UUID(event_id_raw)
+    except ValueError:
+        return False
+    async with AsyncSessionLocal() as db:
+        event = await EventRepository(db).get_by_id(event_id)
+        if event is None:
+            return False
+        member = await OrganisationMemberRepository(db).get(
+            event.organisation_id, user.id
+        )
+        return member is not None
+
+
+def entry_channel_key(event_id: str) -> str:
+    """Return the channel key for an event's entry feed."""
+    return _PATTERN.format(event_id=event_id)

--- a/api/src/com/qode/qrew/v1/service/routers/__init__.py
+++ b/api/src/com/qode/qrew/v1/service/routers/__init__.py
@@ -20,6 +20,7 @@ from com.qode.qrew.v1.service.routers.reservation import (
     router as reservation_router,
 )
 from com.qode.qrew.v1.service.routers.entry import router as entry_router
+from com.qode.qrew.v1.service.routers.entry_stats import router as entry_stats_router
 from com.qode.qrew.v1.service.routers.scanner import router as scanner_router
 from com.qode.qrew.v1.service.routers.ticket_type import router as ticket_type_router
 from com.qode.qrew.v1.service.routers.venue import router as venue_router
@@ -43,6 +44,7 @@ router.include_router(ticket_qr_router)
 router.include_router(ticket_restore_router)
 router.include_router(scanner_router)
 router.include_router(entry_router)
+router.include_router(entry_stats_router)
 
 if settings.debug:
     from com.qode.qrew.v1.service.routers.dev import router as dev_router

--- a/api/src/com/qode/qrew/v1/service/routers/entry_stats.py
+++ b/api/src/com/qode/qrew/v1/service/routers/entry_stats.py
@@ -1,0 +1,72 @@
+import uuid
+from datetime import datetime
+from typing import Annotated
+
+import redis.asyncio as aioredis
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from com.qode.qrew.v1.service.core.auth.auth import get_current_user
+from com.qode.qrew.v1.service.core.infra.database import get_db
+from com.qode.qrew.v1.service.core.infra.limiter import limiter
+from com.qode.qrew.v1.service.core.infra.redis import get_redis
+from com.qode.qrew.v1.service.models.auth.user import User
+from com.qode.qrew.v1.service.repositories.event import EventRepository
+from com.qode.qrew.v1.service.repositories.organisation import (
+    OrganisationMemberRepository,
+)
+from com.qode.qrew.v1.service.schemas.entry_stats import EntryStatsResponse
+from com.qode.qrew.v1.service.services.entry_stats import compute_entry_stats
+
+router = APIRouter(tags=["entry-stats"])
+
+
+async def _require_event_member(
+    db: AsyncSession, event_id: uuid.UUID, user: User
+) -> None:
+    """Gate the caller on membership of the organisation that owns this event."""
+    event = await EventRepository(db).get_by_id(event_id)
+    if event is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={"message": "Event not found", "field": "event_id"},
+        )
+    member = await OrganisationMemberRepository(db).get(event.organisation_id, user.id)
+    if member is None:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail={
+                "message": "Not a member of this organisation",
+                "field": None,
+            },
+        )
+
+
+@router.get(
+    "/events/{event_id}/entry-stats",
+    response_model=EntryStatsResponse,
+    status_code=status.HTTP_200_OK,
+    summary="Per-event entry rollup for the organiser console",
+)
+@limiter.limit("60/minute")  # type: ignore[misc]
+async def get_entry_stats(
+    request: Request,
+    event_id: uuid.UUID,
+    since: datetime | None = Query(default=None),
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+    redis: Annotated[aioredis.Redis, Depends(get_redis)] = ...,  # type: ignore[type-arg, assignment]
+) -> EntryStatsResponse:
+    """Return a cached entry rollup over a settable since window."""
+    del request
+    await _require_event_member(db, event_id, current_user)
+    stats = await compute_entry_stats(db, redis, event_id=event_id, since=since)
+    return EntryStatsResponse(
+        event_id=stats.event_id,
+        since=stats.since,
+        total_issued=stats.total_issued,
+        total_entered=stats.total_entered,
+        total_remaining=stats.total_remaining,
+        rejections_by_reason=stats.rejections_by_reason,
+        last_scan_at=stats.last_scan_at,
+    )

--- a/api/src/com/qode/qrew/v1/service/schemas/entry_stats/__init__.py
+++ b/api/src/com/qode/qrew/v1/service/schemas/entry_stats/__init__.py
@@ -1,0 +1,3 @@
+from com.qode.qrew.v1.service.schemas.entry_stats.entry_stats import EntryStatsResponse
+
+__all__ = ["EntryStatsResponse"]

--- a/api/src/com/qode/qrew/v1/service/schemas/entry_stats/entry_stats.py
+++ b/api/src/com/qode/qrew/v1/service/schemas/entry_stats/entry_stats.py
@@ -1,0 +1,14 @@
+import uuid
+from datetime import datetime
+
+from pydantic import BaseModel
+
+
+class EntryStatsResponse(BaseModel):
+    event_id: uuid.UUID
+    since: datetime
+    total_issued: int
+    total_entered: int
+    total_remaining: int
+    rejections_by_reason: dict[str, int]
+    last_scan_at: datetime | None

--- a/api/src/com/qode/qrew/v1/service/services/entry/entry.py
+++ b/api/src/com/qode/qrew/v1/service/services/entry/entry.py
@@ -14,6 +14,8 @@ from com.qode.qrew.v1.service.core.auth import jwt_keys
 from com.qode.qrew.v1.service.core.locking import redlock
 from com.qode.qrew.v1.service.core.locking.errors import LockUnavailableError
 from com.qode.qrew.v1.service.core.observability import traced
+from com.qode.qrew.v1.service.core.ws import publish as ws_publish
+from com.qode.qrew.v1.service.realtime.entry_channel import entry_channel_key
 from com.qode.qrew.v1.service.models.audit.audit import AuditAction
 from com.qode.qrew.v1.service.models.scanner.scanner import Scanner
 from com.qode.qrew.v1.service.models.ticket import Ticket, TicketState
@@ -151,10 +153,14 @@ async def _evaluate(
         return _denied(EntryReason.signature)
 
     if scanner_event_id is not None and scanner_event_id != event_id:
-        await _audit_reject(audit, scanner.id, ticket_id, EntryReason.wrong_event)
+        await _audit_reject(
+            audit, scanner.id, ticket_id, EntryReason.wrong_event, event_id=event_id
+        )
         return _denied(EntryReason.wrong_event, ticket_id=ticket_id)
     if scanner_venue_id != venue_id:
-        await _audit_reject(audit, scanner.id, ticket_id, EntryReason.wrong_venue)
+        await _audit_reject(
+            audit, scanner.id, ticket_id, EntryReason.wrong_venue, event_id=event_id
+        )
         return _denied(EntryReason.wrong_venue, ticket_id=ticket_id)
 
     now_unix = int(_now().timestamp())
@@ -166,15 +172,21 @@ async def _evaluate(
         nx=True,
     )
     if not claimed:
-        await _audit_reject(audit, scanner.id, ticket_id, EntryReason.replay)
+        await _audit_reject(
+            audit, scanner.id, ticket_id, EntryReason.replay, event_id=event_id
+        )
         return _denied(EntryReason.replay, ticket_id=ticket_id)
 
     ticket = await session.get(Ticket, ticket_id)
     if ticket is None:
-        await _audit_reject(audit, scanner.id, ticket_id, EntryReason.not_found)
+        await _audit_reject(
+            audit, scanner.id, ticket_id, EntryReason.not_found, event_id=event_id
+        )
         return _denied(EntryReason.not_found, ticket_id=ticket_id)
     if ticket.event_id != event_id:
-        await _audit_reject(audit, scanner.id, ticket_id, EntryReason.wrong_owner)
+        await _audit_reject(
+            audit, scanner.id, ticket_id, EntryReason.wrong_owner, event_id=event_id
+        )
         return _denied(EntryReason.wrong_owner, ticket_id=ticket_id)
     if ticket.state not in {TicketState.issued, TicketState.entry_pending}:
         await _audit_reject(
@@ -183,6 +195,7 @@ async def _evaluate(
             ticket_id,
             EntryReason.state,
             extra={"current_state": ticket.state.value},
+            event_id=event_id,
         )
         return _denied(EntryReason.state, ticket_id=ticket_id)
 
@@ -197,7 +210,9 @@ async def _evaluate(
                 audit=audit,
             )
     except (LockUnavailableError, TicketTransitionError):
-        await _audit_reject(audit, scanner.id, ticket_id, EntryReason.busy)
+        await _audit_reject(
+            audit, scanner.id, ticket_id, EntryReason.busy, event_id=event_id
+        )
         return _denied(EntryReason.busy, ticket_id=ticket_id)
 
     await audit.record(
@@ -211,6 +226,18 @@ async def _evaluate(
             "scanner_id": str(scanner.id),
         },
     )
+    try:
+        await ws_publish(
+            entry_channel_key(str(event_id)),
+            {
+                "type": "entry.validated",
+                "ticket_id": str(ticket_id),
+                "scanner_id": str(scanner.id),
+                "scanned_at": _now().isoformat(),
+            },
+        )
+    except Exception:
+        await logger.awarning("entry_ws_publish_failed", event_id=str(event_id))
     return EntryOutcome(
         allowed=True,
         reason=None,
@@ -237,10 +264,13 @@ async def _audit_reject(
     reason: EntryReason,
     *,
     extra: dict[str, Any] | None = None,
+    event_id: uuid.UUID | None = None,
 ) -> None:
     payload: dict[str, Any] = {"reason": reason.value, "scanner_id": str(scanner_id)}
     if extra:
         payload.update(extra)
+    if event_id is not None:
+        payload["event_id"] = str(event_id)
     try:
         await audit.record(
             action=AuditAction.ENTRY_REJECTED,
@@ -251,3 +281,15 @@ async def _audit_reject(
         )
     except Exception:
         await logger.awarning("audit_write_failed", action=AuditAction.ENTRY_REJECTED)
+    if event_id is not None:
+        try:
+            await ws_publish(
+                entry_channel_key(str(event_id)),
+                {
+                    "type": "entry.rejected",
+                    "reason": reason.value,
+                    "scanned_at": _now().isoformat(),
+                },
+            )
+        except Exception:
+            await logger.awarning("entry_ws_publish_failed", event_id=str(event_id))

--- a/api/src/com/qode/qrew/v1/service/services/entry_stats/__init__.py
+++ b/api/src/com/qode/qrew/v1/service/services/entry_stats/__init__.py
@@ -1,0 +1,6 @@
+from com.qode.qrew.v1.service.services.entry_stats.stats import (
+    EntryStats,
+    compute_entry_stats,
+)
+
+__all__ = ["EntryStats", "compute_entry_stats"]

--- a/api/src/com/qode/qrew/v1/service/services/entry_stats/stats.py
+++ b/api/src/com/qode/qrew/v1/service/services/entry_stats/stats.py
@@ -1,0 +1,178 @@
+import json
+import uuid
+from dataclasses import dataclass, field as _field
+from datetime import UTC, datetime, timedelta
+
+import redis.asyncio as aioredis
+import structlog
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from com.qode.qrew.v1.service.core.observability import traced
+from com.qode.qrew.v1.service.models.audit.audit import AuditAction, AuditEvent
+from com.qode.qrew.v1.service.models.ticket import Ticket, TicketState
+from com.qode.qrew.v1.service.settings import settings
+
+logger = structlog.get_logger(__name__)
+
+_REASONS: tuple[str, ...] = (
+    "signature",
+    "audience",
+    "expired",
+    "wrong_event",
+    "wrong_venue",
+    "replay",
+    "not_found",
+    "wrong_owner",
+    "state",
+    "busy",
+)
+
+
+@dataclass(frozen=True)
+class EntryStats:
+    event_id: uuid.UUID
+    since: datetime
+    total_issued: int
+    total_entered: int
+    total_remaining: int
+    rejections_by_reason: dict[str, int] = _field(default_factory=lambda: {})  # noqa: PIE807
+    last_scan_at: datetime | None = None
+
+    def to_payload(self) -> dict[str, object]:
+        return {
+            "event_id": str(self.event_id),
+            "since": self.since.isoformat(),
+            "total_issued": self.total_issued,
+            "total_entered": self.total_entered,
+            "total_remaining": self.total_remaining,
+            "rejections_by_reason": dict(self.rejections_by_reason),
+            "last_scan_at": self.last_scan_at.isoformat()
+            if self.last_scan_at
+            else None,
+        }
+
+
+def _stats_cache_key(event_id: uuid.UUID, since: datetime) -> str:
+    return f"entry:stats:{event_id}:{int(since.timestamp())}"
+
+
+def _resolve_since(since: datetime | None) -> datetime:
+    if since is not None:
+        return since
+    return datetime.now(UTC) - timedelta(
+        hours=settings.entry_stats_default_window_hours
+    )
+
+
+@traced("entry_stats.compute")
+async def compute_entry_stats(
+    db: AsyncSession,
+    redis: aioredis.Redis,  # type: ignore[type-arg]
+    *,
+    event_id: uuid.UUID,
+    since: datetime | None = None,
+) -> EntryStats:
+    """Return the entry stats rollup, using a short Redis cache."""
+    since_at = _resolve_since(since)
+    key = _stats_cache_key(event_id, since_at)
+    cached = await redis.get(key)  # type: ignore[misc]
+    if cached is not None:
+        return _deserialise(cached, event_id, since_at)
+    stats = await _compute_uncached(db, event_id=event_id, since=since_at)
+    try:
+        await redis.set(  # type: ignore[misc]
+            key,
+            json.dumps(stats.to_payload()),
+            ex=settings.entry_stats_cache_ttl_seconds,
+        )
+    except Exception:
+        await logger.awarning("entry_stats_cache_write_failed")
+    return stats
+
+
+async def _compute_uncached(
+    db: AsyncSession, *, event_id: uuid.UUID, since: datetime
+) -> EntryStats:
+    counted_states = {
+        TicketState.issued,
+        TicketState.entry_pending,
+        TicketState.used,
+    }
+    rows = await db.execute(
+        select(Ticket.state, func.count())
+        .where(Ticket.event_id == event_id)
+        .group_by(Ticket.state)
+    )
+    counts: dict[str, int] = {}
+    for state_value, count in rows.all():
+        if isinstance(state_value, TicketState):
+            counts[state_value.value] = int(count)
+        elif isinstance(state_value, str):
+            counts[state_value] = int(count)
+    total_issued = sum(
+        n for s, n in counts.items() if s in {st.value for st in counted_states}
+    )
+    total_entered = counts.get(TicketState.used.value, 0)
+    total_remaining = max(total_issued - total_entered, 0)
+
+    rejection_rows = await db.execute(
+        select(
+            AuditEvent.payload["reason"].astext.label("reason"),
+            func.count(),
+        )
+        .where(AuditEvent.action == AuditAction.ENTRY_REJECTED.value)
+        .where(AuditEvent.created_at >= since)
+        .where(AuditEvent.payload["event_id"].astext == str(event_id))
+        .group_by(AuditEvent.payload["reason"].astext)
+    )
+    rejections: dict[str, int] = dict.fromkeys(_REASONS, 0)
+    for reason, count in rejection_rows.all():
+        if isinstance(reason, str) and reason in rejections:
+            rejections[reason] = int(count)
+
+    last_validated_at = await db.scalar(
+        select(func.max(AuditEvent.created_at))
+        .where(AuditEvent.action == AuditAction.ENTRY_VALIDATED.value)
+        .where(AuditEvent.created_at >= since)
+        .where(AuditEvent.payload["event_id"].astext == str(event_id))
+    )
+    last_rejected_at = await db.scalar(
+        select(func.max(AuditEvent.created_at))
+        .where(AuditEvent.action == AuditAction.ENTRY_REJECTED.value)
+        .where(AuditEvent.created_at >= since)
+        .where(AuditEvent.payload["event_id"].astext == str(event_id))
+    )
+    last_scan_at = _max_optional(last_validated_at, last_rejected_at)
+    return EntryStats(
+        event_id=event_id,
+        since=since,
+        total_issued=total_issued,
+        total_entered=total_entered,
+        total_remaining=total_remaining,
+        rejections_by_reason=rejections,
+        last_scan_at=last_scan_at,
+    )
+
+
+def _max_optional(a: datetime | None, b: datetime | None) -> datetime | None:
+    if a is None:
+        return b
+    if b is None:
+        return a
+    return max(a, b)
+
+
+def _deserialise(raw: str | bytes, event_id: uuid.UUID, since: datetime) -> EntryStats:
+    data = json.loads(raw)
+    last_raw = data.get("last_scan_at")
+    last_scan = datetime.fromisoformat(last_raw) if last_raw else None
+    return EntryStats(
+        event_id=event_id,
+        since=since,
+        total_issued=int(data.get("total_issued", 0)),
+        total_entered=int(data.get("total_entered", 0)),
+        total_remaining=int(data.get("total_remaining", 0)),
+        rejections_by_reason=dict(data.get("rejections_by_reason", {})),
+        last_scan_at=last_scan,
+    )

--- a/api/src/com/qode/qrew/v1/service/settings.py
+++ b/api/src/com/qode/qrew/v1/service/settings.py
@@ -167,6 +167,8 @@ class Settings(BaseSettings):
     ticket_qr_stream_max_seconds: int = 1800
 
     entry_replay_grace_seconds: int = 10
+    entry_stats_cache_ttl_seconds: int = 5
+    entry_stats_default_window_hours: int = 24
 
 
 settings = Settings()

--- a/api/tests/v1/entry/stats_test.py
+++ b/api/tests/v1/entry/stats_test.py
@@ -1,0 +1,119 @@
+import uuid
+from datetime import UTC, datetime, timedelta
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import fakeredis.aioredis
+import pytest_asyncio
+
+from com.qode.qrew.v1.service.models.audit.audit import AuditAction
+from com.qode.qrew.v1.service.models.ticket import TicketState
+from com.qode.qrew.v1.service.services.entry_stats import compute_entry_stats
+
+
+@pytest_asyncio.fixture
+async def redis_client() -> Any:
+    client = fakeredis.aioredis.FakeRedis(decode_responses=True)
+    try:
+        yield client
+    finally:
+        await client.aclose()
+
+
+def _session_with(
+    *,
+    state_counts: dict[str, int],
+    rejection_counts: dict[str, int],
+    last_validated: datetime | None = None,
+    last_rejected: datetime | None = None,
+) -> MagicMock:
+    """Build a session whose executes return the listed counts in order."""
+    db = MagicMock()
+    state_rows = [(TicketState(s), c) for s, c in state_counts.items()]
+    rejection_rows = list(rejection_counts.items())
+    last_scans = [last_validated, last_rejected]
+    executes: list[Any] = []
+
+    async def _execute(*_args: Any, **_kwargs: Any) -> Any:
+        idx = len(executes)
+        executes.append(idx)
+        result = MagicMock()
+        if idx == 0:
+            result.all = MagicMock(return_value=state_rows)
+        elif idx == 1:
+            result.all = MagicMock(return_value=rejection_rows)
+        else:
+            result.all = MagicMock(return_value=[])
+        return result
+
+    async def _scalar(*_args: Any, **_kwargs: Any) -> Any:
+        if last_scans:
+            return last_scans.pop(0)
+        return None
+
+    db.execute = AsyncMock(side_effect=_execute)
+    db.scalar = AsyncMock(side_effect=_scalar)
+    return db
+
+
+async def test_compute_entry_stats_rolls_up_counts(redis_client: Any) -> None:
+    event_id = uuid.uuid4()
+    db = _session_with(
+        state_counts={
+            TicketState.issued.value: 7,
+            TicketState.used.value: 5,
+            TicketState.cancelled.value: 1,
+        },
+        rejection_counts={"signature": 2, "replay": 3, "state": 1},
+    )
+    stats = await compute_entry_stats(db, redis_client, event_id=event_id)
+    assert stats.total_issued == 12  # issued + used (cancelled excluded)
+    assert stats.total_entered == 5
+    assert stats.total_remaining == 7
+    assert stats.rejections_by_reason["signature"] == 2
+    assert stats.rejections_by_reason["replay"] == 3
+    assert stats.rejections_by_reason["state"] == 1
+    assert stats.rejections_by_reason["audience"] == 0
+
+
+async def test_compute_entry_stats_caches_within_ttl(redis_client: Any) -> None:
+    event_id = uuid.uuid4()
+    db = _session_with(
+        state_counts={TicketState.issued.value: 3},
+        rejection_counts={},
+    )
+    first = await compute_entry_stats(db, redis_client, event_id=event_id)
+    second = await compute_entry_stats(db, redis_client, event_id=event_id)
+    assert first.total_issued == second.total_issued == 3
+    assert db.execute.await_count == 2
+
+
+async def test_compute_entry_stats_returns_last_scan_at(redis_client: Any) -> None:
+    event_id = uuid.uuid4()
+    last = datetime(2026, 7, 1, 19, 30, tzinfo=UTC)
+    earlier = last - timedelta(minutes=5)
+    db = _session_with(
+        state_counts={TicketState.used.value: 1},
+        rejection_counts={"replay": 1},
+        last_validated=last,
+        last_rejected=earlier,
+    )
+    stats = await compute_entry_stats(db, redis_client, event_id=event_id)
+    assert stats.last_scan_at == last
+
+
+async def test_payload_serialisation_round_trips(redis_client: Any) -> None:
+    event_id = uuid.uuid4()
+    db = _session_with(
+        state_counts={TicketState.used.value: 2, TicketState.issued.value: 4},
+        rejection_counts={"signature": 1},
+    )
+    first = await compute_entry_stats(db, redis_client, event_id=event_id)
+    again = await compute_entry_stats(db, redis_client, event_id=event_id)
+    assert first.total_entered == again.total_entered
+    assert first.rejections_by_reason == again.rejections_by_reason
+
+
+def test_audit_action_constants_present() -> None:
+    assert AuditAction.ENTRY_VALIDATED.value == "entry_validated"
+    assert AuditAction.ENTRY_REJECTED.value == "entry_rejected"


### PR DESCRIPTION
## Summary

It gives organisers a live view of the gate. Two new surfaces:

- `GET /v1/events/{event_id}/entry-stats?since=`
- WebSocket channel `entry.{event_id}`

To make the stats query cheap and correct, the entry validator's `_audit_reject` helper now also stamps `event_id` into the payload on every rejection that has a resolved one (signature/audience/expiry rejections happen before we know the event, so they aren't included in the per-event roll-up. They're already covered by the `entry.scan.outcome` log).

The stats service reads:

- `tickets WHERE event_id = ? GROUP BY state` to derive `issued/entered/remaining` (cancelled tickets are excluded; `frozen` doesn't count as issued for this purpose).
- `audit_events WHERE action = 'entry_rejected' AND payload->>'event_id' = ? AND created_at >= since GROUP BY payload->>'reason'` for the rejection bucket. The default `since` is `now - 24h`, settings-driven via `entry_stats_default_window_hours`.
- Two `MAX(created_at)` scans over the same window for `entry_validated` / `entry_rejected` to compute `last_scan_at`.

Cache key includes the `since` bucket so a panel that bumps `since` to "last 5 minutes" gets a fresh read without invalidating the default cache.

## Verification

- `api/tests/v1/entry/stats_test.py`

## Issue Reference

Closes [QRW-176](https://github.com/cristiangilsanz/qrew/issues/176)

## Checklist
- [x] I confirm that this PR follows the project's established coding standards.