### PR TITLE
ci: add workflow_dispatch to all manually runnable workflows

### DIFF
--- a/.github/workflows/api-ci.yml
+++ b/.github/workflows/api-ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
     types: [opened, synchronize, reopened]
   workflow_call:
+  workflow_dispatch:
 
 jobs:
   lint:

--- a/.github/workflows/api-release-versioning.yml
+++ b/.github/workflows/api-release-versioning.yml
@@ -3,6 +3,12 @@ name: Release Versioning
 on:
   push:
     branches: [main]
+  workflow_dispatch:
+    inputs:
+      force_publish:
+        description: Publish Docker images without a release-please release
+        type: boolean
+        default: false
 
 permissions:
   contents: write
@@ -31,7 +37,7 @@ jobs:
   publish:
     name: Publish Docker Images
     needs: release-please
-    if: needs.release-please.outputs.release_created == 'true'
+    if: needs.release-please.outputs.release_created == 'true' || inputs.force_publish == true
     runs-on: ubuntu-latest
     permissions:
       packages: write

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches: [main]
     types: [opened, edited, synchronize, reopened]
+  workflow_dispatch:
 
 jobs:
   analyze:

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -3,6 +3,7 @@ name: Secret Scan
 on:
   pull_request:
     branches: [main]
+  workflow_dispatch:
 
 jobs:
   gitleaks:


### PR DESCRIPTION
## Summary

Adds `workflow_dispatch` to every CI workflow where manual execution makes sense, so any pipeline can be triggered on demand from the Actions tab without needing to push a commit or open a PR.

## Issue Reference

Closes [QRW-226](https://github.com/cristiangilsanz/qrew/issues/226)

## Checklist
- [x] I confirm that this PR follows the project's established coding standards.