### PR TITLE
fix: add missing messaging package to audit Dockerfile

### DIFF
--- a/services/audit/Dockerfile
+++ b/services/audit/Dockerfile
@@ -13,6 +13,7 @@ COPY packages/shared-python/locking/pyproject.toml packages/shared-python/lockin
 COPY packages/shared-python/observability/pyproject.toml packages/shared-python/observability/pyproject.toml
 COPY packages/shared-python/worker/pyproject.toml packages/shared-python/worker/pyproject.toml
 COPY packages/auditor/pyproject.toml packages/auditor/pyproject.toml
+COPY packages/shared-python/messaging/pyproject.toml packages/shared-python/messaging/pyproject.toml
 COPY packages/contracts/pyproject.toml packages/contracts/pyproject.toml
 COPY uv.lock ./
 
@@ -31,6 +32,7 @@ COPY packages/shared-python/locking/src/ ./src/
 COPY packages/shared-python/observability/src/ ./src/
 COPY packages/shared-python/worker/src/ ./src/
 COPY packages/auditor/src/ ./src/
+COPY packages/shared-python/messaging/src/ ./src/
 COPY packages/contracts/src/ ./src/
 
 ENV PATH="/app/.venv/bin:$PATH"


### PR DESCRIPTION
## Summary

`auditor` depends on `messaging` as a workspace package, but `packages/shared-python/messaging` was not included in the `services/audit/Dockerfile` build context.

This caused `uv sync --package audit --no-dev --frozen` to fail with exit code 2 (`Distribution not found at: .../messaging`). Added `messaging` to both the builder stage (pyproject.toml for uv resolution) and runtime stage.

## Verification

Confirmed fix locally by simulating the Docker build context.

## Issue Reference

Closes [QRW-211](https://github.com/cristiangilsanz/qrew/issues/211)

## Checklist
- [x] I confirm that this PR follows the project's established coding standards.