### PR TITLE
feat: implement passkey registration and authentication

### DIFF
--- a/apps/app/src/features/auth/api/index.ts
+++ b/apps/app/src/features/auth/api/index.ts
@@ -50,4 +50,12 @@ export const authApi = {
     apiClient
       .post<RegisterResponse>('/v1/auth/registration/', { ...data, captcha_token: 'dev-bypass' })
       .then((r) => r.data),
+
+  passkeyAuthBegin: (email: string) =>
+    apiClient.post('/v1/auth/passkeys/authenticate/begin', { email }).then((r) => r.data),
+
+  passkeyAuthComplete: (credential: object) =>
+    apiClient
+      .post<LoginResponse>('/v1/auth/passkeys/authenticate/complete', credential)
+      .then((r) => r.data),
 }

--- a/apps/app/src/features/auth/components/LoginForm.test.tsx
+++ b/apps/app/src/features/auth/components/LoginForm.test.tsx
@@ -4,11 +4,19 @@ import userEvent from '@testing-library/user-event'
 import { http, HttpResponse } from 'msw'
 import { describe, expect, it, vi } from 'vitest'
 
-import { server } from '@/test/server'
-
-import { LoginForm } from './LoginForm'
-
-const mockNavigate = vi.fn()
+vi.mock('@simplewebauthn/browser', () => ({
+  startAuthentication: vi.fn().mockResolvedValue({
+    id: 'mock-cred-id',
+    rawId: 'mock-raw-id',
+    type: 'public-key',
+    response: {
+      clientDataJSON: 'mock-client-data',
+      authenticatorData: 'mock-auth-data',
+      signature: 'mock-sig',
+      userHandle: null,
+    },
+  }),
+}))
 
 vi.mock('sonner', () => ({
   toast: { error: vi.fn(), success: vi.fn() },
@@ -23,6 +31,12 @@ vi.mock('@tanstack/react-router', async (importOriginal) => {
     Link: ({ children, to }: { children: unknown; to: string }) => <a href={to}>{children}</a>,
   }
 })
+
+import { server } from '@/test/server'
+
+import { LoginForm } from './LoginForm'
+
+const mockNavigate = vi.fn()
 
 function renderLoginForm() {
   const queryClient = new QueryClient({
@@ -40,12 +54,13 @@ describe('LoginForm', () => {
     renderLoginForm()
     expect(screen.getByLabelText(/email/i)).toBeInTheDocument()
     expect(screen.getByLabelText(/password/i)).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: /sign in/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /^sign in$/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /sign in with passkey/i })).toBeInTheDocument()
   })
 
   it('shows validation errors on empty submit', async () => {
     renderLoginForm()
-    await userEvent.click(screen.getByRole('button', { name: /sign in/i }))
+    await userEvent.click(screen.getByRole('button', { name: /^sign in$/i }))
     await waitFor(() => {
       expect(document.querySelectorAll('[id$="-form-item-message"]').length).toBeGreaterThan(0)
     })
@@ -56,10 +71,34 @@ describe('LoginForm', () => {
 
     await userEvent.type(screen.getByLabelText(/email/i), 'user@example.com')
     await userEvent.type(screen.getByLabelText(/password/i), 'secret123')
-    await userEvent.click(screen.getByRole('button', { name: /sign in/i }))
+    await userEvent.click(screen.getByRole('button', { name: /^sign in$/i }))
 
     await waitFor(() => {
       expect(mockNavigate).toHaveBeenCalledWith({ to: '/events' })
+    })
+  })
+
+  it('navigates to /setup when setup_required is true', async () => {
+    server.use(
+      http.post('http://localhost:8001/v1/auth/login', () =>
+        HttpResponse.json({
+          access_token: 'mock-setup-token',
+          refresh_token: null,
+          token_type: 'bearer',
+          setup_required: true,
+          password_compromised: false,
+        }),
+      ),
+    )
+
+    renderLoginForm()
+
+    await userEvent.type(screen.getByLabelText(/email/i), 'new@example.com')
+    await userEvent.type(screen.getByLabelText(/password/i), 'secret123')
+    await userEvent.click(screen.getByRole('button', { name: /^sign in$/i }))
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith({ to: '/setup' })
     })
   })
 
@@ -75,10 +114,33 @@ describe('LoginForm', () => {
 
     await userEvent.type(screen.getByLabelText(/email/i), 'bad@example.com')
     await userEvent.type(screen.getByLabelText(/password/i), 'wrongpass')
-    await userEvent.click(screen.getByRole('button', { name: /sign in/i }))
+    await userEvent.click(screen.getByRole('button', { name: /^sign in$/i }))
 
     await waitFor(() => {
       expect(toast.error).toHaveBeenCalledWith('Invalid credentials')
+    })
+  })
+
+  it('navigates to /events after passkey sign-in', async () => {
+    renderLoginForm()
+
+    await userEvent.type(screen.getByLabelText(/email/i), 'user@example.com')
+    await userEvent.click(screen.getByRole('button', { name: /sign in with passkey/i }))
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith({ to: '/events' })
+    })
+  })
+
+  it('shows email error when passkey button clicked with no email', async () => {
+    renderLoginForm()
+
+    await userEvent.click(screen.getByRole('button', { name: /sign in with passkey/i }))
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/enter your email to sign in with a passkey/i),
+      ).toBeInTheDocument()
     })
   })
 })

