### PR TITLE
fix: upgrade release-please-action to v5 for Node.js 24 compatibility

### DIFF
--- a/.github/workflows/api-release-versioning.yml
+++ b/.github/workflows/api-release-versioning.yml
@@ -28,7 +28,7 @@ jobs:
       tag_name: ${{ steps.release.outputs.tag_name }}
       version: ${{ steps.release.outputs.version }}
     steps:
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@v5
         id: release
         with:
           config-file: release-please-config.json

--- a/uv.lock
+++ b/uv.lock
@@ -3257,7 +3257,7 @@ wheels = [
 
 [[package]]
 name = "qrew-workspace"
-version = "1.0.0"
+version = "1.1.0"
 source = { virtual = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
## Summary

`googleapis/release-please-action@v4` runs on Node.js 20 but GitHub runners now force Node.js 24, causing it to fail silently with a blank error message ("release-please failed: "). Upgraded to `v5.0.0` (latest stable) which supports Node.js 24.

## Issue Reference

Closes [QRW-236]()

## Checklist
- [x] I confirm that this PR follows the project's established coding standards.