### PR TITLE
fix: update audit Dockerfile to reference renamed auditor package

### DIFF
--- a/services/audit/Dockerfile
+++ b/services/audit/Dockerfile
@@ -12,7 +12,7 @@ COPY packages/shared-python/middleware/pyproject.toml packages/shared-python/mid
 COPY packages/shared-python/locking/pyproject.toml packages/shared-python/locking/pyproject.toml
 COPY packages/shared-python/observability/pyproject.toml packages/shared-python/observability/pyproject.toml
 COPY packages/shared-python/worker/pyproject.toml packages/shared-python/worker/pyproject.toml
-COPY packages/audit-publisher/pyproject.toml packages/audit-publisher/pyproject.toml
+COPY packages/auditor/pyproject.toml packages/auditor/pyproject.toml
 COPY packages/contracts/pyproject.toml packages/contracts/pyproject.toml
 COPY uv.lock ./
 
@@ -30,7 +30,7 @@ COPY packages/shared-python/middleware/src/ ./src/
 COPY packages/shared-python/locking/src/ ./src/
 COPY packages/shared-python/observability/src/ ./src/
 COPY packages/shared-python/worker/src/ ./src/
-COPY packages/audit-publisher/src/ ./src/
+COPY packages/auditor/src/ ./src/
 COPY packages/contracts/src/ ./src/
 
 ENV PATH="/app/.venv/bin:$PATH"


### PR DESCRIPTION
## Summary

`services/audit/Dockerfile` still referenced `packages/audit-publisher/` in two `COPY` instructions after the package was renamed to `packages/auditor/`. This caused the Docker build to fail with `"/packages/audit-publisher/src": not found`.

## Verification

- No tests modified — Dockerfile-only change, verified by successful Docker build in CI.

## Issue Reference

Closes [QRW-209](https://github.com/cristiangilsanz/qrew/issues/209)

## Checklist
- [x] I confirm that this PR follows the project's established coding standards.