### PR TITLE
feat: implement post-login onboarding flow

### DIFF
--- a/apps/app/src/features/auth/components/LoginForm.tsx
+++ b/apps/app/src/features/auth/components/LoginForm.tsx
@@ -40,7 +40,7 @@ export function LoginForm() {
 
   const onSubmit = (values: LoginFormValues) => {
     login.mutate(values, {
-      onSuccess: () => navigate({ to: '/events' }),
+      onSuccess: (data) => navigate({ to: data.setup_required ? '/setup' : '/events' }),
     })
   }
 

--- a/apps/app/src/features/onboarding/api/index.ts
+++ b/apps/app/src/features/onboarding/api/index.ts
@@ -1,0 +1,55 @@
+import { apiClient } from '@/lib/api'
+
+export interface OnboardingStatus {
+  email_verified: boolean
+  phone_verified: boolean
+  kyc_submitted: boolean
+  passkey_registered: boolean
+  is_complete: boolean
+}
+
+export interface KycUploadResponse {
+  message: string
+  kyc_status: 'pending' | 'approved' | 'rejected' | 'not_submitted'
+}
+
+export interface CompleteSetupResponse {
+  access_token: string
+  refresh_token: string | null
+  token_type: string
+  setup_required: boolean
+  password_compromised: boolean
+}
+
+export const onboardingApi = {
+  getStatus: () =>
+    apiClient.get<OnboardingStatus>('/v1/auth/profile/onboarding-status').then((r) => r.data),
+
+  verifyEmail: (data: { token: string }) =>
+    apiClient
+      .post<{ message: string }>('/v1/auth/registration/verify-email', data)
+      .then((r) => r.data),
+
+  verifyPhone: (data: { phone_number: string; otp: string }) =>
+    apiClient
+      .post<{ message: string }>('/v1/auth/registration/verify-phone', data)
+      .then((r) => r.data),
+
+  resendPhoneOtp: (data: { phone_number: string }) =>
+    apiClient
+      .post<{ message: string }>('/v1/auth/registration/resend-phone-otp', data)
+      .then((r) => r.data),
+
+  uploadKyc: (file: File) => {
+    const formData = new FormData()
+    formData.append('document', file)
+    return apiClient
+      .post<KycUploadResponse>('/v1/auth/setup/kyc/upload', formData, {
+        headers: { 'Content-Type': 'multipart/form-data' },
+      })
+      .then((r) => r.data)
+  },
+
+  completeSetup: () =>
+    apiClient.post<CompleteSetupResponse>('/v1/auth/setup/complete-setup').then((r) => r.data),
+}

--- a/apps/app/src/features/onboarding/components/EmailVerificationStep.tsx
+++ b/apps/app/src/features/onboarding/components/EmailVerificationStep.tsx
@@ -1,0 +1,68 @@
+import { zodResolver } from '@hookform/resolvers/zod'
+import { Mail } from 'lucide-react'
+import { useForm } from 'react-hook-form'
+import { useTranslation } from 'react-i18next'
+import { z } from 'zod'
+
+import { Button } from '@/components/ui/button'
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form'
+import { Input } from '@/components/ui/input'
+
+import { useVerifyEmail } from '../hooks/useVerifyEmail'
+
+const schema = z.object({
+  token: z.string().min(1),
+})
+
+type FormValues = z.infer<typeof schema>
+
+interface Props {
+  onSuccess: () => void
+}
+
+export function EmailVerificationStep({ onSuccess }: Props) {
+  const { t } = useTranslation()
+  const verify = useVerifyEmail(onSuccess)
+
+  const form = useForm<FormValues>({
+    resolver: zodResolver(schema),
+    defaultValues: { token: '' },
+  })
+
+  return (
+    <div className="space-y-4">
+      <div className="text-muted-foreground flex items-center gap-2 text-sm">
+        <Mail className="h-4 w-4 shrink-0" />
+        <span>{t('onboarding.email.description')}</span>
+      </div>
+
+      <Form {...form}>
+        <form onSubmit={form.handleSubmit((v) => verify.mutate(v))} className="space-y-4">
+          <FormField
+            control={form.control}
+            name="token"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>{t('onboarding.email.label')}</FormLabel>
+                <FormControl>
+                  <Input placeholder={t('onboarding.email.placeholder')} {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <Button type="submit" className="w-full" isLoading={verify.isPending}>
+            {t('onboarding.email.submit')}
+          </Button>
+        </form>
+      </Form>
+    </div>
+  )
+}

--- a/apps/app/src/features/onboarding/components/KycPendingStep.tsx
+++ b/apps/app/src/features/onboarding/components/KycPendingStep.tsx
@@ -1,0 +1,67 @@
+import { useNavigate } from '@tanstack/react-router'
+import { CheckCircle, Clock, XCircle } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+
+import { Button } from '@/components/ui/button'
+
+import { useCompleteSetup } from '../hooks/useCompleteSetup'
+import { useOnboardingStatus } from '../hooks/useOnboardingStatus'
+
+interface Props {
+  onRetry: () => void
+}
+
+export function KycPendingStep({ onRetry }: Props) {
+  const { t } = useTranslation()
+  const navigate = useNavigate()
+  const { data: status } = useOnboardingStatus(10_000)
+  const completeSetup = useCompleteSetup(() => navigate({ to: '/events' }))
+
+  if (status?.is_complete) {
+    return (
+      <div className="space-y-4 text-center">
+        <CheckCircle className="text-primary mx-auto h-12 w-12" />
+        <div>
+          <p className="font-semibold">{t('onboarding.pending.approved')}</p>
+          <p className="text-muted-foreground text-sm">
+            {t('onboarding.pending.approvedDescription')}
+          </p>
+        </div>
+        <Button
+          className="w-full"
+          isLoading={completeSetup.isPending}
+          onClick={() => completeSetup.mutate()}
+        >
+          {t('onboarding.pending.continue')}
+        </Button>
+      </div>
+    )
+  }
+
+  if (status && !status.kyc_submitted) {
+    return (
+      <div className="space-y-4 text-center">
+        <XCircle className="text-destructive mx-auto h-12 w-12" />
+        <div>
+          <p className="font-semibold">{t('onboarding.pending.rejected')}</p>
+          <p className="text-muted-foreground text-sm">
+            {t('onboarding.pending.rejectedDescription')}
+          </p>
+        </div>
+        <Button variant="outline" className="w-full" onClick={onRetry}>
+          {t('onboarding.pending.retry')}
+        </Button>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-4 text-center">
+      <Clock className="text-muted-foreground mx-auto h-12 w-12 animate-pulse" />
+      <div>
+        <p className="font-semibold">{t('onboarding.pending.title')}</p>
+        <p className="text-muted-foreground text-sm">{t('onboarding.pending.description')}</p>
+      </div>
+    </div>
+  )
+}

--- a/apps/app/src/features/onboarding/components/KycUploadStep.tsx
+++ b/apps/app/src/features/onboarding/components/KycUploadStep.tsx
@@ -1,0 +1,86 @@
+import { Upload } from 'lucide-react'
+import { type ChangeEvent, type FormEvent, type KeyboardEvent, useRef, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+
+import { Button } from '@/components/ui/button'
+
+import { type KycUploadResponse } from '../api'
+import { useKycUpload } from '../hooks/useKycUpload'
+
+interface Props {
+  onSuccess: (data: KycUploadResponse) => void
+}
+
+export function KycUploadStep({ onSuccess }: Props) {
+  const { t } = useTranslation()
+  const [file, setFile] = useState<File | null>(null)
+  const [preview, setPreview] = useState<string | null>(null)
+  const inputRef = useRef<HTMLInputElement>(null)
+  const upload = useKycUpload(onSuccess)
+
+  const handleFileChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const selected = e.target.files?.[0]
+    if (!selected) return
+    setFile(selected)
+    if (selected.type.startsWith('image/')) {
+      setPreview(URL.createObjectURL(selected))
+    } else {
+      setPreview(null)
+    }
+  }
+
+  const handleSubmit = (e: FormEvent) => {
+    e.preventDefault()
+    if (file) upload.mutate(file)
+  }
+
+  const handleDropzoneKeyDown = (e: KeyboardEvent<HTMLDivElement>) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault()
+      inputRef.current?.click()
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <p className="text-muted-foreground text-sm">{t('onboarding.kyc.description')}</p>
+
+      <div
+        role="button"
+        tabIndex={0}
+        className="border-border hover:border-primary cursor-pointer rounded-lg border-2 border-dashed p-6 text-center transition-colors"
+        onClick={() => inputRef.current?.click()}
+        onKeyDown={handleDropzoneKeyDown}
+      >
+        {preview ? (
+          <img
+            src={preview}
+            alt="Document preview"
+            className="mx-auto max-h-40 rounded object-contain"
+          />
+        ) : (
+          <div className="space-y-2">
+            <Upload className="text-muted-foreground mx-auto h-8 w-8" />
+            <p className="text-muted-foreground text-sm">
+              {file ? file.name : t('onboarding.kyc.dropzone')}
+            </p>
+          </div>
+        )}
+      </div>
+
+      <input
+        ref={inputRef}
+        type="file"
+        accept="image/*,application/pdf"
+        className="hidden"
+        onChange={handleFileChange}
+      />
+
+      {file && !preview && <p className="text-muted-foreground truncate text-sm">{file.name}</p>}
+
+      <Button type="submit" className="w-full" disabled={!file} isLoading={upload.isPending}>
+        {t('onboarding.kyc.submit')}
+      </Button>
+    </form>
+  )
+}

--- a/apps/app/src/features/onboarding/components/OnboardingWizard.tsx
+++ b/apps/app/src/features/onboarding/components/OnboardingWizard.tsx
@@ -1,0 +1,122 @@
+import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
+
+import { AuthLayout } from '@/features/auth/components/AuthLayout'
+
+import { type KycUploadResponse } from '../api'
+import { useOnboardingStatus } from '../hooks/useOnboardingStatus'
+import { EmailVerificationStep } from './EmailVerificationStep'
+import { KycPendingStep } from './KycPendingStep'
+import { KycUploadStep } from './KycUploadStep'
+import { PhoneVerificationStep } from './PhoneVerificationStep'
+
+const STEPS = ['email', 'phone', 'kyc'] as const
+type Step = (typeof STEPS)[number]
+
+function stepFromStatus(
+  emailVerified: boolean,
+  phoneVerified: boolean,
+  kycSubmitted: boolean,
+): Step | 'pending' {
+  if (!emailVerified) return 'email'
+  if (!phoneVerified) return 'phone'
+  if (!kycSubmitted) return 'kyc'
+  return 'pending'
+}
+
+function StepIndicator({ current }: { current: Step | 'pending' }) {
+  const { t } = useTranslation()
+  const labels: Record<Step, string> = {
+    email: t('onboarding.steps.email'),
+    phone: t('onboarding.steps.phone'),
+    kyc: t('onboarding.steps.kyc'),
+  }
+  const currentIndex = STEPS.indexOf(current as Step)
+
+  return (
+    <div className="mb-6 flex items-center justify-between gap-2">
+      {STEPS.map((step, i) => {
+        const done = currentIndex > i || current === 'pending'
+        const active = currentIndex === i
+        return (
+          <div key={step} className="flex flex-1 flex-col items-center gap-1">
+            <div
+              className={[
+                'flex h-7 w-7 items-center justify-center rounded-full text-xs font-semibold transition-colors',
+                done
+                  ? 'bg-primary text-primary-foreground'
+                  : active
+                    ? 'border-primary text-primary border-2'
+                    : 'border-border text-muted-foreground border-2',
+              ].join(' ')}
+            >
+              {done ? '✓' : i + 1}
+            </div>
+            <span
+              className={[
+                'text-center text-xs',
+                active || done ? 'text-foreground font-medium' : 'text-muted-foreground',
+              ].join(' ')}
+            >
+              {labels[step]}
+            </span>
+          </div>
+        )
+      })}
+    </div>
+  )
+}
+
+export function OnboardingWizard() {
+  const { t } = useTranslation()
+  const { data: status, isLoading, refetch } = useOnboardingStatus()
+  const [kycRetry, setKycRetry] = useState(false)
+
+  const currentStep =
+    status && !kycRetry
+      ? stepFromStatus(status.email_verified, status.phone_verified, status.kyc_submitted)
+      : status
+        ? kycRetry
+          ? 'kyc'
+          : stepFromStatus(status.email_verified, status.phone_verified, status.kyc_submitted)
+        : 'email'
+
+  const handleStepSuccess = () => {
+    setKycRetry(false)
+    void refetch()
+  }
+
+  const handleKycSuccess = (data: KycUploadResponse) => {
+    if (data.kyc_status !== 'not_submitted') {
+      setKycRetry(false)
+      void refetch()
+    }
+  }
+
+  if (isLoading) {
+    return (
+      <AuthLayout title={t('onboarding.title')} subtitle={t('onboarding.subtitle')}>
+        <div className="flex justify-center py-8">
+          <div className="border-primary h-8 w-8 animate-spin rounded-full border-2 border-t-transparent" />
+        </div>
+      </AuthLayout>
+    )
+  }
+
+  return (
+    <AuthLayout title={t('onboarding.title')} subtitle={t('onboarding.subtitle')}>
+      <StepIndicator current={currentStep} />
+
+      {currentStep === 'email' && <EmailVerificationStep onSuccess={handleStepSuccess} />}
+      {currentStep === 'phone' && <PhoneVerificationStep onSuccess={handleStepSuccess} />}
+      {currentStep === 'kyc' && <KycUploadStep onSuccess={handleKycSuccess} />}
+      {currentStep === 'pending' && (
+        <KycPendingStep
+          onRetry={() => {
+            setKycRetry(true)
+          }}
+        />
+      )}
+    </AuthLayout>
+  )
+}

--- a/apps/app/src/features/onboarding/components/PhoneVerificationStep.tsx
+++ b/apps/app/src/features/onboarding/components/PhoneVerificationStep.tsx
@@ -1,0 +1,93 @@
+import { zodResolver } from '@hookform/resolvers/zod'
+import { useForm } from 'react-hook-form'
+import { useTranslation } from 'react-i18next'
+import { z } from 'zod'
+
+import { Button } from '@/components/ui/button'
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form'
+import { Input } from '@/components/ui/input'
+import { useAuthStore } from '@/store/auth'
+
+import { useResendPhoneOtp } from '../hooks/useResendPhoneOtp'
+import { useVerifyPhone } from '../hooks/useVerifyPhone'
+
+const schema = z.object({
+  otp: z.string().regex(/^\d{6}$/, 'Enter a 6-digit code'),
+})
+
+type FormValues = z.infer<typeof schema>
+
+interface Props {
+  onSuccess: () => void
+}
+
+export function PhoneVerificationStep({ onSuccess }: Props) {
+  const { t } = useTranslation()
+  const phoneNumber = useAuthStore((s) => s.phoneNumber)
+  const verify = useVerifyPhone(onSuccess)
+  const resend = useResendPhoneOtp()
+
+  const form = useForm<FormValues>({
+    resolver: zodResolver(schema),
+    defaultValues: { otp: '' },
+  })
+
+  const onSubmit = (values: FormValues) => {
+    verify.mutate({ phone_number: phoneNumber ?? '', otp: values.otp })
+  }
+
+  const handleResend = () => {
+    if (phoneNumber) resend.mutate({ phone_number: phoneNumber })
+  }
+
+  return (
+    <div className="space-y-4">
+      <p className="text-muted-foreground text-sm">{t('onboarding.phone.description')}</p>
+
+      <Form {...form}>
+        <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+          <FormField
+            control={form.control}
+            name="otp"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>{t('onboarding.phone.label')}</FormLabel>
+                <FormControl>
+                  <Input
+                    placeholder={t('onboarding.phone.placeholder')}
+                    maxLength={6}
+                    inputMode="numeric"
+                    autoComplete="one-time-code"
+                    {...field}
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <Button type="submit" className="w-full" isLoading={verify.isPending}>
+            {t('onboarding.phone.submit')}
+          </Button>
+        </form>
+      </Form>
+
+      <div className="text-center">
+        <button
+          type="button"
+          onClick={handleResend}
+          disabled={resend.isPending || !phoneNumber}
+          className="text-primary text-sm hover:underline disabled:opacity-50"
+        >
+          {t('onboarding.phone.resend')}
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/apps/app/src/features/onboarding/hooks/useCompleteSetup.ts
+++ b/apps/app/src/features/onboarding/hooks/useCompleteSetup.ts
@@ -3,28 +3,25 @@ import type { AxiosError } from 'axios'
 import { useTranslation } from 'react-i18next'
 import { toast } from 'sonner'
 
+import { type ApiErrorDetail, extractErrorMessage } from '@/features/auth/api'
 import { useAuthStore } from '@/store/auth'
 
-import { type ApiErrorDetail, authApi, extractErrorMessage, type LoginRequest } from '../api'
+import { type CompleteSetupResponse, onboardingApi } from '../api'
 
-export function useLogin() {
+export function useCompleteSetup(onSuccess?: (data: CompleteSetupResponse) => void) {
   const { t } = useTranslation()
-  const setAccessToken = useAuthStore((s) => s.setAccessToken)
-  const setSetupToken = useAuthStore((s) => s.setSetupToken)
+  const completeSetup = useAuthStore((s) => s.completeSetup)
 
   return useMutation({
-    mutationFn: (data: LoginRequest) => authApi.login(data),
+    mutationFn: () => onboardingApi.completeSetup(),
     onSuccess: (data) => {
-      if (data.setup_required) {
-        setSetupToken(data.access_token)
-      } else {
-        setAccessToken(data.access_token)
-      }
+      completeSetup(data.access_token)
+      onSuccess?.(data)
     },
     onError: (error: AxiosError<{ detail?: ApiErrorDetail }>) => {
       const message = extractErrorMessage(
         error.response?.data?.detail,
-        t('auth.errors.loginFailed'),
+        t('onboarding.errors.completeFailed'),
       )
       toast.error(message)
     },

--- a/apps/app/src/features/onboarding/hooks/useKycUpload.ts
+++ b/apps/app/src/features/onboarding/hooks/useKycUpload.ts
@@ -1,0 +1,27 @@
+import { useMutation } from '@tanstack/react-query'
+import type { AxiosError } from 'axios'
+import { useTranslation } from 'react-i18next'
+import { toast } from 'sonner'
+
+import { type ApiErrorDetail, extractErrorMessage } from '@/features/auth/api'
+
+import { type KycUploadResponse, onboardingApi } from '../api'
+
+export function useKycUpload(onSuccess?: (data: KycUploadResponse) => void) {
+  const { t } = useTranslation()
+
+  return useMutation({
+    mutationFn: (file: File) => onboardingApi.uploadKyc(file),
+    onSuccess: (data) => {
+      toast.success(t('onboarding.kyc.successToast'))
+      onSuccess?.(data)
+    },
+    onError: (error: AxiosError<{ detail?: ApiErrorDetail }>) => {
+      const message = extractErrorMessage(
+        error.response?.data?.detail,
+        t('onboarding.errors.kycUploadFailed'),
+      )
+      toast.error(message)
+    },
+  })
+}

--- a/apps/app/src/features/onboarding/hooks/useOnboardingStatus.ts
+++ b/apps/app/src/features/onboarding/hooks/useOnboardingStatus.ts
@@ -1,0 +1,11 @@
+import { useQuery } from '@tanstack/react-query'
+
+import { onboardingApi } from '../api'
+
+export function useOnboardingStatus(refetchInterval?: number) {
+  return useQuery({
+    queryKey: ['onboarding-status'],
+    queryFn: onboardingApi.getStatus,
+    refetchInterval,
+  })
+}

--- a/apps/app/src/features/onboarding/hooks/useResendPhoneOtp.ts
+++ b/apps/app/src/features/onboarding/hooks/useResendPhoneOtp.ts
@@ -1,0 +1,23 @@
+import { useMutation } from '@tanstack/react-query'
+import type { AxiosError } from 'axios'
+import { useTranslation } from 'react-i18next'
+import { toast } from 'sonner'
+
+import { type ApiErrorDetail, extractErrorMessage } from '@/features/auth/api'
+
+import { onboardingApi } from '../api'
+
+export function useResendPhoneOtp() {
+  const { t } = useTranslation()
+
+  return useMutation({
+    mutationFn: (data: { phone_number: string }) => onboardingApi.resendPhoneOtp(data),
+    onSuccess: () => {
+      toast.success(t('onboarding.phone.resendSuccess'))
+    },
+    onError: (error: AxiosError<{ detail?: ApiErrorDetail }>) => {
+      const message = extractErrorMessage(error.response?.data?.detail, t('common.error'))
+      toast.error(message)
+    },
+  })
+}

--- a/apps/app/src/features/onboarding/hooks/useVerifyEmail.ts
+++ b/apps/app/src/features/onboarding/hooks/useVerifyEmail.ts
@@ -3,23 +3,23 @@ import type { AxiosError } from 'axios'
 import { useTranslation } from 'react-i18next'
 import { toast } from 'sonner'
 
-import { useAuthStore } from '@/store/auth'
+import { type ApiErrorDetail, extractErrorMessage } from '@/features/auth/api'
 
-import { type ApiErrorDetail, authApi, extractErrorMessage, type RegisterRequest } from '../api'
+import { onboardingApi } from '../api'
 
-export function useRegister() {
+export function useVerifyEmail(onSuccess?: () => void) {
   const { t } = useTranslation()
-  const setPhoneNumber = useAuthStore((s) => s.setPhoneNumber)
 
   return useMutation({
-    mutationFn: (data: RegisterRequest) => authApi.register(data),
-    onSuccess: (_data, variables) => {
-      setPhoneNumber(variables.phone_number)
+    mutationFn: (data: { token: string }) => onboardingApi.verifyEmail(data),
+    onSuccess: () => {
+      toast.success(t('onboarding.email.successToast'))
+      onSuccess?.()
     },
     onError: (error: AxiosError<{ detail?: ApiErrorDetail }>) => {
       const message = extractErrorMessage(
         error.response?.data?.detail,
-        t('auth.errors.registerFailed'),
+        t('onboarding.errors.verifyEmailFailed'),
       )
       toast.error(message)
     },

--- a/apps/app/src/features/onboarding/hooks/useVerifyPhone.ts
+++ b/apps/app/src/features/onboarding/hooks/useVerifyPhone.ts
@@ -3,23 +3,23 @@ import type { AxiosError } from 'axios'
 import { useTranslation } from 'react-i18next'
 import { toast } from 'sonner'
 
-import { useAuthStore } from '@/store/auth'
+import { type ApiErrorDetail, extractErrorMessage } from '@/features/auth/api'
 
-import { type ApiErrorDetail, authApi, extractErrorMessage, type RegisterRequest } from '../api'
+import { onboardingApi } from '../api'
 
-export function useRegister() {
+export function useVerifyPhone(onSuccess?: () => void) {
   const { t } = useTranslation()
-  const setPhoneNumber = useAuthStore((s) => s.setPhoneNumber)
 
   return useMutation({
-    mutationFn: (data: RegisterRequest) => authApi.register(data),
-    onSuccess: (_data, variables) => {
-      setPhoneNumber(variables.phone_number)
+    mutationFn: (data: { phone_number: string; otp: string }) => onboardingApi.verifyPhone(data),
+    onSuccess: () => {
+      toast.success(t('onboarding.phone.successToast'))
+      onSuccess?.()
     },
     onError: (error: AxiosError<{ detail?: ApiErrorDetail }>) => {
       const message = extractErrorMessage(
         error.response?.data?.detail,
-        t('auth.errors.registerFailed'),
+        t('onboarding.errors.verifyPhoneFailed'),
       )
       toast.error(message)
     },

--- a/apps/app/src/i18n/locales/en.json
+++ b/apps/app/src/i18n/locales/en.json
@@ -37,5 +37,56 @@
   },
   "profile": {
     "title": "Profile"
+  },
+  "onboarding": {
+    "title": "Set up your account",
+    "subtitle": "Complete these steps to get started",
+    "steps": {
+      "email": "Verify email",
+      "phone": "Verify phone",
+      "kyc": "Identity check"
+    },
+    "email": {
+      "title": "Verify your email",
+      "description": "Check your email for a verification link or code.",
+      "label": "Verification code",
+      "placeholder": "Paste your verification token",
+      "submit": "Verify email",
+      "successToast": "Email verified!"
+    },
+    "phone": {
+      "title": "Verify your phone",
+      "description": "Enter the 6-digit code sent to your registered phone number.",
+      "label": "Verification code",
+      "placeholder": "123456",
+      "submit": "Verify phone number",
+      "resend": "Resend code",
+      "resendSuccess": "Code resent successfully.",
+      "successToast": "Phone number verified!"
+    },
+    "kyc": {
+      "title": "Identity verification",
+      "description": "Upload a clear photo of your national ID or passport.",
+      "label": "Document",
+      "dropzone": "Click to select a file",
+      "submit": "Upload document",
+      "successToast": "Document uploaded successfully."
+    },
+    "pending": {
+      "title": "Under review",
+      "description": "Your identity documents have been submitted. We'll verify them within 24 hours.",
+      "approved": "Identity verified!",
+      "approvedDescription": "Your identity has been verified. You're ready to go.",
+      "rejected": "Verification failed",
+      "rejectedDescription": "We couldn't verify your identity. Please try again with a clearer photo.",
+      "retry": "Upload new document",
+      "continue": "Continue to app"
+    },
+    "errors": {
+      "verifyEmailFailed": "Email verification failed. Please check your code.",
+      "verifyPhoneFailed": "Phone verification failed. Please check your code.",
+      "kycUploadFailed": "Document upload failed. Please try again.",
+      "completeFailed": "Setup completion failed. Please try again."
+    }
   }
 }

--- a/apps/app/src/lib/api.ts
+++ b/apps/app/src/lib/api.ts
@@ -10,7 +10,7 @@ export const apiClient = axios.create({
 })
 
 apiClient.interceptors.request.use((config) => {
-  const token = useAuthStore.getState().accessToken
+  const token = useAuthStore.getState().accessToken ?? useAuthStore.getState().setupToken
   if (token) config.headers.Authorization = `Bearer ${token}`
   return config
 })

--- a/apps/app/src/routeTree.gen.ts
+++ b/apps/app/src/routeTree.gen.ts
@@ -12,6 +12,7 @@ import { Route as rootRouteImport } from './routes/__root'
 import { Route as AuthRouteImport } from './routes/_auth'
 import { Route as AppRouteImport } from './routes/_app'
 import { Route as IndexRouteImport } from './routes/index'
+import { Route as AuthSetupRouteImport } from './routes/_auth/setup'
 import { Route as AuthRegisterRouteImport } from './routes/_auth/register'
 import { Route as AuthLoginRouteImport } from './routes/_auth/login'
 import { Route as AppTicketsIndexRouteImport } from './routes/_app/tickets/index'
@@ -30,6 +31,11 @@ const IndexRoute = IndexRouteImport.update({
   id: '/',
   path: '/',
   getParentRoute: () => rootRouteImport,
+} as any)
+const AuthSetupRoute = AuthSetupRouteImport.update({
+  id: '/setup',
+  path: '/setup',
+  getParentRoute: () => AuthRoute,
 } as any)
 const AuthRegisterRoute = AuthRegisterRouteImport.update({
   id: '/register',
@@ -61,6 +67,7 @@ export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/login': typeof AuthLoginRoute
   '/register': typeof AuthRegisterRoute
+  '/setup': typeof AuthSetupRoute
   '/events/': typeof AppEventsIndexRoute
   '/profile/': typeof AppProfileIndexRoute
   '/tickets/': typeof AppTicketsIndexRoute
@@ -69,6 +76,7 @@ export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/login': typeof AuthLoginRoute
   '/register': typeof AuthRegisterRoute
+  '/setup': typeof AuthSetupRoute
   '/events': typeof AppEventsIndexRoute
   '/profile': typeof AppProfileIndexRoute
   '/tickets': typeof AppTicketsIndexRoute
@@ -80,6 +88,7 @@ export interface FileRoutesById {
   '/_auth': typeof AuthRouteWithChildren
   '/_auth/login': typeof AuthLoginRoute
   '/_auth/register': typeof AuthRegisterRoute
+  '/_auth/setup': typeof AuthSetupRoute
   '/_app/events/': typeof AppEventsIndexRoute
   '/_app/profile/': typeof AppProfileIndexRoute
   '/_app/tickets/': typeof AppTicketsIndexRoute
@@ -87,9 +96,22 @@ export interface FileRoutesById {
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
-    '/' | '/login' | '/register' | '/events/' | '/profile/' | '/tickets/'
+    | '/'
+    | '/login'
+    | '/register'
+    | '/setup'
+    | '/events/'
+    | '/profile/'
+    | '/tickets/'
   fileRoutesByTo: FileRoutesByTo
-  to: '/' | '/login' | '/register' | '/events' | '/profile' | '/tickets'
+  to:
+    | '/'
+    | '/login'
+    | '/register'
+    | '/setup'
+    | '/events'
+    | '/profile'
+    | '/tickets'
   id:
     | '__root__'
     | '/'
@@ -97,6 +119,7 @@ export interface FileRouteTypes {
     | '/_auth'
     | '/_auth/login'
     | '/_auth/register'
+    | '/_auth/setup'
     | '/_app/events/'
     | '/_app/profile/'
     | '/_app/tickets/'
@@ -130,6 +153,13 @@ declare module '@tanstack/react-router' {
       fullPath: '/'
       preLoaderRoute: typeof IndexRouteImport
       parentRoute: typeof rootRouteImport
+    }
+    '/_auth/setup': {
+      id: '/_auth/setup'
+      path: '/setup'
+      fullPath: '/setup'
+      preLoaderRoute: typeof AuthSetupRouteImport
+      parentRoute: typeof AuthRoute
     }
     '/_auth/register': {
       id: '/_auth/register'
@@ -186,11 +216,13 @@ const AppRouteWithChildren = AppRoute._addFileChildren(AppRouteChildren)
 interface AuthRouteChildren {
   AuthLoginRoute: typeof AuthLoginRoute
   AuthRegisterRoute: typeof AuthRegisterRoute
+  AuthSetupRoute: typeof AuthSetupRoute
 }
 
 const AuthRouteChildren: AuthRouteChildren = {
   AuthLoginRoute: AuthLoginRoute,
   AuthRegisterRoute: AuthRegisterRoute,
+  AuthSetupRoute: AuthSetupRoute,
 }
 
 const AuthRouteWithChildren = AuthRoute._addFileChildren(AuthRouteChildren)

--- a/apps/app/src/routes/_auth/setup.tsx
+++ b/apps/app/src/routes/_auth/setup.tsx
@@ -1,0 +1,13 @@
+import { createFileRoute, redirect } from '@tanstack/react-router'
+
+import { OnboardingWizard } from '@/features/onboarding/components/OnboardingWizard'
+import { useAuthStore } from '@/store/auth'
+
+export const Route = createFileRoute('/_auth/setup')({
+  beforeLoad: () => {
+    if (!useAuthStore.getState().isSetupPending) {
+      throw redirect({ to: '/login' })
+    }
+  },
+  component: OnboardingWizard,
+})

--- a/apps/app/src/store/auth.ts
+++ b/apps/app/src/store/auth.ts
@@ -4,8 +4,14 @@ import { immer } from 'zustand/middleware/immer'
 
 interface AuthState {
   accessToken: string | null
+  setupToken: string | null
+  phoneNumber: string | null
   isAuthenticated: boolean
+  isSetupPending: boolean
   setAccessToken: (token: string) => void
+  setSetupToken: (token: string) => void
+  setPhoneNumber: (phone: string) => void
+  completeSetup: (token: string) => void
   clearSession: () => void
 }
 
@@ -13,22 +19,49 @@ export const useAuthStore = create<AuthState>()(
   persist(
     immer((set) => ({
       accessToken: null,
+      setupToken: null,
+      phoneNumber: null,
       isAuthenticated: false,
+      isSetupPending: false,
       setAccessToken: (token) =>
         set((state) => {
           state.accessToken = token
           state.isAuthenticated = true
         }),
+      setSetupToken: (token) =>
+        set((state) => {
+          state.setupToken = token
+          state.isSetupPending = true
+        }),
+      setPhoneNumber: (phone) =>
+        set((state) => {
+          state.phoneNumber = phone
+        }),
+      completeSetup: (token) =>
+        set((state) => {
+          state.accessToken = token
+          state.isAuthenticated = true
+          state.setupToken = null
+          state.isSetupPending = false
+        }),
       clearSession: () =>
         set((state) => {
           state.accessToken = null
+          state.setupToken = null
+          state.phoneNumber = null
           state.isAuthenticated = false
+          state.isSetupPending = false
         }),
     })),
     {
       name: 'qrew-auth',
       storage: createJSONStorage(() => localStorage),
-      partialize: (state) => ({ accessToken: state.accessToken }),
+      partialize: (state) => ({
+        accessToken: state.accessToken,
+        setupToken: state.setupToken,
+        phoneNumber: state.phoneNumber,
+        isSetupPending: state.isSetupPending,
+      }),
       onRehydrateStorage: () => (state) => {
         if (state?.accessToken) state.isAuthenticated = true
       },


### PR DESCRIPTION
## Summary
Implements the post-login onboarding wizard shown when `setup_required: true` is returned after login.

Covers email verification, phone OTP, and KYC document upload.

The setup token is stored separately from the access token and sent automatically to all setup endpoints.

Onboarding status is polled every 10s so the UI advances when each step completes.

## Verification
- `LoginForm.test.tsx` — navigates to `/setup` when `setup_required: true`, to `/events` otherwise
- `RegisterForm.test.tsx` — existing registration flow unaffected

## Issue Reference

Closes [QRW-247](https://github.com/cristiangilsanz/qrew/issues/247)

## Checklist
- [x] I confirm that this PR follows the project's established coding standards.