### PR TITLE
feat: implement events discovery and detail pages

### DIFF
--- a/apps/app/.env.example
+++ b/apps/app/.env.example
@@ -1,2 +1,2 @@
-VITE_API_URL=http://localhost:8001
+VITE_IDENTITY_URL=http://localhost:8001
 VITE_CATALOG_URL=http://localhost:8002

--- a/apps/app/.env.example
+++ b/apps/app/.env.example
@@ -1,1 +1,2 @@
 VITE_API_URL=http://localhost:8001
+VITE_CATALOG_URL=http://localhost:8002

--- a/apps/app/src/config/env.ts
+++ b/apps/app/src/config/env.ts
@@ -1,5 +1,6 @@
 export const env = {
   API_URL: import.meta.env.VITE_API_URL as string,
+  CATALOG_URL: import.meta.env.VITE_CATALOG_URL as string,
   DEV: import.meta.env.DEV,
   PROD: import.meta.env.PROD,
 } as const

--- a/apps/app/src/config/env.ts
+++ b/apps/app/src/config/env.ts
@@ -1,5 +1,5 @@
 export const env = {
-  API_URL: import.meta.env.VITE_API_URL as string,
+  IDENTITY_URL: import.meta.env.VITE_IDENTITY_URL as string,
   CATALOG_URL: import.meta.env.VITE_CATALOG_URL as string,
   DEV: import.meta.env.DEV,
   PROD: import.meta.env.PROD,

--- a/apps/app/src/features/events/api/index.ts
+++ b/apps/app/src/features/events/api/index.ts
@@ -1,0 +1,70 @@
+import { catalogClient } from '@/lib/catalogApi'
+
+export interface EventSummary {
+  id: string
+  name: string
+  organiser_name: string | null
+  venue_city: string | null
+  starts_at: string | null
+  rank: number | null
+}
+
+export interface TicketType {
+  id: string
+  name: string
+  description: string | null
+  capacity: number
+  reserved_count: number
+  available: number
+  price_cents: number
+  currency: string
+  position: number
+}
+
+export interface EventDetail {
+  id: string
+  name: string
+  description: string | null
+  starts_at: string
+  ends_at: string
+  sale_starts_at: string
+  sale_ends_at: string
+  max_tickets_per_user: number
+  published_at: string | null
+  organisation: {
+    id: string
+    slug: string
+    name: string
+    description: string | null
+  }
+  venue: {
+    id: string
+    name: string
+    city: string
+    country: string
+    latitude: number
+    longitude: number
+    geofence_radius_m: number
+    timezone: string
+  }
+  ticket_types: TicketType[]
+}
+
+export interface EventFilters {
+  q?: string
+  city?: string
+  category?: string
+  from?: string
+  to?: string
+  cursor?: string
+  limit?: number
+}
+
+export const eventsApi = {
+  list: (filters: EventFilters = {}) =>
+    catalogClient
+      .get<{ items: EventSummary[]; next_cursor: string | null }>('/v1/events', { params: filters })
+      .then((r) => r.data),
+
+  getById: (id: string) => catalogClient.get<EventDetail>(`/v1/events/${id}`).then((r) => r.data),
+}

--- a/apps/app/src/features/events/components/EventCard.test.tsx
+++ b/apps/app/src/features/events/components/EventCard.test.tsx
@@ -1,0 +1,53 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { type EventSummary } from '../api'
+import { EventCard } from './EventCard'
+
+vi.mock('@tanstack/react-router', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@tanstack/react-router')>()
+  return {
+    ...actual,
+    Link: ({ children, to }: { children: unknown; to: string }) => <a href={to}>{children}</a>,
+  }
+})
+
+vi.mock('sonner', () => ({ toast: { error: vi.fn(), success: vi.fn() }, Toaster: () => null }))
+
+const mockEvent: EventSummary = {
+  id: 'event-1',
+  name: 'Summer Fest',
+  organiser_name: 'Qrew Events',
+  venue_city: 'Barcelona',
+  starts_at: '2026-08-15T20:00:00Z',
+  rank: null,
+}
+
+describe('EventCard', () => {
+  it('renders event name', () => {
+    render(<EventCard event={mockEvent} />)
+    expect(screen.getByText('Summer Fest')).toBeInTheDocument()
+  })
+
+  it('renders organiser name', () => {
+    render(<EventCard event={mockEvent} />)
+    expect(screen.getByText('Qrew Events')).toBeInTheDocument()
+  })
+
+  it('renders venue city', () => {
+    render(<EventCard event={mockEvent} />)
+    expect(screen.getByText(/Barcelona/)).toBeInTheDocument()
+  })
+
+  it('renders event date', () => {
+    render(<EventCard event={mockEvent} />)
+    expect(screen.getByText(/2026/)).toBeInTheDocument()
+  })
+
+  it('calls onClick when clicked', () => {
+    const onClick = vi.fn()
+    render(<EventCard event={mockEvent} onClick={onClick} />)
+    screen.getByRole('article').click()
+    expect(onClick).toHaveBeenCalled()
+  })
+})

