### PR TITLE
feat: implement profile and account management

### DIFF
--- a/apps/app/src/features/profile/api/index.ts
+++ b/apps/app/src/features/profile/api/index.ts
@@ -1,0 +1,62 @@
+import { apiClient } from '@/lib/api'
+
+export interface UserProfile {
+  id: string
+  email: string
+  full_name: string
+  phone_number: string
+  kyc_status: 'not_submitted' | 'pending' | 'approved' | 'rejected'
+  email_verified: boolean
+  phone_verified: boolean
+  created_at: string
+}
+
+export interface Session {
+  id: string
+  jti: string
+  ip_address: string | null
+  user_agent: string | null
+  device_fingerprint: string | null
+  created_at: string
+  last_used_at: string
+}
+
+export const profileApi = {
+  getMe: () => apiClient.get<UserProfile>('/v1/auth/profile/me').then((r) => r.data),
+
+  changePassword: (data: { current_password: string; new_password: string }) =>
+    apiClient
+      .post<{ message: string }>('/v1/auth/account/change-password', data)
+      .then((r) => r.data),
+
+  changeEmail: (data: { new_email: string; current_password: string }) =>
+    apiClient.post<{ message: string }>('/v1/auth/account/change-email', data).then((r) => r.data),
+
+  confirmEmailChange: (token: string) =>
+    apiClient
+      .post<{ message: string }>('/v1/auth/account/confirm-email-change', { token })
+      .then((r) => r.data),
+
+  changePhone: (data: { new_phone_number: string; current_password: string }) =>
+    apiClient.post<{ message: string }>('/v1/auth/account/change-phone', data).then((r) => r.data),
+
+  confirmPhoneChange: (data: { new_phone_number: string; otp: string }) =>
+    apiClient
+      .post<{ message: string }>('/v1/auth/account/confirm-phone-change', data)
+      .then((r) => r.data),
+
+  getSessions: () =>
+    apiClient
+      .get<{ items: Session[]; next_cursor: string | null }>('/v1/auth/sessions')
+      .then((r) => r.data),
+
+  revokeSession: (jti: string) => apiClient.delete(`/v1/auth/sessions/${jti}`),
+
+  revokeAllSessions: () =>
+    apiClient.post<{ message: string }>('/v1/auth/sessions/revoke-all').then((r) => r.data),
+
+  deleteAccount: (current_password: string) =>
+    apiClient
+      .post<{ message: string }>('/v1/auth/account/delete', { current_password })
+      .then((r) => r.data),
+}

--- a/apps/app/src/features/profile/components/ChangeEmailForm.tsx
+++ b/apps/app/src/features/profile/components/ChangeEmailForm.tsx
@@ -1,0 +1,88 @@
+import { zodResolver } from '@hookform/resolvers/zod'
+import { useState } from 'react'
+import { useForm } from 'react-hook-form'
+import { useTranslation } from 'react-i18next'
+import { z } from 'zod'
+
+import { Button } from '@/components/ui/button'
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form'
+import { Input } from '@/components/ui/input'
+
+import { useChangeEmail } from '../hooks/useChangeEmail'
+
+const schema = z.object({
+  new_email: z.string().email(),
+  current_password: z.string().min(1),
+})
+
+type Values = z.infer<typeof schema>
+
+export function ChangeEmailForm() {
+  const { t } = useTranslation()
+  const [sent, setSent] = useState(false)
+
+  const form = useForm<Values>({
+    resolver: zodResolver(schema),
+    defaultValues: { new_email: '', current_password: '' },
+  })
+
+  const changeEmail = useChangeEmail(() => setSent(true))
+
+  if (sent) {
+    return (
+      <div className="space-y-2">
+        <h3 className="font-medium">{t('profile.changeEmail.title')}</h3>
+        <p className="text-muted-foreground text-sm">{t('profile.changeEmail.success')}</p>
+        <button className="text-primary text-sm hover:underline" onClick={() => setSent(false)}>
+          {t('common.back')}
+        </button>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-4">
+      <h3 className="font-medium">{t('profile.changeEmail.title')}</h3>
+      <Form {...form}>
+        <form onSubmit={form.handleSubmit((v) => changeEmail.mutate(v))} className="space-y-3">
+          <FormField
+            control={form.control}
+            name="new_email"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>{t('profile.changeEmail.newEmail')}</FormLabel>
+                <FormControl>
+                  <Input type="email" autoComplete="email" {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name="current_password"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>{t('profile.changeEmail.currentPassword')}</FormLabel>
+                <FormControl>
+                  <Input type="password" autoComplete="current-password" {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <Button type="submit" isLoading={changeEmail.isPending}>
+            {t('profile.changeEmail.submit')}
+          </Button>
+        </form>
+      </Form>
+    </div>
+  )
+}

--- a/apps/app/src/features/profile/components/ChangePasswordForm.test.tsx
+++ b/apps/app/src/features/profile/components/ChangePasswordForm.test.tsx
@@ -1,0 +1,66 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { http, HttpResponse } from 'msw'
+import { describe, expect, it, vi } from 'vitest'
+
+import { server } from '@/test/server'
+
+import { ChangePasswordForm } from './ChangePasswordForm'
+
+vi.mock('sonner', () => ({
+  toast: { error: vi.fn(), success: vi.fn() },
+  Toaster: () => null,
+}))
+
+function renderForm() {
+  const queryClient = new QueryClient({
+    defaultOptions: { mutations: { retry: false } },
+  })
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <ChangePasswordForm />
+    </QueryClientProvider>,
+  )
+}
+
+describe('ChangePasswordForm', () => {
+  it('renders current and new password fields', () => {
+    renderForm()
+    expect(screen.getByLabelText(/current password/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/new password/i)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /update password/i })).toBeInTheDocument()
+  })
+
+  it('shows toast.success on successful password change', async () => {
+    const { toast } = await import('sonner')
+    renderForm()
+
+    await userEvent.type(screen.getByLabelText(/current password/i), 'oldpass123')
+    await userEvent.type(screen.getByLabelText(/new password/i), 'newpass456')
+    await userEvent.click(screen.getByRole('button', { name: /update password/i }))
+
+    await waitFor(() => {
+      expect(toast.success).toHaveBeenCalledWith('Password updated.')
+    })
+  })
+
+  it('shows toast.error when change-password returns 400', async () => {
+    const { toast } = await import('sonner')
+    server.use(
+      http.post('http://localhost:8001/v1/auth/account/change-password', () =>
+        HttpResponse.json({ detail: 'Incorrect current password' }, { status: 400 }),
+      ),
+    )
+
+    renderForm()
+
+    await userEvent.type(screen.getByLabelText(/current password/i), 'wrongpass')
+    await userEvent.type(screen.getByLabelText(/new password/i), 'newpass456')
+    await userEvent.click(screen.getByRole('button', { name: /update password/i }))
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith('Incorrect current password')
+    })
+  })
+})

