### PR TITLE
fix: add missing shared-python package COPYs to service Dockerfiles

### DIFF
--- a/apps/api/gateway/Dockerfile
+++ b/apps/api/gateway/Dockerfile
@@ -9,6 +9,7 @@ COPY apps/api/gateway/pyproject.toml apps/api/gateway/pyproject.toml
 COPY packages/shared-python/exceptions/pyproject.toml packages/shared-python/exceptions/pyproject.toml
 COPY packages/shared-python/idempotency/pyproject.toml packages/shared-python/idempotency/pyproject.toml
 COPY packages/shared-python/middleware/pyproject.toml packages/shared-python/middleware/pyproject.toml
+COPY packages/shared-python/security/pyproject.toml packages/shared-python/security/pyproject.toml
 COPY packages/shared-python/observability/pyproject.toml packages/shared-python/observability/pyproject.toml
 COPY packages/contracts/pyproject.toml packages/contracts/pyproject.toml
 COPY uv.lock ./
@@ -26,6 +27,7 @@ COPY apps/api/gateway/src/ ./src/
 COPY packages/shared-python/exceptions/src/ ./src/
 COPY packages/shared-python/idempotency/src/ ./src/
 COPY packages/shared-python/middleware/src/ ./src/
+COPY packages/shared-python/security/src/ ./src/
 COPY packages/shared-python/observability/src/ ./src/
 COPY packages/contracts/src/ ./src/
 

--- a/apps/api/services/catalog/Dockerfile
+++ b/apps/api/services/catalog/Dockerfile
@@ -9,6 +9,7 @@ COPY apps/api/services/catalog/pyproject.toml apps/api/services/catalog/pyprojec
 COPY packages/shared-python/exceptions/pyproject.toml packages/shared-python/exceptions/pyproject.toml
 COPY packages/shared-python/idempotency/pyproject.toml packages/shared-python/idempotency/pyproject.toml
 COPY packages/shared-python/middleware/pyproject.toml packages/shared-python/middleware/pyproject.toml
+COPY packages/shared-python/security/pyproject.toml packages/shared-python/security/pyproject.toml
 COPY packages/shared-python/observability/pyproject.toml packages/shared-python/observability/pyproject.toml
 COPY packages/shared-python/db/pyproject.toml packages/shared-python/db/pyproject.toml
 COPY packages/shared-python/jobs/pyproject.toml packages/shared-python/jobs/pyproject.toml
@@ -29,6 +30,7 @@ COPY apps/api/services/catalog/src/ ./src/
 COPY packages/shared-python/exceptions/src/ ./src/
 COPY packages/shared-python/idempotency/src/ ./src/
 COPY packages/shared-python/middleware/src/ ./src/
+COPY packages/shared-python/security/src/ ./src/
 COPY packages/shared-python/observability/src/ ./src/
 COPY packages/shared-python/db/src/ ./src/
 COPY packages/shared-python/jobs/src/ ./src/

--- a/apps/api/services/entry/Dockerfile
+++ b/apps/api/services/entry/Dockerfile
@@ -9,6 +9,7 @@ COPY apps/api/services/entry/pyproject.toml apps/api/services/entry/pyproject.to
 COPY packages/shared-python/exceptions/pyproject.toml packages/shared-python/exceptions/pyproject.toml
 COPY packages/shared-python/idempotency/pyproject.toml packages/shared-python/idempotency/pyproject.toml
 COPY packages/shared-python/middleware/pyproject.toml packages/shared-python/middleware/pyproject.toml
+COPY packages/shared-python/security/pyproject.toml packages/shared-python/security/pyproject.toml
 COPY packages/shared-python/observability/pyproject.toml packages/shared-python/observability/pyproject.toml
 COPY packages/shared-python/db/pyproject.toml packages/shared-python/db/pyproject.toml
 COPY packages/shared-python/locking/pyproject.toml packages/shared-python/locking/pyproject.toml