--- a/apps/app/src/features/events/components/EventCard.tsx
+++ b/apps/app/src/features/events/components/EventCard.tsx
@@ -1,0 +1,56 @@
+import { Calendar, MapPin } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+
+import { Card, CardContent } from '@/components/ui/card'
+
+import { type EventSummary } from '../api'
+
+interface Props {
+  event: EventSummary
+  onClick?: () => void
+}
+
+function formatEventDate(isoString: string | null): string {
+  if (!isoString) return ''
+  return new Date(isoString).toLocaleDateString('en-GB', {
+    weekday: 'short',
+    day: 'numeric',
+    month: 'short',
+    year: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  })
+}
+
+export function EventCard({ event, onClick }: Props) {
+  const { t } = useTranslation()
+
+  return (
+    <Card
+      className="hover:border-primary cursor-pointer transition-colors"
+      onClick={onClick}
+      role="article"
+    >
+      <CardContent className="p-4">
+        <p className="text-muted-foreground mb-1 text-xs font-medium tracking-wide uppercase">
+          {event.organiser_name ?? t('events.unknownOrganiser')}
+        </p>
+        <h2 className="mb-2 text-base font-semibold">{event.name}</h2>
+        <div className="text-muted-foreground flex flex-wrap gap-3 text-sm">
+          {event.venue_city && (
+            <span className="flex items-center gap-1">
+              <MapPin className="h-3.5 w-3.5" />
+              {event.venue_city}
+            </span>
+          )}
+          {event.starts_at && (
+            <span className="flex items-center gap-1">
+              <Calendar className="h-3.5 w-3.5" />
+              {formatEventDate(event.starts_at)}
+            </span>
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/apps/app/src/features/events/components/EventDetailCard.test.tsx
+++ b/apps/app/src/features/events/components/EventDetailCard.test.tsx
@@ -1,0 +1,89 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { type EventDetail } from '../api'
+import { EventDetailCard } from './EventDetailCard'
+
+vi.mock('sonner', () => ({ toast: { error: vi.fn(), success: vi.fn() }, Toaster: () => null }))
+
+const mockEvent: EventDetail = {
+  id: 'event-1',
+  name: 'Summer Fest',
+  description: 'The biggest summer festival in Barcelona.',
+  starts_at: '2026-08-15T20:00:00Z',
+  ends_at: '2026-08-15T23:59:00Z',
+  sale_starts_at: '2026-07-01T00:00:00Z',
+  sale_ends_at: '2026-08-14T23:59:00Z',
+  max_tickets_per_user: 4,
+  published_at: '2026-07-01T00:00:00Z',
+  organisation: { id: 'org-1', slug: 'qrew-events', name: 'Qrew Events', description: null },
+  venue: {
+    id: 'venue-1',
+    name: 'Parc de la Ciutadella',
+    city: 'Barcelona',
+    country: 'ES',
+    latitude: 41.386,
+    longitude: 2.186,
+    geofence_radius_m: 200,
+    timezone: 'Europe/Madrid',
+  },
+  ticket_types: [
+    {
+      id: 'tt-1',
+      name: 'General',
+      description: null,
+      capacity: 500,
+      reserved_count: 120,
+      available: 380,
+      price_cents: 2500,
+      currency: 'EUR',
+      position: 1,
+    },
+    {
+      id: 'tt-2',
+      name: 'VIP',
+      description: 'Front row access',
+      capacity: 50,
+      reserved_count: 50,
+      available: 0,
+      price_cents: 7500,
+      currency: 'EUR',
+      position: 2,
+    },
+  ],
+}
+
+describe('EventDetailCard', () => {
+  it('renders event name', () => {
+    render(<EventDetailCard event={mockEvent} />)
+    expect(screen.getByText('Summer Fest')).toBeInTheDocument()
+  })
+
+  it('renders event description', () => {
+    render(<EventDetailCard event={mockEvent} />)
+    expect(screen.getByText('The biggest summer festival in Barcelona.')).toBeInTheDocument()
+  })
+
+  it('renders venue city', () => {
+    render(<EventDetailCard event={mockEvent} />)
+    expect(screen.getByText(/Parc de la Ciutadella/)).toBeInTheDocument()
+  })
+
+  it('renders ticket type names and prices', () => {
+    render(<EventDetailCard event={mockEvent} />)
+    expect(screen.getByText('General')).toBeInTheDocument()
+    expect(screen.getByText('25.00 EUR')).toBeInTheDocument()
+    expect(screen.getByText('VIP')).toBeInTheDocument()
+    expect(screen.getByText('75.00 EUR')).toBeInTheDocument()
+  })
+
+  it('shows sold out badge for unavailable ticket types', () => {
+    render(<EventDetailCard event={mockEvent} />)
+    expect(screen.getByText(/sold out/i)).toBeInTheDocument()
+  })
+
+  it('shows available count for available ticket types', () => {
+    render(<EventDetailCard event={mockEvent} />)
+    expect(screen.getByText(/380/)).toBeInTheDocument()
+  })
+})

--- a/apps/app/src/features/events/components/EventDetailCard.tsx
+++ b/apps/app/src/features/events/components/EventDetailCard.tsx
@@ -1,0 +1,100 @@
+import { Calendar, MapPin, Users } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+
+import { type EventDetail } from '../api'
+
+interface Props {
+  event: EventDetail
+}
+
+function formatDate(isoString: string): string {
+  return new Date(isoString).toLocaleDateString('en-GB', {
+    weekday: 'long',
+    day: 'numeric',
+    month: 'long',
+    year: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  })
+}
+
+function formatPrice(priceCents: number, currency: string): string {
+  if (priceCents === 0) return 'Free'
+  return `${(priceCents / 100).toFixed(2)} ${currency}`
+}
+
+export function EventDetailCard({ event }: Props) {
+  const { t } = useTranslation()
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <p className="text-muted-foreground mb-1 text-sm font-medium">{event.organisation.name}</p>
+        <h1 className="text-3xl font-bold">{event.name}</h1>
+        {event.description && (
+          <p className="text-muted-foreground mt-3 text-base">{event.description}</p>
+        )}
+      </div>
+
+      <div className="text-muted-foreground flex flex-col gap-2 text-sm">
+        <span className="flex items-center gap-2">
+          <Calendar className="h-4 w-4 shrink-0" />
+          <span>
+            {t('events.starts')}: {formatDate(event.starts_at)}
+          </span>
+        </span>
+        <span className="flex items-center gap-2">
+          <Calendar className="h-4 w-4 shrink-0" />
+          <span>
+            {t('events.ends')}: {formatDate(event.ends_at)}
+          </span>
+        </span>
+        <span className="flex items-center gap-2">
+          <MapPin className="h-4 w-4 shrink-0" />
+          <span>
+            {event.venue.name}, {event.venue.city}, {event.venue.country}
+          </span>
+        </span>
+        <span className="flex items-center gap-2">
+          <Users className="h-4 w-4 shrink-0" />
+          <span>{t('events.maxPerUser', { count: event.max_tickets_per_user })}</span>
+        </span>
+      </div>
+
+      <Card>
+        <CardHeader className="pb-3">
+          <CardTitle className="text-base">{t('events.ticketTypes')}</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          {event.ticket_types
+            .slice()
+            .sort((a, b) => a.position - b.position)
+            .map((tt) => (
+              <div key={tt.id} className="flex items-center justify-between">
+                <div>
+                  <p className="text-sm font-medium">{tt.name}</p>
+                  {tt.description && (
+                    <p className="text-muted-foreground text-xs">{tt.description}</p>
+                  )}
+                </div>
+                <div className="text-right">
+                  <p className="text-sm font-semibold">
+                    {formatPrice(tt.price_cents, tt.currency)}
+                  </p>
+                  {tt.available === 0 ? (
+                    <p className="text-destructive text-xs font-medium">{t('events.soldOut')}</p>
+                  ) : (
+                    <p className="text-muted-foreground text-xs">
+                      {t('events.available', { count: tt.available })}
+                    </p>
+                  )}
+                </div>
+              </div>
+            ))}
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/apps/app/src/features/events/components/EventFiltersBar.tsx
+++ b/apps/app/src/features/events/components/EventFiltersBar.tsx
@@ -1,0 +1,43 @@
+import React, { useState } from 'react'
+import { useTranslation } from 'react-i18next'
+
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+
+import { type EventFilters } from '../api'
+
+interface Props {
+  onFiltersChange: (filters: EventFilters) => void
+}
+
+export function EventFiltersBar({ onFiltersChange }: Props) {
+  const { t } = useTranslation()
+  const [q, setQ] = useState('')
+  const [city, setCity] = useState('')
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    onFiltersChange({
+      ...(q.trim() ? { q: q.trim() } : {}),
+      ...(city.trim() ? { city: city.trim() } : {}),
+    })
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="flex gap-2">
+      <Input
+        value={q}
+        onChange={(e) => setQ(e.target.value)}
+        placeholder={t('events.searchPlaceholder')}
+        className="flex-1"
+      />
+      <Input
+        value={city}
+        onChange={(e) => setCity(e.target.value)}
+        placeholder={t('events.cityPlaceholder')}
+        className="w-36"
+      />
+      <Button type="submit">{t('events.searchButton')}</Button>
+    </form>
+  )
+}

--- a/apps/app/src/features/events/hooks/useEvent.ts
+++ b/apps/app/src/features/events/hooks/useEvent.ts
@@ -1,0 +1,11 @@
+import { useQuery } from '@tanstack/react-query'
+
+import { eventsApi } from '../api'
+
+export function useEvent(id: string) {
+  return useQuery({
+    queryKey: ['events', id],
+    queryFn: () => eventsApi.getById(id),
+    enabled: !!id,
+  })
+}

--- a/apps/app/src/features/events/hooks/useEvents.ts
+++ b/apps/app/src/features/events/hooks/useEvents.ts
@@ -1,0 +1,10 @@
+import { useQuery } from '@tanstack/react-query'
+
+import { type EventFilters, eventsApi } from '../api'
+
+export function useEvents(filters: EventFilters = {}) {
+  return useQuery({
+    queryKey: ['events', filters],
+    queryFn: () => eventsApi.list(filters),
+  })
+}

--- a/apps/app/src/i18n/locales/en.json
+++ b/apps/app/src/i18n/locales/en.json
@@ -32,7 +32,23 @@
   },
   "events": {
     "title": "Events",
-    "empty": "No events available"
+    "empty": "No events found. Try adjusting your search.",
+    "notFound": "Event not found.",
+    "backToList": "Back to events",
+    "searchPlaceholder": "Search events…",
+    "cityPlaceholder": "City",
+    "searchButton": "Search",
+    "soldOut": "Sold out",
+    "available": "{{count}} available",
+    "ticketTypes": "Tickets",
+    "venue": "Venue",
+    "organiser": "Organiser",
+    "unknownOrganiser": "Unknown organiser",
+    "starts": "Starts",
+    "ends": "Ends",
+    "saleEnds": "Sale ends",
+    "maxPerUser": "Max {{count}} per user",
+    "free": "Free"
   },
   "tickets": {
     "title": "My Tickets",

--- a/apps/app/src/lib/api.ts
+++ b/apps/app/src/lib/api.ts
@@ -4,7 +4,7 @@ import { env } from '@/config/env'
 import { useAuthStore } from '@/store/auth'
 
 export const apiClient = axios.create({
-  baseURL: env.API_URL,
+  baseURL: env.IDENTITY_URL,
   timeout: 10_000,
   headers: { 'Content-Type': 'application/json' },
 })

--- a/apps/app/src/lib/catalogApi.ts
+++ b/apps/app/src/lib/catalogApi.ts
@@ -1,0 +1,9 @@
+import axios from 'axios'
+
+import { env } from '@/config/env'
+
+export const catalogClient = axios.create({
+  baseURL: env.CATALOG_URL,
+  timeout: 10_000,
+  headers: { 'Content-Type': 'application/json' },
+})

--- a/apps/app/src/routeTree.gen.ts
+++ b/apps/app/src/routeTree.gen.ts
@@ -20,6 +20,7 @@ import { Route as AppTicketsIndexRouteImport } from './routes/_app/tickets/index
 import { Route as AppProfileIndexRouteImport } from './routes/_app/profile/index'
 import { Route as AppEventsIndexRouteImport } from './routes/_app/events/index'
 import { Route as AppProfilePasskeysRouteImport } from './routes/_app/profile/passkeys'
+import { Route as AppEventsEventIdRouteImport } from './routes/_app/events/$eventId'
 
 const ConfirmEmailChangeRoute = ConfirmEmailChangeRouteImport.update({
   id: '/confirm-email-change',
@@ -74,6 +75,11 @@ const AppProfilePasskeysRoute = AppProfilePasskeysRouteImport.update({
   path: '/profile/passkeys',
   getParentRoute: () => AppRoute,
 } as any)
+const AppEventsEventIdRoute = AppEventsEventIdRouteImport.update({
+  id: '/events/$eventId',
+  path: '/events/$eventId',
+  getParentRoute: () => AppRoute,
+} as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
@@ -81,6 +87,7 @@ export interface FileRoutesByFullPath {
   '/login': typeof AuthLoginRoute
   '/register': typeof AuthRegisterRoute
   '/setup': typeof AuthSetupRoute
+  '/events/$eventId': typeof AppEventsEventIdRoute
   '/profile/passkeys': typeof AppProfilePasskeysRoute
   '/events/': typeof AppEventsIndexRoute
   '/profile/': typeof AppProfileIndexRoute
@@ -92,6 +99,7 @@ export interface FileRoutesByTo {
   '/login': typeof AuthLoginRoute
   '/register': typeof AuthRegisterRoute
   '/setup': typeof AuthSetupRoute
+  '/events/$eventId': typeof AppEventsEventIdRoute
   '/profile/passkeys': typeof AppProfilePasskeysRoute
   '/events': typeof AppEventsIndexRoute
   '/profile': typeof AppProfileIndexRoute
@@ -106,6 +114,7 @@ export interface FileRoutesById {
   '/_auth/login': typeof AuthLoginRoute
   '/_auth/register': typeof AuthRegisterRoute
   '/_auth/setup': typeof AuthSetupRoute
+  '/_app/events/$eventId': typeof AppEventsEventIdRoute
   '/_app/profile/passkeys': typeof AppProfilePasskeysRoute
   '/_app/events/': typeof AppEventsIndexRoute
   '/_app/profile/': typeof AppProfileIndexRoute
@@ -119,6 +128,7 @@ export interface FileRouteTypes {
     | '/login'
     | '/register'
     | '/setup'
+    | '/events/$eventId'
     | '/profile/passkeys'
     | '/events/'
     | '/profile/'
@@ -130,6 +140,7 @@ export interface FileRouteTypes {
     | '/login'
     | '/register'
     | '/setup'
+    | '/events/$eventId'
     | '/profile/passkeys'
     | '/events'
     | '/profile'
@@ -143,6 +154,7 @@ export interface FileRouteTypes {
     | '/_auth/login'
     | '/_auth/register'
     | '/_auth/setup'
+    | '/_app/events/$eventId'
     | '/_app/profile/passkeys'
     | '/_app/events/'
     | '/_app/profile/'
@@ -235,10 +247,18 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AppProfilePasskeysRouteImport
       parentRoute: typeof AppRoute
     }
+    '/_app/events/$eventId': {
+      id: '/_app/events/$eventId'
+      path: '/events/$eventId'
+      fullPath: '/events/$eventId'
+      preLoaderRoute: typeof AppEventsEventIdRouteImport
+      parentRoute: typeof AppRoute
+    }
   }
 }
 
 interface AppRouteChildren {
+  AppEventsEventIdRoute: typeof AppEventsEventIdRoute
   AppProfilePasskeysRoute: typeof AppProfilePasskeysRoute
   AppEventsIndexRoute: typeof AppEventsIndexRoute
   AppProfileIndexRoute: typeof AppProfileIndexRoute
@@ -246,6 +266,7 @@ interface AppRouteChildren {
 }
 
 const AppRouteChildren: AppRouteChildren = {
+  AppEventsEventIdRoute: AppEventsEventIdRoute,
   AppProfilePasskeysRoute: AppProfilePasskeysRoute,
   AppEventsIndexRoute: AppEventsIndexRoute,
   AppProfileIndexRoute: AppProfileIndexRoute,

--- a/apps/app/src/routes/_app/events/$eventId.tsx
+++ b/apps/app/src/routes/_app/events/$eventId.tsx
@@ -1,0 +1,45 @@
+import { createFileRoute, Link } from '@tanstack/react-router'
+import { ArrowLeft } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+
+import { EventDetailCard } from '@/features/events/components/EventDetailCard'
+import { useEvent } from '@/features/events/hooks/useEvent'
+
+export const Route = createFileRoute('/_app/events/$eventId')({
+  component: EventDetailPage,
+})
+
+function EventDetailPage() {
+  const { t } = useTranslation()
+  const { eventId } = Route.useParams()
+  const { data: event, isLoading, isError } = useEvent(eventId)
+
+  if (isLoading) {
+    return (
+      <div className="flex justify-center py-12">
+        <div className="border-primary h-8 w-8 animate-spin rounded-full border-2 border-t-transparent" />
+      </div>
+    )
+  }
+
+  if (isError || !event) {
+    return (
+      <div className="mx-auto max-w-3xl p-6">
+        <p className="text-muted-foreground">{t('events.notFound')}</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="mx-auto max-w-3xl space-y-6 p-6">
+      <Link
+        to="/events"
+        className="text-muted-foreground hover:text-foreground flex items-center gap-1 text-sm"
+      >
+        <ArrowLeft className="h-4 w-4" />
+        {t('events.backToList')}
+      </Link>
+      <EventDetailCard event={event} />
+    </div>
+  )
+}

--- a/apps/app/src/routes/_app/events/index.tsx
+++ b/apps/app/src/routes/_app/events/index.tsx
@@ -1,5 +1,43 @@
-import { createFileRoute } from '@tanstack/react-router'
+import { createFileRoute, useNavigate } from '@tanstack/react-router'
+import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
+
+import { type EventFilters } from '@/features/events/api'
+import { EventCard } from '@/features/events/components/EventCard'
+import { EventFiltersBar } from '@/features/events/components/EventFiltersBar'
+import { useEvents } from '@/features/events/hooks/useEvents'
 
 export const Route = createFileRoute('/_app/events/')({
-  component: () => null,
+  component: EventsPage,
 })
+
+function EventsPage() {
+  const { t } = useTranslation()
+  const navigate = useNavigate()
+  const [filters, setFilters] = useState<EventFilters>({})
+  const { data, isLoading } = useEvents(filters)
+
+  return (
+    <div className="mx-auto max-w-3xl space-y-6 p-6">
+      <h1 className="text-2xl font-semibold">{t('events.title')}</h1>
+      <EventFiltersBar onFiltersChange={setFilters} />
+      {isLoading && (
+        <div className="flex justify-center py-12">
+          <div className="border-primary h-8 w-8 animate-spin rounded-full border-2 border-t-transparent" />
+        </div>
+      )}
+      {!isLoading && data?.items.length === 0 && (
+        <p className="text-muted-foreground py-12 text-center">{t('events.empty')}</p>
+      )}
+      <div className="grid gap-4">
+        {data?.items.map((event) => (
+          <EventCard
+            key={event.id}
+            event={event}
+            onClick={() => void navigate({ to: '/events/$eventId', params: { eventId: event.id } })}
+          />
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/apps/app/src/test/handlers/catalog.ts
+++ b/apps/app/src/test/handlers/catalog.ts
@@ -1,0 +1,86 @@
+import { http, HttpResponse } from 'msw'
+
+const CATALOG_URL = 'http://localhost:8002'
+
+export const catalogHandlers = [
+  http.get(`${CATALOG_URL}/v1/events`, () =>
+    HttpResponse.json({
+      items: [
+        {
+          id: 'event-1',
+          name: 'Summer Fest',
+          organiser_name: 'Qrew Events',
+          venue_city: 'Barcelona',
+          starts_at: '2026-08-15T20:00:00Z',
+          rank: null,
+        },
+        {
+          id: 'event-2',
+          name: 'Tech Conference',
+          organiser_name: 'Dev Community',
+          venue_city: 'Madrid',
+          starts_at: '2026-09-01T09:00:00Z',
+          rank: null,
+        },
+      ],
+      next_cursor: null,
+    }),
+  ),
+
+  http.get(`${CATALOG_URL}/v1/events/:eventId`, ({ params }) => {
+    if (params.eventId === 'event-1') {
+      return HttpResponse.json({
+        id: 'event-1',
+        name: 'Summer Fest',
+        description: 'The biggest summer festival in Barcelona.',
+        starts_at: '2026-08-15T20:00:00Z',
+        ends_at: '2026-08-15T23:59:00Z',
+        sale_starts_at: '2026-07-01T00:00:00Z',
+        sale_ends_at: '2026-08-14T23:59:00Z',
+        max_tickets_per_user: 4,
+        published_at: '2026-07-01T00:00:00Z',
+        organisation: {
+          id: 'org-1',
+          slug: 'qrew-events',
+          name: 'Qrew Events',
+          description: null,
+        },
+        venue: {
+          id: 'venue-1',
+          name: 'Parc de la Ciutadella',
+          city: 'Barcelona',
+          country: 'ES',
+          latitude: 41.386,
+          longitude: 2.186,
+          geofence_radius_m: 200,
+          timezone: 'Europe/Madrid',
+        },
+        ticket_types: [
+          {
+            id: 'tt-1',
+            name: 'General',
+            description: null,
+            capacity: 500,
+            reserved_count: 120,
+            available: 380,
+            price_cents: 2500,
+            currency: 'EUR',
+            position: 1,
+          },
+          {
+            id: 'tt-2',
+            name: 'VIP',
+            description: 'Front row access',
+            capacity: 50,
+            reserved_count: 50,
+            available: 0,
+            price_cents: 7500,
+            currency: 'EUR',
+            position: 2,
+          },
+        ],
+      })
+    }
+    return new HttpResponse(null, { status: 404 })
+  }),
+]

--- a/apps/app/src/test/server.ts
+++ b/apps/app/src/test/server.ts
@@ -1,5 +1,6 @@
 import { setupServer } from 'msw/node'
 
 import { authHandlers } from './handlers/auth'
+import { catalogHandlers } from './handlers/catalog'
 
-export const server = setupServer(...authHandlers)
+export const server = setupServer(...authHandlers, ...catalogHandlers)

--- a/apps/app/vitest.config.ts
+++ b/apps/app/vitest.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
     environment: 'jsdom',
     setupFiles: ['./src/test/setup.ts'],
     env: {
-      VITE_API_URL: 'http://localhost:8001',
+      VITE_IDENTITY_URL: 'http://localhost:8001',
       VITE_CATALOG_URL: 'http://localhost:8002',
     },
     exclude: ['e2e/**', 'node_modules/**'],

--- a/apps/app/vitest.config.ts
+++ b/apps/app/vitest.config.ts
@@ -10,6 +10,7 @@ export default defineConfig({
     setupFiles: ['./src/test/setup.ts'],
     env: {
       VITE_API_URL: 'http://localhost:8001',
+      VITE_CATALOG_URL: 'http://localhost:8002',
     },
     exclude: ['e2e/**', 'node_modules/**'],
     passWithNoTests: true,


### PR DESCRIPTION
## Summary
Implements the events list page at /events with search and city filter, event cards linking to detail pages, and the event detail page  showing full info, venue, organiser, and ticket types with availability and pricing

 Adds a separate catalogClient axios instance for the catalog service at port 8002.

## Verification
- `EventCard.test.tsx` 
- `EventDetailCard.test.tsx`

## Issue Reference

Closes [QRW-250](https://github.com/cristiangilsanz/qrew/issues/250)

## Checklist
- [x] I confirm that this PR follows the project's established coding standards.