--- a/apps/app/src/features/profile/components/ChangePasswordForm.tsx
+++ b/apps/app/src/features/profile/components/ChangePasswordForm.tsx
@@ -1,0 +1,108 @@
+import { zodResolver } from '@hookform/resolvers/zod'
+import { Eye, EyeOff } from 'lucide-react'
+import { useState } from 'react'
+import { useForm } from 'react-hook-form'
+import { useTranslation } from 'react-i18next'
+import { z } from 'zod'
+
+import { Button } from '@/components/ui/button'
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form'
+import { Input } from '@/components/ui/input'
+
+import { useChangePassword } from '../hooks/useChangePassword'
+
+const schema = z.object({
+  current_password: z.string().min(1),
+  new_password: z.string().min(8),
+})
+
+type Values = z.infer<typeof schema>
+
+export function ChangePasswordForm() {
+  const { t } = useTranslation()
+  const [showCurrent, setShowCurrent] = useState(false)
+  const [showNew, setShowNew] = useState(false)
+
+  const form = useForm<Values>({
+    resolver: zodResolver(schema),
+    defaultValues: { current_password: '', new_password: '' },
+  })
+
+  const changePassword = useChangePassword(() => form.reset())
+
+  return (
+    <div className="space-y-4">
+      <h3 className="font-medium">{t('profile.changePassword.title')}</h3>
+      <Form {...form}>
+        <form onSubmit={form.handleSubmit((v) => changePassword.mutate(v))} className="space-y-3">
+          <FormField
+            control={form.control}
+            name="current_password"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>{t('profile.changePassword.currentPassword')}</FormLabel>
+                <div className="relative">
+                  <FormControl>
+                    <Input
+                      type={showCurrent ? 'text' : 'password'}
+                      autoComplete="current-password"
+                      className="pr-10"
+                      {...field}
+                    />
+                  </FormControl>
+                  <button
+                    type="button"
+                    onClick={() => setShowCurrent((v) => !v)}
+                    className="text-muted-foreground hover:text-foreground absolute top-1/2 right-3 -translate-y-1/2"
+                    tabIndex={-1}
+                  >
+                    {showCurrent ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+                  </button>
+                </div>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name="new_password"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>{t('profile.changePassword.newPassword')}</FormLabel>
+                <div className="relative">
+                  <FormControl>
+                    <Input
+                      type={showNew ? 'text' : 'password'}
+                      autoComplete="new-password"
+                      className="pr-10"
+                      {...field}
+                    />
+                  </FormControl>
+                  <button
+                    type="button"
+                    onClick={() => setShowNew((v) => !v)}
+                    className="text-muted-foreground hover:text-foreground absolute top-1/2 right-3 -translate-y-1/2"
+                    tabIndex={-1}
+                  >
+                    {showNew ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+                  </button>
+                </div>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <Button type="submit" isLoading={changePassword.isPending}>
+            {t('profile.changePassword.submit')}
+          </Button>
+        </form>
+      </Form>
+    </div>
+  )
+}

--- a/apps/app/src/features/profile/components/ChangePhoneForm.tsx
+++ b/apps/app/src/features/profile/components/ChangePhoneForm.tsx
@@ -1,0 +1,138 @@
+import { zodResolver } from '@hookform/resolvers/zod'
+import { useState } from 'react'
+import { useForm } from 'react-hook-form'
+import { useTranslation } from 'react-i18next'
+import { z } from 'zod'
+
+import { Button } from '@/components/ui/button'
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form'
+import { Input } from '@/components/ui/input'
+
+import { useChangePhone } from '../hooks/useChangePhone'
+import { useConfirmPhoneChange } from '../hooks/useConfirmPhoneChange'
+
+const step1Schema = z.object({
+  new_phone_number: z.string().min(7),
+  current_password: z.string().min(1),
+})
+
+const step2Schema = z.object({
+  otp: z.string().length(6),
+})
+
+type Step1Values = z.infer<typeof step1Schema>
+type Step2Values = z.infer<typeof step2Schema>
+
+export function ChangePhoneForm() {
+  const { t } = useTranslation()
+  const [pendingPhone, setPendingPhone] = useState<string | null>(null)
+
+  const step1Form = useForm<Step1Values>({
+    resolver: zodResolver(step1Schema),
+    defaultValues: { new_phone_number: '', current_password: '' },
+  })
+
+  const step2Form = useForm<Step2Values>({
+    resolver: zodResolver(step2Schema),
+    defaultValues: { otp: '' },
+  })
+
+  const changePhone = useChangePhone()
+  const confirmPhone = useConfirmPhoneChange(() => {
+    setPendingPhone(null)
+    step1Form.reset()
+    step2Form.reset()
+  })
+
+  if (pendingPhone) {
+    return (
+      <div className="space-y-4">
+        <h3 className="font-medium">{t('profile.changePhone.title')}</h3>
+        <p className="text-muted-foreground text-sm">{t('profile.changePhone.otpSent')}</p>
+        <Form {...step2Form}>
+          <form
+            onSubmit={step2Form.handleSubmit((v) =>
+              confirmPhone.mutate({ new_phone_number: pendingPhone, otp: v.otp }),
+            )}
+            className="space-y-3"
+          >
+            <FormField
+              control={step2Form.control}
+              name="otp"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>{t('profile.changePhone.otp')}</FormLabel>
+                  <FormControl>
+                    <Input placeholder="123456" autoComplete="one-time-code" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <div className="flex gap-2">
+              <Button type="submit" isLoading={confirmPhone.isPending}>
+                {t('profile.changePhone.confirmSubmit')}
+              </Button>
+              <Button type="button" variant="outline" onClick={() => setPendingPhone(null)}>
+                {t('common.cancel')}
+              </Button>
+            </div>
+          </form>
+        </Form>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-4">
+      <h3 className="font-medium">{t('profile.changePhone.title')}</h3>
+      <Form {...step1Form}>
+        <form
+          onSubmit={step1Form.handleSubmit((v) =>
+            changePhone.mutate(v, {
+              onSuccess: () => setPendingPhone(v.new_phone_number),
+            }),
+          )}
+          className="space-y-3"
+        >
+          <FormField
+            control={step1Form.control}
+            name="new_phone_number"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>{t('profile.changePhone.newPhone')}</FormLabel>
+                <FormControl>
+                  <Input type="tel" autoComplete="tel" {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={step1Form.control}
+            name="current_password"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>{t('profile.changePhone.currentPassword')}</FormLabel>
+                <FormControl>
+                  <Input type="password" autoComplete="current-password" {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <Button type="submit" isLoading={changePhone.isPending}>
+            {t('profile.changePhone.submit')}
+          </Button>
+        </form>
+      </Form>
+    </div>
+  )
+}

--- a/apps/app/src/features/profile/components/DeleteAccountDialog.tsx
+++ b/apps/app/src/features/profile/components/DeleteAccountDialog.tsx
@@ -1,0 +1,81 @@
+import { zodResolver } from '@hookform/resolvers/zod'
+import { useState } from 'react'
+import { useForm } from 'react-hook-form'
+import { useTranslation } from 'react-i18next'
+import { z } from 'zod'
+
+import { Button } from '@/components/ui/button'
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form'
+import { Input } from '@/components/ui/input'
+
+import { useDeleteAccount } from '../hooks/useDeleteAccount'
+
+const schema = z.object({
+  current_password: z.string().min(1),
+})
+
+type Values = z.infer<typeof schema>
+
+export function DeleteAccountDialog() {
+  const { t } = useTranslation()
+  const [open, setOpen] = useState(false)
+
+  const form = useForm<Values>({
+    resolver: zodResolver(schema),
+    defaultValues: { current_password: '' },
+  })
+
+  const deleteAccount = useDeleteAccount()
+
+  if (!open) {
+    return (
+      <div className="space-y-1">
+        <p className="text-muted-foreground text-sm">{t('profile.deleteAccount.description')}</p>
+        <Button variant="destructive" onClick={() => setOpen(true)}>
+          {t('profile.deleteAccount.button')}
+        </Button>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-4">
+      <p className="text-muted-foreground text-sm">{t('profile.deleteAccount.description')}</p>
+      <Form {...form}>
+        <form
+          onSubmit={form.handleSubmit((v) => deleteAccount.mutate(v.current_password))}
+          className="space-y-3"
+        >
+          <FormField
+            control={form.control}
+            name="current_password"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>{t('profile.deleteAccount.currentPassword')}</FormLabel>
+                <FormControl>
+                  <Input type="password" autoComplete="current-password" {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <div className="flex gap-2">
+            <Button type="submit" variant="destructive" isLoading={deleteAccount.isPending}>
+              {t('profile.deleteAccount.confirm')}
+            </Button>
+            <Button type="button" variant="outline" onClick={() => setOpen(false)}>
+              {t('profile.deleteAccount.cancel')}
+            </Button>
+          </div>
+        </form>
+      </Form>
+    </div>
+  )
+}

--- a/apps/app/src/features/profile/components/ProfileCard.tsx
+++ b/apps/app/src/features/profile/components/ProfileCard.tsx
@@ -1,0 +1,66 @@
+import { useTranslation } from 'react-i18next'
+
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+
+import { useProfile } from '../hooks/useProfile'
+
+const kycColors: Record<string, string> = {
+  approved: 'bg-green-100 text-green-800',
+  pending: 'bg-yellow-100 text-yellow-800',
+  rejected: 'bg-red-100 text-red-800',
+  not_submitted: 'bg-gray-100 text-gray-600',
+}
+
+export function ProfileCard() {
+  const { t } = useTranslation()
+  const { data: profile, isLoading } = useProfile()
+
+  if (isLoading) {
+    return (
+      <Card>
+        <CardContent className="flex justify-center py-8">
+          <div className="border-primary h-8 w-8 animate-spin rounded-full border-2 border-t-transparent" />
+        </CardContent>
+      </Card>
+    )
+  }
+
+  if (!profile) return null
+
+  const kycKey = profile.kyc_status as keyof typeof kycColors
+  const badgeClass = kycColors[kycKey] ?? kycColors.not_submitted
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-lg">{t('profile.sections.personal')}</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-3 text-sm">
+        <div className="flex justify-between">
+          <span className="text-muted-foreground">{t('auth.fullName')}</span>
+          <span className="font-medium">{profile.full_name}</span>
+        </div>
+        <div className="flex justify-between">
+          <span className="text-muted-foreground">{t('auth.email')}</span>
+          <span className="font-medium">{profile.email}</span>
+        </div>
+        <div className="flex justify-between">
+          <span className="text-muted-foreground">{t('auth.phoneNumber')}</span>
+          <span className="font-medium">{profile.phone_number}</span>
+        </div>
+        <div className="flex justify-between">
+          <span className="text-muted-foreground">{t('profile.kycStatus.label')}</span>
+          <span className={`rounded-full px-2 py-0.5 text-xs font-medium ${badgeClass}`}>
+            {t(`profile.kycStatus.${profile.kyc_status}`)}
+          </span>
+        </div>
+        <div className="flex justify-between">
+          <span className="text-muted-foreground">
+            {t('profile.memberSince', { date: '' }).trim()}
+          </span>
+          <span className="font-medium">{new Date(profile.created_at).toLocaleDateString()}</span>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/apps/app/src/features/profile/components/SessionList.test.tsx
+++ b/apps/app/src/features/profile/components/SessionList.test.tsx
@@ -1,0 +1,54 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { http, HttpResponse } from 'msw'
+import { describe, expect, it, vi } from 'vitest'
+
+import { server } from '@/test/server'
+
+import { SessionList } from './SessionList'
+
+vi.mock('sonner', () => ({
+  toast: { error: vi.fn(), success: vi.fn() },
+  Toaster: () => null,
+}))
+
+function renderList() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  })
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <SessionList />
+    </QueryClientProvider>,
+  )
+}
+
+describe('SessionList', () => {
+  it('renders session user_agent', async () => {
+    renderList()
+    await waitFor(() => {
+      expect(screen.getByText('Mozilla/5.0 Chrome/120')).toBeInTheDocument()
+    })
+  })
+
+  it('calls revoke endpoint when revoke button is clicked', async () => {
+    let revokeCalled = false
+    server.use(
+      http.delete('http://localhost:8001/v1/auth/sessions/:jti', () => {
+        revokeCalled = true
+        return new HttpResponse(null, { status: 204 })
+      }),
+    )
+
+    renderList()
+    await waitFor(() => screen.getByText('Mozilla/5.0 Chrome/120'))
+
+    const revokeBtn = screen.getByRole('button')
+    await userEvent.click(revokeBtn)
+
+    await waitFor(() => {
+      expect(revokeCalled).toBe(true)
+    })
+  })
+})

--- a/apps/app/src/features/profile/components/SessionList.tsx
+++ b/apps/app/src/features/profile/components/SessionList.tsx
@@ -1,0 +1,73 @@
+import { Monitor, Trash2 } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+
+import { Button } from '@/components/ui/button'
+
+import { useRevokeAllSessions } from '../hooks/useRevokeAllSessions'
+import { useRevokeSession } from '../hooks/useRevokeSession'
+import { useSessions } from '../hooks/useSessions'
+
+export function SessionList() {
+  const { t } = useTranslation()
+  const { data, isLoading } = useSessions()
+  const revokeSession = useRevokeSession()
+  const revokeAll = useRevokeAllSessions()
+
+  if (isLoading) {
+    return (
+      <div className="flex justify-center py-4">
+        <div className="border-primary h-6 w-6 animate-spin rounded-full border-2 border-t-transparent" />
+      </div>
+    )
+  }
+
+  const sessions = data?.items ?? []
+
+  return (
+    <div className="space-y-3">
+      {sessions.length > 1 && (
+        <div className="flex justify-end">
+          <Button
+            variant="outline"
+            size="sm"
+            isLoading={revokeAll.isPending}
+            onClick={() => revokeAll.mutate()}
+          >
+            {t('profile.sessions.revokeAll')}
+          </Button>
+        </div>
+      )}
+      {sessions.length === 0 && <p className="text-muted-foreground py-4 text-center text-sm">—</p>}
+      <ul className="space-y-2">
+        {sessions.map((session) => (
+          <li
+            key={session.jti}
+            className="bg-muted/40 flex items-center gap-3 rounded-lg p-3 text-sm"
+          >
+            <Monitor className="text-muted-foreground h-4 w-4 shrink-0" />
+            <div className="min-w-0 flex-1">
+              <p className="truncate font-medium">
+                {session.user_agent ?? t('profile.sessions.unknownDevice')}
+              </p>
+              <p className="text-muted-foreground text-xs">
+                {session.ip_address ?? t('profile.sessions.unknownIp')} ·{' '}
+                {t('profile.sessions.lastUsed', {
+                  date: new Date(session.last_used_at).toLocaleDateString(),
+                })}
+              </p>
+            </div>
+            <Button
+              size="icon"
+              variant="ghost"
+              className="text-destructive hover:text-destructive h-7 w-7 shrink-0"
+              isLoading={revokeSession.isPending}
+              onClick={() => revokeSession.mutate(session.jti)}
+            >
+              <Trash2 className="h-3.5 w-3.5" />
+            </Button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}

--- a/apps/app/src/features/profile/hooks/useChangeEmail.ts
+++ b/apps/app/src/features/profile/hooks/useChangeEmail.ts
@@ -1,0 +1,26 @@
+import { useMutation } from '@tanstack/react-query'
+import type { AxiosError } from 'axios'
+import { useTranslation } from 'react-i18next'
+import { toast } from 'sonner'
+
+import { type ApiErrorDetail, extractErrorMessage } from '@/features/auth/api'
+
+import { profileApi } from '../api'
+
+export function useChangeEmail(onSuccess?: () => void) {
+  const { t } = useTranslation()
+  return useMutation({
+    mutationFn: (data: { new_email: string; current_password: string }) =>
+      profileApi.changeEmail(data),
+    onSuccess: () => {
+      onSuccess?.()
+    },
+    onError: (error: AxiosError<{ detail?: ApiErrorDetail }>) => {
+      const message = extractErrorMessage(
+        error.response?.data?.detail,
+        t('profile.errors.changeEmailFailed'),
+      )
+      toast.error(message)
+    },
+  })
+}

--- a/apps/app/src/features/profile/hooks/useChangePassword.ts
+++ b/apps/app/src/features/profile/hooks/useChangePassword.ts
@@ -1,0 +1,27 @@
+import { useMutation } from '@tanstack/react-query'
+import type { AxiosError } from 'axios'
+import { useTranslation } from 'react-i18next'
+import { toast } from 'sonner'
+
+import { type ApiErrorDetail, extractErrorMessage } from '@/features/auth/api'
+
+import { profileApi } from '../api'
+
+export function useChangePassword(onSuccess?: () => void) {
+  const { t } = useTranslation()
+  return useMutation({
+    mutationFn: (data: { current_password: string; new_password: string }) =>
+      profileApi.changePassword(data),
+    onSuccess: () => {
+      toast.success(t('profile.changePassword.success'))
+      onSuccess?.()
+    },
+    onError: (error: AxiosError<{ detail?: ApiErrorDetail }>) => {
+      const message = extractErrorMessage(
+        error.response?.data?.detail,
+        t('profile.errors.changePasswordFailed'),
+      )
+      toast.error(message)
+    },
+  })
+}

--- a/apps/app/src/features/profile/hooks/useChangePhone.ts
+++ b/apps/app/src/features/profile/hooks/useChangePhone.ts
@@ -1,0 +1,26 @@
+import { useMutation } from '@tanstack/react-query'
+import type { AxiosError } from 'axios'
+import { useTranslation } from 'react-i18next'
+import { toast } from 'sonner'
+
+import { type ApiErrorDetail, extractErrorMessage } from '@/features/auth/api'
+
+import { profileApi } from '../api'
+
+export function useChangePhone(onSuccess?: () => void) {
+  const { t } = useTranslation()
+  return useMutation({
+    mutationFn: (data: { new_phone_number: string; current_password: string }) =>
+      profileApi.changePhone(data),
+    onSuccess: () => {
+      onSuccess?.()
+    },
+    onError: (error: AxiosError<{ detail?: ApiErrorDetail }>) => {
+      const message = extractErrorMessage(
+        error.response?.data?.detail,
+        t('profile.errors.changePhoneFailed'),
+      )
+      toast.error(message)
+    },
+  })
+}

--- a/apps/app/src/features/profile/hooks/useConfirmPhoneChange.ts
+++ b/apps/app/src/features/profile/hooks/useConfirmPhoneChange.ts
@@ -1,0 +1,29 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import type { AxiosError } from 'axios'
+import { useTranslation } from 'react-i18next'
+import { toast } from 'sonner'
+
+import { type ApiErrorDetail, extractErrorMessage } from '@/features/auth/api'
+
+import { profileApi } from '../api'
+
+export function useConfirmPhoneChange(onSuccess?: () => void) {
+  const { t } = useTranslation()
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (data: { new_phone_number: string; otp: string }) =>
+      profileApi.confirmPhoneChange(data),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['profile'] })
+      toast.success(t('profile.changePhone.success'))
+      onSuccess?.()
+    },
+    onError: (error: AxiosError<{ detail?: ApiErrorDetail }>) => {
+      const message = extractErrorMessage(
+        error.response?.data?.detail,
+        t('profile.errors.confirmPhoneFailed'),
+      )
+      toast.error(message)
+    },
+  })
+}

--- a/apps/app/src/features/profile/hooks/useDeleteAccount.ts
+++ b/apps/app/src/features/profile/hooks/useDeleteAccount.ts
@@ -1,0 +1,28 @@
+import { useMutation } from '@tanstack/react-query'
+import type { AxiosError } from 'axios'
+import { useTranslation } from 'react-i18next'
+import { toast } from 'sonner'
+
+import { type ApiErrorDetail, extractErrorMessage } from '@/features/auth/api'
+import { useAuthStore } from '@/store/auth'
+
+import { profileApi } from '../api'
+
+export function useDeleteAccount() {
+  const { t } = useTranslation()
+  const clearSession = useAuthStore((s) => s.clearSession)
+  return useMutation({
+    mutationFn: (current_password: string) => profileApi.deleteAccount(current_password),
+    onSuccess: () => {
+      toast.success(t('profile.deleteAccount.success'))
+      clearSession()
+    },
+    onError: (error: AxiosError<{ detail?: ApiErrorDetail }>) => {
+      const message = extractErrorMessage(
+        error.response?.data?.detail,
+        t('profile.errors.deleteAccountFailed'),
+      )
+      toast.error(message)
+    },
+  })
+}

--- a/apps/app/src/features/profile/hooks/useProfile.ts
+++ b/apps/app/src/features/profile/hooks/useProfile.ts
@@ -1,0 +1,10 @@
+import { useQuery } from '@tanstack/react-query'
+
+import { profileApi } from '../api'
+
+export function useProfile() {
+  return useQuery({
+    queryKey: ['profile'],
+    queryFn: profileApi.getMe,
+  })
+}

--- a/apps/app/src/features/profile/hooks/useRevokeAllSessions.ts
+++ b/apps/app/src/features/profile/hooks/useRevokeAllSessions.ts
@@ -1,0 +1,17 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { useTranslation } from 'react-i18next'
+import { toast } from 'sonner'
+
+import { profileApi } from '../api'
+
+export function useRevokeAllSessions() {
+  const { t } = useTranslation()
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: profileApi.revokeAllSessions,
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['sessions'] })
+      toast.success(t('profile.sessions.revokeAllSuccess'))
+    },
+  })
+}