@@ -29,6 +30,7 @@ COPY apps/api/services/entry/src/ ./src/
 COPY packages/shared-python/exceptions/src/ ./src/
 COPY packages/shared-python/idempotency/src/ ./src/
 COPY packages/shared-python/middleware/src/ ./src/
+COPY packages/shared-python/security/src/ ./src/
 COPY packages/shared-python/observability/src/ ./src/
 COPY packages/shared-python/db/src/ ./src/
 COPY packages/shared-python/locking/src/ ./src/

--- a/apps/api/services/identity/Dockerfile
+++ b/apps/api/services/identity/Dockerfile
@@ -19,6 +19,7 @@ COPY packages/shared-python/messaging/pyproject.toml packages/shared-python/mess
 COPY packages/shared-python/worker/pyproject.toml packages/shared-python/worker/pyproject.toml
 COPY packages/shared-python/probes/pyproject.toml packages/shared-python/probes/pyproject.toml
 COPY packages/shared-python/pagination/pyproject.toml packages/shared-python/pagination/pyproject.toml
+COPY packages/shared-python/outbox/pyproject.toml packages/shared-python/outbox/pyproject.toml
 COPY packages/contracts/pyproject.toml packages/contracts/pyproject.toml
 COPY uv.lock ./
 
@@ -47,6 +48,7 @@ COPY packages/shared-python/messaging/src/ ./src/
 COPY packages/shared-python/worker/src/ ./src/
 COPY packages/shared-python/probes/src/ ./src/
 COPY packages/shared-python/pagination/src/ ./src/
+COPY packages/shared-python/outbox/src/ ./src/
 COPY packages/contracts/src/ ./src/
 
 ENV PATH="/app/.venv/bin:$PATH"

--- a/apps/api/services/identity/Dockerfile
+++ b/apps/api/services/identity/Dockerfile
@@ -9,6 +9,7 @@ COPY apps/api/services/identity/pyproject.toml apps/api/services/identity/pyproj
 COPY packages/shared-python/exceptions/pyproject.toml packages/shared-python/exceptions/pyproject.toml
 COPY packages/shared-python/idempotency/pyproject.toml packages/shared-python/idempotency/pyproject.toml
 COPY packages/shared-python/middleware/pyproject.toml packages/shared-python/middleware/pyproject.toml
+COPY packages/shared-python/security/pyproject.toml packages/shared-python/security/pyproject.toml
 COPY packages/shared-python/ratelimit/pyproject.toml packages/shared-python/ratelimit/pyproject.toml
 COPY packages/shared-python/observability/pyproject.toml packages/shared-python/observability/pyproject.toml
 COPY packages/shared-python/db/pyproject.toml packages/shared-python/db/pyproject.toml
@@ -36,6 +37,7 @@ COPY apps/api/services/identity/src/ ./src/
 COPY packages/shared-python/exceptions/src/ ./src/
 COPY packages/shared-python/idempotency/src/ ./src/
 COPY packages/shared-python/middleware/src/ ./src/
+COPY packages/shared-python/security/src/ ./src/
 COPY packages/shared-python/ratelimit/src/ ./src/
 COPY packages/shared-python/observability/src/ ./src/
 COPY packages/shared-python/db/src/ ./src/

--- a/apps/api/services/payments/Dockerfile
+++ b/apps/api/services/payments/Dockerfile
@@ -9,6 +9,7 @@ COPY apps/api/services/payments/pyproject.toml apps/api/services/payments/pyproj
 COPY packages/shared-python/exceptions/pyproject.toml packages/shared-python/exceptions/pyproject.toml
 COPY packages/shared-python/idempotency/pyproject.toml packages/shared-python/idempotency/pyproject.toml
 COPY packages/shared-python/middleware/pyproject.toml packages/shared-python/middleware/pyproject.toml
+COPY packages/shared-python/security/pyproject.toml packages/shared-python/security/pyproject.toml
 COPY packages/shared-python/observability/pyproject.toml packages/shared-python/observability/pyproject.toml
 COPY packages/shared-python/db/pyproject.toml packages/shared-python/db/pyproject.toml
 COPY packages/shared-python/probes/pyproject.toml packages/shared-python/probes/pyproject.toml