--- a/apps/app/src/features/auth/components/LoginForm.test.tsx
+++ b/apps/app/src/features/auth/components/LoginForm.test.tsx
@@ -138,9 +138,7 @@ describe('LoginForm', () => {
     await userEvent.click(screen.getByRole('button', { name: /sign in with passkey/i }))
 
     await waitFor(() => {
-      expect(
-        screen.getByText(/enter your email to sign in with a passkey/i),
-      ).toBeInTheDocument()
+      expect(screen.getByText(/enter your email to sign in with a passkey/i)).toBeInTheDocument()
     })
   })
 })

--- a/apps/app/src/features/auth/components/LoginForm.tsx
+++ b/apps/app/src/features/auth/components/LoginForm.tsx
@@ -1,6 +1,6 @@
 import { zodResolver } from '@hookform/resolvers/zod'
 import { Link, useNavigate } from '@tanstack/react-router'
-import { Eye, EyeOff, Lock, Mail } from 'lucide-react'
+import { Eye, EyeOff, KeyRound, Lock, Mail } from 'lucide-react'
 import { useState } from 'react'
 import { useForm } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
@@ -18,6 +18,7 @@ import {
 import { Input } from '@/components/ui/input'
 
 import { useLogin } from '../hooks/useLogin'
+import { usePasskeyLogin } from '../hooks/usePasskeyLogin'
 import { AuthLayout } from './AuthLayout'
 
 const loginSchema = z.object({
@@ -31,6 +32,7 @@ export function LoginForm() {
   const { t } = useTranslation()
   const navigate = useNavigate()
   const login = useLogin()
+  const passkeyLogin = usePasskeyLogin()
   const [showPassword, setShowPassword] = useState(false)
 
   const form = useForm<LoginFormValues>({
@@ -40,6 +42,17 @@ export function LoginForm() {
 
   const onSubmit = (values: LoginFormValues) => {
     login.mutate(values, {
+      onSuccess: (data) => navigate({ to: data.setup_required ? '/setup' : '/events' }),
+    })
+  }
+
+  const onPasskeyLogin = () => {
+    const email = form.getValues('email')
+    if (!email) {
+      form.setError('email', { message: t('auth.emailRequiredForPasskey') })
+      return
+    }
+    passkeyLogin.mutate(email, {
       onSuccess: (data) => navigate({ to: data.setup_required ? '/setup' : '/events' }),
     })
   }
@@ -107,6 +120,26 @@ export function LoginForm() {
           </Button>
         </form>
       </Form>
+
+      <div className="relative my-4">
+        <div className="absolute inset-0 flex items-center">
+          <span className="border-border w-full border-t" />
+        </div>
+        <div className="relative flex justify-center text-xs uppercase">
+          <span className="bg-background text-muted-foreground px-2">{t('auth.or')}</span>
+        </div>
+      </div>
+
+      <Button
+        type="button"
+        variant="outline"
+        className="w-full"
+        isLoading={passkeyLogin.isPending}
+        onClick={onPasskeyLogin}
+      >
+        <KeyRound className="mr-2 h-4 w-4" />
+        {t('auth.passkeyLogin')}
+      </Button>
 
       <p className="text-muted-foreground mt-4 text-center text-sm">
         {t('auth.noAccount')}{' '}

--- a/apps/app/src/features/auth/hooks/usePasskeyLogin.ts
+++ b/apps/app/src/features/auth/hooks/usePasskeyLogin.ts
@@ -1,0 +1,37 @@
+import { startAuthentication } from '@simplewebauthn/browser'
+import { useMutation } from '@tanstack/react-query'
+import type { AxiosError } from 'axios'
+import { useTranslation } from 'react-i18next'
+import { toast } from 'sonner'
+
+import { useAuthStore } from '@/store/auth'
+
+import { type ApiErrorDetail, authApi, extractErrorMessage } from '../api'
+
+export function usePasskeyLogin() {
+  const { t } = useTranslation()
+  const setAccessToken = useAuthStore((s) => s.setAccessToken)
+  const setSetupToken = useAuthStore((s) => s.setSetupToken)
+
+  return useMutation({
+    mutationFn: async (email: string) => {
+      const options = await authApi.passkeyAuthBegin(email)
+      const credential = await startAuthentication({ optionsJSON: options })
+      return authApi.passkeyAuthComplete(credential)
+    },
+    onSuccess: (data) => {
+      if (data.setup_required) {
+        setSetupToken(data.access_token)
+      } else {
+        setAccessToken(data.access_token)
+      }
+    },
+    onError: (error: AxiosError<{ detail?: ApiErrorDetail }>) => {
+      const message = extractErrorMessage(
+        error.response?.data?.detail,
+        t('passkeys.errors.loginFailed'),
+      )
+      toast.error(message)
+    },
+  })
+}

--- a/apps/app/src/features/onboarding/api/index.ts
+++ b/apps/app/src/features/onboarding/api/index.ts
@@ -52,4 +52,12 @@ export const onboardingApi = {
 
   completeSetup: () =>
     apiClient.post<CompleteSetupResponse>('/v1/auth/setup/complete-setup').then((r) => r.data),
+
+  passkeyRegisterBegin: () =>
+    apiClient.post('/v1/auth/passkeys/register/begin').then((r) => r.data),
+
+  passkeyRegisterComplete: (credential: object) =>
+    apiClient
+      .post<{ message: string }>('/v1/auth/passkeys/register/complete', credential)
+      .then((r) => r.data),
 }

--- a/apps/app/src/features/onboarding/components/OnboardingWizard.tsx
+++ b/apps/app/src/features/onboarding/components/OnboardingWizard.tsx
@@ -8,19 +8,22 @@ import { useOnboardingStatus } from '../hooks/useOnboardingStatus'
 import { EmailVerificationStep } from './EmailVerificationStep'
 import { KycPendingStep } from './KycPendingStep'
 import { KycUploadStep } from './KycUploadStep'
+import { PasskeyRegistrationStep } from './PasskeyRegistrationStep'
 import { PhoneVerificationStep } from './PhoneVerificationStep'
 
-const STEPS = ['email', 'phone', 'kyc'] as const
+const STEPS = ['email', 'phone', 'kyc', 'passkey'] as const
 type Step = (typeof STEPS)[number]
 
 function stepFromStatus(
   emailVerified: boolean,
   phoneVerified: boolean,
   kycSubmitted: boolean,
+  passkeyRegistered: boolean,
 ): Step | 'pending' {
   if (!emailVerified) return 'email'
   if (!phoneVerified) return 'phone'
   if (!kycSubmitted) return 'kyc'
+  if (!passkeyRegistered) return 'passkey'
   return 'pending'
 }
 
@@ -30,6 +33,7 @@ function StepIndicator({ current }: { current: Step | 'pending' }) {
     email: t('onboarding.steps.email'),
     phone: t('onboarding.steps.phone'),
     kyc: t('onboarding.steps.kyc'),
+    passkey: t('onboarding.steps.passkey'),
   }
   const currentIndex = STEPS.indexOf(current as Step)
 
@@ -74,11 +78,21 @@ export function OnboardingWizard() {
 
   const currentStep =
     status && !kycRetry
-      ? stepFromStatus(status.email_verified, status.phone_verified, status.kyc_submitted)
+      ? stepFromStatus(
+          status.email_verified,
+          status.phone_verified,
+          status.kyc_submitted,
+          status.passkey_registered,
+        )
       : status
         ? kycRetry
           ? 'kyc'
-          : stepFromStatus(status.email_verified, status.phone_verified, status.kyc_submitted)
+          : stepFromStatus(
+              status.email_verified,
+              status.phone_verified,
+              status.kyc_submitted,
+              status.passkey_registered,
+            )
         : 'email'
 
   const handleStepSuccess = () => {
@@ -110,6 +124,7 @@ export function OnboardingWizard() {
       {currentStep === 'email' && <EmailVerificationStep onSuccess={handleStepSuccess} />}
       {currentStep === 'phone' && <PhoneVerificationStep onSuccess={handleStepSuccess} />}
       {currentStep === 'kyc' && <KycUploadStep onSuccess={handleKycSuccess} />}
+      {currentStep === 'passkey' && <PasskeyRegistrationStep onSuccess={handleStepSuccess} />}
       {currentStep === 'pending' && (
         <KycPendingStep
           onRetry={() => {

--- a/apps/app/src/features/onboarding/components/PasskeyRegistrationStep.test.tsx
+++ b/apps/app/src/features/onboarding/components/PasskeyRegistrationStep.test.tsx
@@ -1,0 +1,46 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('@simplewebauthn/browser', () => ({
+  startRegistration: vi.fn().mockResolvedValue({
+    id: 'mock-cred-id',
+    rawId: 'mock-raw-id',
+    type: 'public-key',
+    response: { clientDataJSON: 'mock-client-data', attestationObject: 'mock-attestation' },
+  }),
+}))
+
+vi.mock('sonner', () => ({ toast: { error: vi.fn(), success: vi.fn() }, Toaster: () => null }))
+
+import { PasskeyRegistrationStep } from './PasskeyRegistrationStep'
+
+function renderStep(onSuccess = vi.fn()) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  })
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <PasskeyRegistrationStep onSuccess={onSuccess} />
+    </QueryClientProvider>,
+  )
+}
+
+describe('PasskeyRegistrationStep', () => {
+  it('renders the register passkey button', () => {
+    renderStep()
+    expect(screen.getByRole('button', { name: /register passkey/i })).toBeInTheDocument()
+  })
+
+  it('calls onSuccess after successful registration', async () => {
+    const onSuccess = vi.fn()
+    renderStep(onSuccess)
+
+    await userEvent.click(screen.getByRole('button', { name: /register passkey/i }))
+
+    await waitFor(() => {
+      expect(onSuccess).toHaveBeenCalled()
+    })
+  })
+})

--- a/apps/app/src/features/onboarding/components/PasskeyRegistrationStep.tsx
+++ b/apps/app/src/features/onboarding/components/PasskeyRegistrationStep.tsx
@@ -1,0 +1,28 @@
+import { KeyRound } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+
+import { Button } from '@/components/ui/button'
+
+import { useRegisterPasskey } from '../hooks/useRegisterPasskey'
+
+interface Props {
+  onSuccess: () => void
+}
+
+export function PasskeyRegistrationStep({ onSuccess }: Props) {
+  const { t } = useTranslation()
+  const register = useRegisterPasskey(onSuccess)
+
+  return (
+    <div className="space-y-6">
+      <div className="space-y-2 text-center">
+        <KeyRound className="text-primary mx-auto h-12 w-12" />
+        <h2 className="text-lg font-semibold">{t('passkeys.register.title')}</h2>
+        <p className="text-muted-foreground text-sm">{t('passkeys.register.description')}</p>
+      </div>
+      <Button className="w-full" isLoading={register.isPending} onClick={() => register.mutate()}>
+        {t('passkeys.register.submit')}
+      </Button>
+    </div>
+  )
+}

--- a/apps/app/src/features/onboarding/hooks/useRegisterPasskey.ts
+++ b/apps/app/src/features/onboarding/hooks/useRegisterPasskey.ts
@@ -1,0 +1,24 @@
+import { startRegistration } from '@simplewebauthn/browser'
+import { useMutation } from '@tanstack/react-query'
+import { useTranslation } from 'react-i18next'
+import { toast } from 'sonner'
+
+import { onboardingApi } from '../api'
+
+export function useRegisterPasskey(onSuccess?: () => void) {
+  const { t } = useTranslation()
+  return useMutation({
+    mutationFn: async () => {
+      const options = await onboardingApi.passkeyRegisterBegin()
+      const credential = await startRegistration({ optionsJSON: options })
+      return onboardingApi.passkeyRegisterComplete(credential)
+    },
+    onSuccess: () => {
+      toast.success(t('passkeys.registerSuccess'))
+      onSuccess?.()
+    },
+    onError: () => {
+      toast.error(t('passkeys.errors.registerFailed'))
+    },
+  })
+}

--- a/apps/app/src/features/passkeys/api/index.ts
+++ b/apps/app/src/features/passkeys/api/index.ts
@@ -1,0 +1,21 @@
+import { apiClient } from '@/lib/api'
+
+export interface Passkey {
+  id: string
+  name: string | null
+  aaguid: string
+  last_used_at: string | null
+  created_at: string
+}
+
+export const passkeysApi = {
+  list: () =>
+    apiClient
+      .get<{ items: Passkey[]; next_cursor: string | null }>('/v1/auth/passkeys/')
+      .then((r) => r.data),
+
+  remove: (id: string) => apiClient.delete(`/v1/auth/passkeys/${id}`),
+
+  rename: (id: string, name: string) =>
+    apiClient.patch<Passkey>(`/v1/auth/passkeys/${id}`, { name }).then((r) => r.data),
+}

--- a/apps/app/src/features/passkeys/components/PasskeyList.tsx
+++ b/apps/app/src/features/passkeys/components/PasskeyList.tsx
@@ -1,0 +1,115 @@
+import { KeyRound, Pencil, Trash2 } from 'lucide-react'
+import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
+
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+
+import { useDeletePasskey } from '../hooks/useDeletePasskey'
+import { usePasskeys } from '../hooks/usePasskeys'
+import { useRenamePasskey } from '../hooks/useRenamePasskey'
+
+export function PasskeyList() {
+  const { t } = useTranslation()
+  const { data, isLoading } = usePasskeys()
+  const deletePasskey = useDeletePasskey()
+  const renamePasskey = useRenamePasskey()
+  const [editingId, setEditingId] = useState<string | null>(null)
+  const [editName, setEditName] = useState('')
+
+  if (isLoading) {
+    return (
+      <div className="flex justify-center py-8">
+        <div className="border-primary h-8 w-8 animate-spin rounded-full border-2 border-t-transparent" />
+      </div>
+    )
+  }
+
+  const passkeys = data?.items ?? []
+
+  if (passkeys.length === 0) {
+    return (
+      <div className="text-muted-foreground py-8 text-center text-sm">{t('passkeys.empty')}</div>
+    )
+  }
+
+  return (
+    <ul className="space-y-3">
+      {passkeys.map((pk) => (
+        <li
+          key={pk.id}
+          className="bg-card border-border flex items-center gap-3 rounded-lg border p-3"
+        >
+          <KeyRound className="text-muted-foreground h-5 w-5 shrink-0" />
+          <div className="min-w-0 flex-1">
+            {editingId === pk.id ? (
+              <div className="flex gap-2">
+                <Input
+                  value={editName}
+                  onChange={(e) => setEditName(e.target.value)}
+                  className="h-7 text-sm"
+                  // eslint-disable-next-line jsx-a11y/no-autofocus
+                  autoFocus
+                />
+                <Button
+                  size="sm"
+                  isLoading={renamePasskey.isPending}
+                  onClick={() => {
+                    if (editName.trim()) {
+                      renamePasskey.mutate(
+                        { id: pk.id, name: editName.trim() },
+                        { onSuccess: () => setEditingId(null) },
+                      )
+                    }
+                  }}
+                >
+                  {t('common.save')}
+                </Button>
+                <Button size="sm" variant="outline" onClick={() => setEditingId(null)}>
+                  {t('common.cancel')}
+                </Button>
+              </div>
+            ) : (
+              <>
+                <p className="truncate text-sm font-medium">
+                  {pk.name ?? t('passkeys.unnamedPasskey')}
+                </p>
+                {pk.last_used_at && (
+                  <p className="text-muted-foreground text-xs">
+                    {t('passkeys.lastUsed', {
+                      date: new Date(pk.last_used_at).toLocaleDateString(),
+                    })}
+                  </p>
+                )}
+              </>
+            )}
+          </div>
+          {editingId !== pk.id && (
+            <div className="flex gap-1">
+              <Button
+                size="icon"
+                variant="ghost"
+                className="h-7 w-7"
+                onClick={() => {
+                  setEditingId(pk.id)
+                  setEditName(pk.name ?? '')
+                }}
+              >
+                <Pencil className="h-3.5 w-3.5" />
+              </Button>
+              <Button
+                size="icon"
+                variant="ghost"
+                className="text-destructive hover:text-destructive h-7 w-7"
+                isLoading={deletePasskey.isPending}
+                onClick={() => deletePasskey.mutate(pk.id)}
+              >
+                <Trash2 className="h-3.5 w-3.5" />
+              </Button>
+            </div>
+          )}
+        </li>
+      ))}
+    </ul>
+  )
+}

--- a/apps/app/src/features/passkeys/hooks/useDeletePasskey.ts
+++ b/apps/app/src/features/passkeys/hooks/useDeletePasskey.ts
@@ -1,0 +1,24 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import type { AxiosError } from 'axios'
+import { useTranslation } from 'react-i18next'
+import { toast } from 'sonner'
+
+import { passkeysApi } from '../api'
+
+export function useDeletePasskey() {
+  const { t } = useTranslation()
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (id: string) => passkeysApi.remove(id),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['passkeys'] })
+      toast.success(t('passkeys.deleteSuccess'))
+    },
+    onError: (error: AxiosError) => {
+      const status = error.response?.status
+      toast.error(
+        status === 409 ? t('passkeys.errors.lastPasskey') : t('passkeys.errors.deleteFailed'),
+      )
+    },
+  })
+}

--- a/apps/app/src/features/passkeys/hooks/usePasskeys.ts
+++ b/apps/app/src/features/passkeys/hooks/usePasskeys.ts
@@ -1,0 +1,10 @@
+import { useQuery } from '@tanstack/react-query'
+
+import { passkeysApi } from '../api'
+
+export function usePasskeys() {
+  return useQuery({
+    queryKey: ['passkeys'],
+    queryFn: passkeysApi.list,
+  })
+}

--- a/apps/app/src/features/passkeys/hooks/useRenamePasskey.ts
+++ b/apps/app/src/features/passkeys/hooks/useRenamePasskey.ts
@@ -1,0 +1,20 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { useTranslation } from 'react-i18next'
+import { toast } from 'sonner'
+
+import { passkeysApi } from '../api'
+
+export function useRenamePasskey() {
+  const { t } = useTranslation()
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: ({ id, name }: { id: string; name: string }) => passkeysApi.rename(id, name),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['passkeys'] })
+      toast.success(t('passkeys.renameSuccess'))
+    },
+    onError: () => {
+      toast.error(t('passkeys.errors.renameFailed'))
+    },
+  })
+}

--- a/apps/app/src/i18n/locales/en.json
+++ b/apps/app/src/i18n/locales/en.json
@@ -68,7 +68,7 @@
     "steps": {
       "email": "Verify email",
       "phone": "Verify phone",
-      "kyc": "Identity check",
+      "kyc": "Identity",
       "passkey": "Add passkey"
     },
     "email": {

--- a/apps/app/src/i18n/locales/en.json
+++ b/apps/app/src/i18n/locales/en.json
@@ -22,6 +22,9 @@
     "noAccount": "Don't have an account?",
     "hasAccount": "Already have an account?",
     "registrationSuccess": "Account created! Check your email to verify.",
+    "or": "or",
+    "passkeyLogin": "Sign in with passkey",
+    "emailRequiredForPasskey": "Enter your email to sign in with a passkey",
     "errors": {
       "loginFailed": "Invalid email or password",
       "registerFailed": "Registration failed. Please try again."
@@ -38,13 +41,35 @@
   "profile": {
     "title": "Profile"
   },
+  "passkeys": {
+    "title": "Passkeys",
+    "empty": "No passkeys registered yet.",
+    "unnamedPasskey": "Unnamed passkey",
+    "lastUsed": "Last used {{date}}",
+    "registerSuccess": "Passkey registered!",
+    "deleteSuccess": "Passkey removed.",
+    "renameSuccess": "Passkey renamed.",
+    "register": {
+      "title": "Add a passkey",
+      "description": "Use your device's biometric sensor or PIN to authenticate quickly and securely.",
+      "submit": "Register passkey"
+    },
+    "errors": {
+      "registerFailed": "Passkey registration failed. Please try again.",
+      "loginFailed": "Passkey sign-in failed. Please try again.",
+      "deleteFailed": "Failed to remove passkey.",
+      "lastPasskey": "Cannot remove your only passkey.",
+      "renameFailed": "Failed to rename passkey."
+    }
+  },
   "onboarding": {
     "title": "Set up your account",
     "subtitle": "Complete these steps to get started",
     "steps": {
       "email": "Verify email",
       "phone": "Verify phone",
-      "kyc": "Identity check"
+      "kyc": "Identity check",
+      "passkey": "Add passkey"
     },
     "email": {
       "title": "Verify your email",

--- a/apps/app/src/routeTree.gen.ts
+++ b/apps/app/src/routeTree.gen.ts
@@ -18,6 +18,7 @@ import { Route as AuthLoginRouteImport } from './routes/_auth/login'
 import { Route as AppTicketsIndexRouteImport } from './routes/_app/tickets/index'
 import { Route as AppProfileIndexRouteImport } from './routes/_app/profile/index'
 import { Route as AppEventsIndexRouteImport } from './routes/_app/events/index'
+import { Route as AppProfilePasskeysRouteImport } from './routes/_app/profile/passkeys'
 
 const AuthRoute = AuthRouteImport.update({
   id: '/_auth',
@@ -62,12 +63,18 @@ const AppEventsIndexRoute = AppEventsIndexRouteImport.update({
   path: '/events/',
   getParentRoute: () => AppRoute,
 } as any)
+const AppProfilePasskeysRoute = AppProfilePasskeysRouteImport.update({
+  id: '/profile/passkeys',
+  path: '/profile/passkeys',
+  getParentRoute: () => AppRoute,
+} as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/login': typeof AuthLoginRoute
   '/register': typeof AuthRegisterRoute
   '/setup': typeof AuthSetupRoute
+  '/profile/passkeys': typeof AppProfilePasskeysRoute
   '/events/': typeof AppEventsIndexRoute
   '/profile/': typeof AppProfileIndexRoute
   '/tickets/': typeof AppTicketsIndexRoute
@@ -77,6 +84,7 @@ export interface FileRoutesByTo {
   '/login': typeof AuthLoginRoute
   '/register': typeof AuthRegisterRoute
   '/setup': typeof AuthSetupRoute
+  '/profile/passkeys': typeof AppProfilePasskeysRoute
   '/events': typeof AppEventsIndexRoute
   '/profile': typeof AppProfileIndexRoute
   '/tickets': typeof AppTicketsIndexRoute
@@ -89,6 +97,7 @@ export interface FileRoutesById {
   '/_auth/login': typeof AuthLoginRoute
   '/_auth/register': typeof AuthRegisterRoute
   '/_auth/setup': typeof AuthSetupRoute
+  '/_app/profile/passkeys': typeof AppProfilePasskeysRoute
   '/_app/events/': typeof AppEventsIndexRoute
   '/_app/profile/': typeof AppProfileIndexRoute
   '/_app/tickets/': typeof AppTicketsIndexRoute
@@ -100,6 +109,7 @@ export interface FileRouteTypes {
     | '/login'
     | '/register'
     | '/setup'
+    | '/profile/passkeys'
     | '/events/'
     | '/profile/'
     | '/tickets/'
@@ -109,6 +119,7 @@ export interface FileRouteTypes {
     | '/login'
     | '/register'
     | '/setup'
+    | '/profile/passkeys'
     | '/events'
     | '/profile'
     | '/tickets'
@@ -120,6 +131,7 @@ export interface FileRouteTypes {
     | '/_auth/login'
     | '/_auth/register'
     | '/_auth/setup'
+    | '/_app/profile/passkeys'
     | '/_app/events/'
     | '/_app/profile/'
     | '/_app/tickets/'
@@ -196,16 +208,25 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AppEventsIndexRouteImport
       parentRoute: typeof AppRoute
     }
+    '/_app/profile/passkeys': {
+      id: '/_app/profile/passkeys'
+      path: '/profile/passkeys'
+      fullPath: '/profile/passkeys'
+      preLoaderRoute: typeof AppProfilePasskeysRouteImport
+      parentRoute: typeof AppRoute
+    }
   }
 }
 
 interface AppRouteChildren {
+  AppProfilePasskeysRoute: typeof AppProfilePasskeysRoute
   AppEventsIndexRoute: typeof AppEventsIndexRoute
   AppProfileIndexRoute: typeof AppProfileIndexRoute
   AppTicketsIndexRoute: typeof AppTicketsIndexRoute
 }
 
 const AppRouteChildren: AppRouteChildren = {
+  AppProfilePasskeysRoute: AppProfilePasskeysRoute,
   AppEventsIndexRoute: AppEventsIndexRoute,
   AppProfileIndexRoute: AppProfileIndexRoute,
   AppTicketsIndexRoute: AppTicketsIndexRoute,

--- a/apps/app/src/routes/_app/profile/passkeys.tsx
+++ b/apps/app/src/routes/_app/profile/passkeys.tsx
@@ -1,0 +1,18 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { useTranslation } from 'react-i18next'
+
+import { PasskeyList } from '@/features/passkeys/components/PasskeyList'
+
+export const Route = createFileRoute('/_app/profile/passkeys')({
+  component: PasskeysPage,
+})
+
+function PasskeysPage() {
+  const { t } = useTranslation()
+  return (
+    <div className="mx-auto max-w-lg p-6">
+      <h1 className="mb-6 text-2xl font-semibold">{t('passkeys.title')}</h1>
+      <PasskeyList />
+    </div>
+  )
+}

--- a/apps/app/src/test/handlers/auth.ts
+++ b/apps/app/src/test/handlers/auth.ts
@@ -19,4 +19,54 @@ export const authHandlers = [
       { status: 201 },
     )
   }),
+
+  http.post(`${API_URL}/v1/auth/passkeys/register/begin`, () => {
+    return HttpResponse.json({
+      challenge: 'mock-challenge',
+      rp: { name: 'qrew', id: 'localhost' },
+      user: { id: 'bW9jay11c2VyLWlk', name: 'test@example.com', displayName: 'Test User' },
+      pubKeyCredParams: [{ type: 'public-key', alg: -7 }],
+      timeout: 60000,
+      attestation: 'none',
+    })
+  }),
+
+  http.post(`${API_URL}/v1/auth/passkeys/register/complete`, () => {
+    return HttpResponse.json({ message: 'Passkey registered successfully.' })
+  }),
+
+  http.post(`${API_URL}/v1/auth/passkeys/authenticate/begin`, () => {
+    return HttpResponse.json({
+      challenge: 'mock-challenge',
+      timeout: 60000,
+      rpId: 'localhost',
+      allowCredentials: [],
+      userVerification: 'preferred',
+    })
+  }),
+
+  http.post(`${API_URL}/v1/auth/passkeys/authenticate/complete`, () => {
+    return HttpResponse.json({
+      access_token: 'mock-access-token',
+      refresh_token: 'mock-refresh-token',
+      token_type: 'bearer',
+      setup_required: false,
+      password_compromised: false,
+    })
+  }),
+
+  http.get(`${API_URL}/v1/auth/passkeys/`, () => {
+    return HttpResponse.json({
+      items: [
+        {
+          id: 'mock-passkey-id',
+          name: 'My MacBook',
+          aaguid: '00000000-0000-0000-0000-000000000000',
+          last_used_at: '2026-07-01T10:00:00Z',
+          created_at: '2026-06-01T10:00:00Z',
+        },
+      ],
+      next_cursor: null,
+    })
+  }),
 ]


### PR DESCRIPTION
## Summary
Implements passkey registration in the onboarding wizard (4th step, required before complete-setup), passkey authentication option on the login page, and a passkey management page at /profile/passkeys.

## Verification
- `PasskeyRegistrationStep.test.tsx`
- `LoginForm.test.tsx`

## Issue Reference

Closes [QRW-249](https://github.com/cristiangilsanz/qrew/issues/249)

## Checklist
- [x] I confirm that this PR follows the project's established coding standards.