--- a/apps/app/src/features/profile/hooks/useRevokeSession.ts
+++ b/apps/app/src/features/profile/hooks/useRevokeSession.ts
@@ -1,0 +1,17 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { useTranslation } from 'react-i18next'
+import { toast } from 'sonner'
+
+import { profileApi } from '../api'
+
+export function useRevokeSession() {
+  const { t } = useTranslation()
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (jti: string) => profileApi.revokeSession(jti),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['sessions'] })
+      toast.success(t('profile.sessions.revokeSuccess'))
+    },
+  })
+}

--- a/apps/app/src/features/profile/hooks/useSessions.ts
+++ b/apps/app/src/features/profile/hooks/useSessions.ts
@@ -1,0 +1,10 @@
+import { useQuery } from '@tanstack/react-query'
+
+import { profileApi } from '../api'
+
+export function useSessions() {
+  return useQuery({
+    queryKey: ['sessions'],
+    queryFn: profileApi.getSessions,
+  })
+}

--- a/apps/app/src/i18n/locales/en.json
+++ b/apps/app/src/i18n/locales/en.json
@@ -39,7 +39,78 @@
     "empty": "You have no tickets yet"
   },
   "profile": {
-    "title": "Profile"
+    "title": "Profile",
+    "subtitle": "Manage your account",
+    "memberSince": "Member since",
+    "backToProfile": "Back to profile",
+    "managePasskeys": "Manage",
+    "kycStatus": {
+      "label": "Identity",
+      "approved": "Verified",
+      "pending": "Under review",
+      "rejected": "Rejected",
+      "not_submitted": "Not submitted"
+    },
+    "sections": {
+      "personal": "Personal info",
+      "security": "Security",
+      "sessions": "Active sessions",
+      "passkeys": "Passkeys",
+      "dangerZone": "Danger zone"
+    },
+    "changePassword": {
+      "title": "Change password",
+      "currentPassword": "Current password",
+      "newPassword": "New password",
+      "submit": "Update password",
+      "success": "Password updated."
+    },
+    "changeEmail": {
+      "title": "Change email address",
+      "newEmail": "New email",
+      "currentPassword": "Password confirmation",
+      "submit": "Send confirmation link",
+      "success": "Confirmation link sent. Check your inbox.",
+      "confirmTitle": "Email address updated",
+      "confirmDescription": "Your email address has been changed successfully.",
+      "confirmError": "This link is invalid or has expired."
+    },
+    "changePhone": {
+      "title": "Change phone number",
+      "newPhone": "New phone number",
+      "currentPassword": "Password confirmation",
+      "otpSent": "Enter the code sent to your new number",
+      "submit": "Send verification code",
+      "otp": "Verification code",
+      "confirmSubmit": "Confirm",
+      "success": "Phone number updated."
+    },
+    "sessions": {
+      "revokeAll": "Revoke all",
+      "revoke": "Revoke",
+      "revokeAllSuccess": "All sessions revoked.",
+      "revokeSuccess": "Session revoked.",
+      "unknownDevice": "Unknown device",
+      "unknownIp": "Unknown IP",
+      "lastUsed": "Last used {{date}}"
+    },
+    "deleteAccount": {
+      "title": "Delete account",
+      "description": "This is permanent and cannot be undone.",
+      "button": "Delete my account",
+      "currentPassword": "Current password",
+      "confirm": "Permanently delete account",
+      "cancel": "Cancel",
+      "success": "Account deleted."
+    },
+    "errors": {
+      "changePasswordFailed": "Password change failed. Check your current password.",
+      "changeEmailFailed": "Email change failed. Check your password.",
+      "changePhoneFailed": "Phone change failed. Check your password.",
+      "confirmPhoneFailed": "Verification failed. Check your code.",
+      "deleteAccountFailed": "Deletion failed. Check your password.",
+      "fetchFailed": "Failed to load profile."
+    }
   },
   "passkeys": {
     "title": "Passkeys",

--- a/apps/app/src/routeTree.gen.ts
+++ b/apps/app/src/routeTree.gen.ts
@@ -9,6 +9,7 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
+import { Route as ConfirmEmailChangeRouteImport } from './routes/confirm-email-change'
 import { Route as AuthRouteImport } from './routes/_auth'
 import { Route as AppRouteImport } from './routes/_app'
 import { Route as IndexRouteImport } from './routes/index'
@@ -20,6 +21,11 @@ import { Route as AppProfileIndexRouteImport } from './routes/_app/profile/index
 import { Route as AppEventsIndexRouteImport } from './routes/_app/events/index'
 import { Route as AppProfilePasskeysRouteImport } from './routes/_app/profile/passkeys'
 
+const ConfirmEmailChangeRoute = ConfirmEmailChangeRouteImport.update({
+  id: '/confirm-email-change',
+  path: '/confirm-email-change',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const AuthRoute = AuthRouteImport.update({
   id: '/_auth',
   getParentRoute: () => rootRouteImport,
@@ -71,6 +77,7 @@ const AppProfilePasskeysRoute = AppProfilePasskeysRouteImport.update({
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
+  '/confirm-email-change': typeof ConfirmEmailChangeRoute
   '/login': typeof AuthLoginRoute
   '/register': typeof AuthRegisterRoute
   '/setup': typeof AuthSetupRoute
@@ -81,6 +88,7 @@ export interface FileRoutesByFullPath {
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
+  '/confirm-email-change': typeof ConfirmEmailChangeRoute
   '/login': typeof AuthLoginRoute
   '/register': typeof AuthRegisterRoute
   '/setup': typeof AuthSetupRoute
@@ -94,6 +102,7 @@ export interface FileRoutesById {
   '/': typeof IndexRoute
   '/_app': typeof AppRouteWithChildren
   '/_auth': typeof AuthRouteWithChildren
+  '/confirm-email-change': typeof ConfirmEmailChangeRoute
   '/_auth/login': typeof AuthLoginRoute
   '/_auth/register': typeof AuthRegisterRoute
   '/_auth/setup': typeof AuthSetupRoute
@@ -106,6 +115,7 @@ export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
     | '/'
+    | '/confirm-email-change'
     | '/login'
     | '/register'
     | '/setup'
@@ -116,6 +126,7 @@ export interface FileRouteTypes {
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
+    | '/confirm-email-change'
     | '/login'
     | '/register'
     | '/setup'
@@ -128,6 +139,7 @@ export interface FileRouteTypes {
     | '/'
     | '/_app'
     | '/_auth'
+    | '/confirm-email-change'
     | '/_auth/login'
     | '/_auth/register'
     | '/_auth/setup'
@@ -141,10 +153,18 @@ export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   AppRoute: typeof AppRouteWithChildren
   AuthRoute: typeof AuthRouteWithChildren
+  ConfirmEmailChangeRoute: typeof ConfirmEmailChangeRoute
 }
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
+    '/confirm-email-change': {
+      id: '/confirm-email-change'
+      path: '/confirm-email-change'
+      fullPath: '/confirm-email-change'
+      preLoaderRoute: typeof ConfirmEmailChangeRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/_auth': {
       id: '/_auth'
       path: ''
@@ -252,6 +272,7 @@ const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   AppRoute: AppRouteWithChildren,
   AuthRoute: AuthRouteWithChildren,
+  ConfirmEmailChangeRoute: ConfirmEmailChangeRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/apps/app/src/routes/_app/profile/index.tsx
+++ b/apps/app/src/routes/_app/profile/index.tsx
@@ -1,5 +1,69 @@
-import { createFileRoute } from '@tanstack/react-router'
+import { createFileRoute, Link } from '@tanstack/react-router'
+import { useTranslation } from 'react-i18next'
+
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { ChangeEmailForm } from '@/features/profile/components/ChangeEmailForm'
+import { ChangePasswordForm } from '@/features/profile/components/ChangePasswordForm'
+import { ChangePhoneForm } from '@/features/profile/components/ChangePhoneForm'
+import { DeleteAccountDialog } from '@/features/profile/components/DeleteAccountDialog'
+import { ProfileCard } from '@/features/profile/components/ProfileCard'
+import { SessionList } from '@/features/profile/components/SessionList'
 
 export const Route = createFileRoute('/_app/profile/')({
-  component: () => null,
+  component: ProfilePage,
 })
+
+function ProfilePage() {
+  const { t } = useTranslation()
+  return (
+    <div className="mx-auto max-w-2xl space-y-6 p-6">
+      <h1 className="text-2xl font-semibold">{t('profile.title')}</h1>
+
+      <ProfileCard />
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-lg">{t('profile.sections.security')}</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-8">
+          <ChangePasswordForm />
+          <hr className="border-border" />
+          <ChangeEmailForm />
+          <hr className="border-border" />
+          <ChangePhoneForm />
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <div className="flex items-center justify-between">
+            <CardTitle className="text-lg">{t('profile.sections.passkeys')}</CardTitle>
+            <Link to="/profile/passkeys" className="text-primary text-sm hover:underline">
+              {t('profile.managePasskeys')}
+            </Link>
+          </div>
+        </CardHeader>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-lg">{t('profile.sections.sessions')}</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <SessionList />
+        </CardContent>
+      </Card>
+
+      <Card className="border-destructive/50">
+        <CardHeader>
+          <CardTitle className="text-destructive text-lg">
+            {t('profile.sections.dangerZone')}
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <DeleteAccountDialog />
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/apps/app/src/routes/confirm-email-change.tsx
+++ b/apps/app/src/routes/confirm-email-change.tsx
@@ -1,0 +1,65 @@
+import { createFileRoute, useNavigate } from '@tanstack/react-router'
+import { useEffect, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+
+import { profileApi } from '@/features/profile/api'
+
+export const Route = createFileRoute('/confirm-email-change')({
+  validateSearch: (search: Record<string, unknown>) => ({
+    token: typeof search.token === 'string' ? search.token : '',
+  }),
+  component: ConfirmEmailChangePage,
+})
+
+function ConfirmEmailChangePage() {
+  const { t } = useTranslation()
+  const { token } = Route.useSearch()
+  const navigate = useNavigate()
+  const [status, setStatus] = useState<'loading' | 'success' | 'error'>('loading')
+
+  useEffect(() => {
+    if (!token) {
+      setStatus('error')
+      return
+    }
+    profileApi
+      .confirmEmailChange(token)
+      .then(() => setStatus('success'))
+      .catch(() => setStatus('error'))
+  }, [token])
+
+  return (
+    <div className="flex min-h-screen items-center justify-center p-6">
+      <div className="max-w-sm space-y-4 text-center">
+        {status === 'loading' && <p>{t('common.loading')}</p>}
+        {status === 'success' && (
+          <>
+            <p className="text-lg font-semibold">{t('profile.changeEmail.confirmTitle')}</p>
+            <p className="text-muted-foreground text-sm">
+              {t('profile.changeEmail.confirmDescription')}
+            </p>
+            <button
+              onClick={() => void navigate({ to: '/profile' })}
+              className="text-primary text-sm hover:underline"
+            >
+              {t('profile.backToProfile')}
+            </button>
+          </>
+        )}
+        {status === 'error' && (
+          <>
+            <p className="text-destructive font-semibold">
+              {t('profile.changeEmail.confirmError')}
+            </p>
+            <button
+              onClick={() => void navigate({ to: '/profile' })}
+              className="text-primary text-sm hover:underline"
+            >
+              {t('profile.backToProfile')}
+            </button>
+          </>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/apps/app/src/test/handlers/auth.ts
+++ b/apps/app/src/test/handlers/auth.ts
@@ -55,6 +55,66 @@ export const authHandlers = [
     })
   }),
 
+  http.get(`${API_URL}/v1/auth/profile/me`, () => {
+    return HttpResponse.json({
+      id: 'mock-user-id',
+      email: 'user@example.com',
+      full_name: 'Test User',
+      phone_number: '+34600000000',
+      kyc_status: 'approved',
+      email_verified: true,
+      phone_verified: true,
+      created_at: '2026-01-01T00:00:00Z',
+    })
+  }),
+
+  http.post(`${API_URL}/v1/auth/account/change-password`, () =>
+    HttpResponse.json({ message: 'Password changed successfully.' }),
+  ),
+
+  http.post(`${API_URL}/v1/auth/account/change-email`, () =>
+    HttpResponse.json({ message: 'Confirmation link sent to your new email address.' }),
+  ),
+
+  http.post(`${API_URL}/v1/auth/account/confirm-email-change`, () =>
+    HttpResponse.json({ message: 'Email address updated successfully.' }),
+  ),
+
+  http.post(`${API_URL}/v1/auth/account/change-phone`, () =>
+    HttpResponse.json({ message: 'Verification code sent to your new phone number.' }),
+  ),
+
+  http.post(`${API_URL}/v1/auth/account/confirm-phone-change`, () =>
+    HttpResponse.json({ message: 'Phone number updated successfully.' }),
+  ),
+
+  http.get(`${API_URL}/v1/auth/sessions`, () =>
+    HttpResponse.json({
+      items: [
+        {
+          id: 'session-1',
+          jti: 'jti-1',
+          ip_address: '192.168.1.1',
+          user_agent: 'Mozilla/5.0 Chrome/120',
+          device_fingerprint: null,
+          created_at: '2026-07-01T10:00:00Z',
+          last_used_at: '2026-07-06T10:00:00Z',
+        },
+      ],
+      next_cursor: null,
+    }),
+  ),
+
+  http.delete(`${API_URL}/v1/auth/sessions/:jti`, () => new HttpResponse(null, { status: 204 })),
+
+  http.post(`${API_URL}/v1/auth/sessions/revoke-all`, () =>
+    HttpResponse.json({ message: 'All sessions have been revoked.' }),
+  ),
+
+  http.post(`${API_URL}/v1/auth/account/delete`, () =>
+    HttpResponse.json({ message: 'Account deleted.' }),
+  ),
+
   http.get(`${API_URL}/v1/auth/passkeys/`, () => {
     return HttpResponse.json({
       items: [


### PR DESCRIPTION
## Summary
Implements the profile page at with personal info display, change password, change email (with email confirmation flow), change phone with OTP, active sessions management, passkeys section linking, and danger zone with account deletion.

## Verification
- `ChangePasswordForm.test.tsx`
- `SessionList.test.tsx`

## Issue Reference

Closes [QRW-248](https://github.com/cristiangilsanz/qrew/issues/248)

## Checklist
- [x] I confirm that this PR follows the project's established coding standards.