@@ -26,6 +27,7 @@ COPY apps/api/services/payments/src/ ./src/
 COPY packages/shared-python/exceptions/src/ ./src/
 COPY packages/shared-python/idempotency/src/ ./src/
 COPY packages/shared-python/middleware/src/ ./src/
+COPY packages/shared-python/security/src/ ./src/
 COPY packages/shared-python/observability/src/ ./src/
 COPY packages/shared-python/db/src/ ./src/
 COPY packages/shared-python/probes/src/ ./src/

--- a/apps/api/services/sales/Dockerfile
+++ b/apps/api/services/sales/Dockerfile
@@ -11,6 +11,7 @@ COPY packages/shared-python/locking/pyproject.toml packages/shared-python/lockin
 COPY packages/shared-python/messaging/pyproject.toml packages/shared-python/messaging/pyproject.toml
 COPY packages/shared-python/worker/pyproject.toml packages/shared-python/worker/pyproject.toml
 COPY packages/shared-python/observability/pyproject.toml packages/shared-python/observability/pyproject.toml
+COPY packages/shared-python/security/pyproject.toml packages/shared-python/security/pyproject.toml
 COPY packages/contracts/pyproject.toml packages/contracts/pyproject.toml
 COPY uv.lock ./
 
@@ -27,6 +28,7 @@ COPY packages/shared-python/locking/src/ ./src/
 COPY packages/shared-python/messaging/src/ ./src/
 COPY packages/shared-python/worker/src/ ./src/
 COPY packages/shared-python/observability/src/ ./src/
+COPY packages/shared-python/security/src/ ./src/
 COPY packages/contracts/src/ ./src/
 
 ENV PATH="/app/.venv/bin:$PATH"

--- a/apps/api/services/ticketing/Dockerfile
+++ b/apps/api/services/ticketing/Dockerfile
@@ -9,6 +9,7 @@ COPY apps/api/services/ticketing/pyproject.toml apps/api/services/ticketing/pypr
 COPY packages/shared-python/exceptions/pyproject.toml packages/shared-python/exceptions/pyproject.toml
 COPY packages/shared-python/idempotency/pyproject.toml packages/shared-python/idempotency/pyproject.toml
 COPY packages/shared-python/middleware/pyproject.toml packages/shared-python/middleware/pyproject.toml
+COPY packages/shared-python/security/pyproject.toml packages/shared-python/security/pyproject.toml
 COPY packages/shared-python/observability/pyproject.toml packages/shared-python/observability/pyproject.toml
 COPY packages/shared-python/locking/pyproject.toml packages/shared-python/locking/pyproject.toml
 COPY packages/shared-python/worker/pyproject.toml packages/shared-python/worker/pyproject.toml
@@ -28,6 +29,7 @@ COPY apps/api/services/ticketing/src/ ./src/
 COPY packages/shared-python/exceptions/src/ ./src/
 COPY packages/shared-python/idempotency/src/ ./src/
 COPY packages/shared-python/middleware/src/ ./src/
+COPY packages/shared-python/security/src/ ./src/
 COPY packages/shared-python/observability/src/ ./src/
 COPY packages/shared-python/locking/src/ ./src/
 COPY packages/shared-python/worker/src/ ./src/


### PR DESCRIPTION
## Summary

Service Dockerfiles were missing `packages/shared-python/security` in both the builder (pyproject.toml COPY) and runtime (src/ COPY) stages, causing `uv sync --frozen` to fail with "Distribution not found at: file:///app/packages/shared-python/security" during Docker build.

Additionally, `identity` was missing `outbox` and `sales` was missing `security` entirely due to a failed sed anchor.

## Issue Reference

Closes [QRW-234]() / Part of [QRW-233]()

## Checklist
- [x] I confirm that this PR follows the project's established coding standards.