### PR TITLE
fix: pin trivy-action and upgrade release-please-action for Node.js 24

### DIFF
--- a/.github/workflows/api-release-versioning.yml
+++ b/.github/workflows/api-release-versioning.yml
@@ -78,7 +78,7 @@ jobs:
           cache-from: type=gha
 
       - name: Scan Docker Image for Vulnerabilities
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           image-ref: qrew-${{ matrix.service }}:scan
           format: table


### PR DESCRIPTION
## Summary

Two CI failures on main after the monorepo refactor merge:

1. **`trivy-action@master`** picked up a breaking commit in `setup-trivy` that rejects paths containing `$HOME`, causing the Publish Docker Images step to fail. Pinned to `v0.36.0` (latest stable).

2. **`release-please-action@v4`** runs on Node.js 20 but GitHub runners now force Node.js 24, causing it to fail silently with a blank error message. Upgraded to `v5.0.0` which supports Node.js 24.

## Verification

- Release Versioning workflow passes on merge to main.
- `release-please` job completes without error.
- `Publish Docker Images` step completes without trivy path error.

## Issue Reference

Closes [QRW-235]()

## Checklist
- [x] I confirm that this PR follows the project's established coding standards.