### PR TITLE
feat: implement organisation and event management

### DIFF
--- a/apps/app/src/features/organiser/api/index.ts
+++ b/apps/app/src/features/organiser/api/index.ts
@@ -1,0 +1,172 @@
+import { catalogClient } from '@/lib/catalogApi'
+
+export interface Organisation {
+  id: string
+  slug: string
+  name: string
+  description: string | null
+  created_at: string
+}
+
+export interface OrgMember {
+  organisation_id: string
+  user_id: string
+  role: 'member' | 'manager' | 'owner'
+  joined_at: string
+}
+
+export interface OrgEvent {
+  id: string
+  organisation_id: string
+  venue_id: string
+  name: string
+  description: string | null
+  starts_at: string
+  ends_at: string
+  sale_starts_at: string
+  sale_ends_at: string
+  max_tickets_per_user: number
+  status: 'draft' | 'published' | 'cancelled'
+  organiser_name: string
+  venue_city: string
+  queue_required: boolean
+  created_at: string
+  published_at: string | null
+  cancelled_at: string | null
+}
+
+export interface OrgTicketType {
+  id: string
+  event_id: string
+  name: string
+  description: string | null
+  capacity: number
+  reserved_count: number
+  available: number
+  price_cents: number
+  currency: string
+  position: number
+  created_at: string
+}
+
+export interface Venue {
+  id: string
+  name: string
+  city: string
+  country: string
+  latitude: number
+  longitude: number
+  geofence_radius_m: number
+  timezone: string
+}
+
+export interface CreateEventData {
+  venue_id: string
+  name: string
+  description?: string
+  starts_at: string
+  ends_at: string
+  sale_starts_at: string
+  sale_ends_at: string
+  max_tickets_per_user?: number
+}
+
+export interface UpdateEventData {
+  name?: string
+  description?: string
+  starts_at?: string
+  ends_at?: string
+  sale_starts_at?: string
+  sale_ends_at?: string
+  max_tickets_per_user?: number
+}
+
+export interface CreateTicketTypeData {
+  name: string
+  description?: string
+  capacity: number
+  price_cents: number
+  currency: string
+  position?: number
+}
+
+export interface UpdateTicketTypeData {
+  name?: string
+  description?: string
+  capacity?: number
+  price_cents?: number
+  position?: number
+}
+
+export interface CreateVenueData {
+  name: string
+  address_line: string
+  city: string
+  country: string
+  latitude: number
+  longitude: number
+  geofence_radius_m?: number
+  timezone: string
+  description?: string
+}
+
+export const organiserApi = {
+  listMyOrgs: () =>
+    catalogClient
+      .get<{ items: Organisation[]; next_cursor: string | null }>('/v1/organisations')
+      .then((r) => r.data),
+
+  createOrg: (data: { slug: string; name: string; description?: string }) =>
+    catalogClient.post<Organisation>('/v1/organisations', data).then((r) => r.data),
+
+  inviteMember: (orgId: string, data: { email: string; role: 'member' | 'manager' | 'owner' }) =>
+    catalogClient.post<OrgMember>(`/v1/organisations/${orgId}/members`, data).then((r) => r.data),
+
+  removeMember: (orgId: string, userId: string) =>
+    catalogClient.delete(`/v1/organisations/${orgId}/members/${userId}`),
+
+  listOrgEvents: (orgId: string) =>
+    catalogClient
+      .get<{ items: OrgEvent[]; next_cursor: string | null }>(`/v1/organisations/${orgId}/events`)
+      .then((r) => r.data),
+
+  createEvent: (orgId: string, data: CreateEventData) =>
+    catalogClient.post<OrgEvent>(`/v1/organisations/${orgId}/events`, data).then((r) => r.data),
+
+  updateEvent: (eventId: string, data: UpdateEventData) =>
+    catalogClient.patch<OrgEvent>(`/v1/events/${eventId}`, data).then((r) => r.data),
+
+  publishEvent: (eventId: string) =>
+    catalogClient.post<OrgEvent>(`/v1/events/${eventId}/publish`).then((r) => r.data),
+
+  cancelEvent: (eventId: string) =>
+    catalogClient.post<OrgEvent>(`/v1/events/${eventId}/cancel`).then((r) => r.data),
+
+  listTicketTypes: (eventId: string) =>
+    catalogClient
+      .get<{ items: OrgTicketType[]; next_cursor: string | null }>(
+        `/v1/events/${eventId}/ticket-types`,
+      )
+      .then((r) => r.data),
+
+  createTicketType: (eventId: string, data: CreateTicketTypeData) =>
+    catalogClient
+      .post<OrgTicketType>(`/v1/events/${eventId}/ticket-types`, data)
+      .then((r) => r.data),
+
+  updateTicketType: (eventId: string, ttId: string, data: UpdateTicketTypeData) =>
+    catalogClient
+      .patch<OrgTicketType>(`/v1/events/${eventId}/ticket-types/${ttId}`, data)
+      .then((r) => r.data),
+
+  deleteTicketType: (eventId: string, ttId: string) =>
+    catalogClient.delete(`/v1/events/${eventId}/ticket-types/${ttId}`),
+
+  listVenues: () =>
+    catalogClient
+      .get<{ items: Venue[]; next_cursor: string | null }>('/v1/venues')
+      .then((r) => r.data),
+
+  createVenue: (data: CreateVenueData) =>
+    catalogClient.post<Venue>('/v1/venues', data).then((r) => r.data),
+}

--- a/apps/app/src/features/organiser/components/CreateEventForm.tsx
+++ b/apps/app/src/features/organiser/components/CreateEventForm.tsx
@@ -1,0 +1,218 @@
+import { zodResolver } from '@hookform/resolvers/zod'
+import { useForm } from 'react-hook-form'
+import { useTranslation } from 'react-i18next'
+import { z } from 'zod'
+
+import { Button } from '@/components/ui/button'
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form'
+import { Input } from '@/components/ui/input'
+
+import type { OrgEvent } from '../api'
+import { useCreateEvent } from '../hooks/useCreateEvent'
+import { useVenues } from '../hooks/useVenues'
+
+const schema = z
+  .object({
+    name: z.string().min(1),
+    description: z.string().optional(),
+    venue_id: z.string().min(1, 'Venue is required'),
+    starts_at: z.string().min(1),
+    ends_at: z.string().min(1),
+    sale_starts_at: z.string().min(1),
+    sale_ends_at: z.string().min(1),
+    max_tickets_per_user: z.coerce.number().int().min(1).max(20),
+  })
+  .refine((v) => new Date(v.ends_at) > new Date(v.starts_at), {
+    message: 'End time must be after start time',
+    path: ['ends_at'],
+  })
+  .refine((v) => new Date(v.sale_ends_at) <= new Date(v.starts_at), {
+    message: 'Sale must end before or at event start',
+    path: ['sale_ends_at'],
+  })
+
+type Values = z.infer<typeof schema>
+
+interface Props {
+  orgId: string
+  onSuccess?: (eventId: string) => void
+}
+
+export function CreateEventForm({ orgId, onSuccess }: Props) {
+  const { t } = useTranslation()
+  const { data: venuesData } = useVenues()
+  const venues = venuesData?.items ?? []
+
+  const form = useForm<Values>({
+    resolver: zodResolver(schema),
+    defaultValues: {
+      name: '',
+      description: '',
+      venue_id: '',
+      starts_at: '',
+      ends_at: '',
+      sale_starts_at: '',
+      sale_ends_at: '',
+      max_tickets_per_user: 4,
+    },
+  })
+
+  const createEvent = useCreateEvent(orgId, (event: OrgEvent) => {
+    form.reset()
+    onSuccess?.(event.id)
+  })
+
+  return (
+    <Form {...form}>
+      <form
+        onSubmit={form.handleSubmit((v) =>
+          createEvent.mutate({
+            ...v,
+            starts_at: new Date(v.starts_at).toISOString(),
+            ends_at: new Date(v.ends_at).toISOString(),
+            sale_starts_at: new Date(v.sale_starts_at).toISOString(),
+            sale_ends_at: new Date(v.sale_ends_at).toISOString(),
+          }),
+        )}
+        className="space-y-3"
+      >
+        <FormField
+          control={form.control}
+          name="name"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>{t('organiser.events.nameLabel')}</FormLabel>
+              <FormControl>
+                <Input {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name="description"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>{t('organiser.events.descriptionLabel')}</FormLabel>
+              <FormControl>
+                <textarea
+                  rows={3}
+                  className="border-input bg-background ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring flex min-h-[60px] w-full rounded-md border px-3 py-2 text-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
+                  {...field}
+                />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name="venue_id"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>{t('organiser.events.venueLabel')}</FormLabel>
+              <FormControl>
+                {venues.length === 0 ? (
+                  <p className="text-muted-foreground text-sm">
+                    {t('organiser.events.venueEmpty')}
+                  </p>
+                ) : (
+                  <select
+                    className="border-input bg-background ring-offset-background focus-visible:ring-ring flex h-10 w-full rounded-md border px-3 py-2 text-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
+                    {...field}
+                  >
+                    <option value="">Select a venue…</option>
+                    {venues.map((v) => (
+                      <option key={v.id} value={v.id}>
+                        {v.name} — {v.city}
+                      </option>
+                    ))}
+                  </select>
+                )}
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <div className="grid grid-cols-2 gap-3">
+          <FormField
+            control={form.control}
+            name="starts_at"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>{t('organiser.events.startsAtLabel')}</FormLabel>
+                <FormControl>
+                  <Input type="datetime-local" {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name="ends_at"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>{t('organiser.events.endsAtLabel')}</FormLabel>
+                <FormControl>
+                  <Input type="datetime-local" {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name="sale_starts_at"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>{t('organiser.events.saleStartsAtLabel')}</FormLabel>
+                <FormControl>
+                  <Input type="datetime-local" {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name="sale_ends_at"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>{t('organiser.events.saleEndsAtLabel')}</FormLabel>
+                <FormControl>
+                  <Input type="datetime-local" {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        </div>
+        <FormField
+          control={form.control}
+          name="max_tickets_per_user"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>{t('organiser.events.maxTicketsLabel')}</FormLabel>
+              <FormControl>
+                <Input type="number" min={1} max={20} {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <Button type="submit" isLoading={createEvent.isPending}>
+          {t('organiser.events.create')}
+        </Button>
+      </form>
+    </Form>
+  )
+}

--- a/apps/app/src/features/organiser/components/CreateOrganisationForm.test.tsx
+++ b/apps/app/src/features/organiser/components/CreateOrganisationForm.test.tsx
@@ -1,0 +1,71 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { http, HttpResponse } from 'msw'
+import { describe, expect, it, vi } from 'vitest'
+
+import { server } from '@/test/server'
+
+import { CreateOrganisationForm } from './CreateOrganisationForm'
+
+vi.mock('sonner', () => ({
+  toast: { error: vi.fn(), success: vi.fn() },
+  Toaster: () => null,
+}))
+
+vi.mock('@tanstack/react-router', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@tanstack/react-router')>()
+  return { ...actual, useNavigate: () => vi.fn(), Link: actual.Link }
+})
+
+function renderForm(onSuccess?: (id: string) => void) {
+  const queryClient = new QueryClient({
+    defaultOptions: { mutations: { retry: false } },
+  })
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <CreateOrganisationForm onSuccess={onSuccess} />
+    </QueryClientProvider>,
+  )
+}
+
+describe('CreateOrganisationForm', () => {
+  it('renders slug and name fields', () => {
+    renderForm()
+    expect(screen.getByLabelText(/slug/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/^name/i)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /new organisation/i })).toBeInTheDocument()
+  })
+
+  it('shows toast.success on successful create', async () => {
+    const { toast } = await import('sonner')
+    renderForm()
+
+    await userEvent.type(screen.getByLabelText(/slug/i), 'my-org')
+    await userEvent.type(screen.getByLabelText(/^name/i), 'My Org')
+    await userEvent.click(screen.getByRole('button', { name: /new organisation/i }))
+
+    await waitFor(() => {
+      expect(toast.success).toHaveBeenCalledWith('Organisation created.')
+    })
+  })
+
+  it('shows toast.error on slug conflict (409)', async () => {
+    const { toast } = await import('sonner')
+    server.use(
+      http.post('http://localhost:8002/v1/organisations', () =>
+        HttpResponse.json({ detail: 'Slug already taken' }, { status: 409 }),
+      ),
+    )
+
+    renderForm()
+
+    await userEvent.type(screen.getByLabelText(/slug/i), 'taken-org')
+    await userEvent.type(screen.getByLabelText(/^name/i), 'Taken Org')
+    await userEvent.click(screen.getByRole('button', { name: /new organisation/i }))
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith('Slug already taken')
+    })
+  })
+})

--- a/apps/app/src/features/organiser/components/CreateOrganisationForm.tsx
+++ b/apps/app/src/features/organiser/components/CreateOrganisationForm.tsx
@@ -1,0 +1,101 @@
+import { zodResolver } from '@hookform/resolvers/zod'
+import { useForm } from 'react-hook-form'
+import { useTranslation } from 'react-i18next'
+import { z } from 'zod'
+
+import { Button } from '@/components/ui/button'
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form'
+import { Input } from '@/components/ui/input'
+
+import type { Organisation } from '../api'
+import { useCreateOrganisation } from '../hooks/useCreateOrganisation'
+
+const schema = z.object({
+  slug: z
+    .string()
+    .min(3)
+    .max(64)
+    .regex(/^[a-z0-9-]+$/, 'Only lowercase letters, numbers, and hyphens'),
+  name: z.string().min(1).max(128),
+  description: z.string().optional(),
+})
+
+type Values = z.infer<typeof schema>
+
+interface Props {
+  onSuccess?: (orgId: string) => void
+}
+
+export function CreateOrganisationForm({ onSuccess }: Props) {
+  const { t } = useTranslation()
+
+  const form = useForm<Values>({
+    resolver: zodResolver(schema),
+    defaultValues: { slug: '', name: '', description: '' },
+  })
+
+  const createOrg = useCreateOrganisation((org: Organisation) => {
+    form.reset()
+    onSuccess?.(org.id)
+  })
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit((v) => createOrg.mutate(v))} className="space-y-3">
+        <FormField
+          control={form.control}
+          name="slug"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>{t('organiser.org.slugLabel')}</FormLabel>
+              <FormControl>
+                <Input placeholder={t('organiser.org.slugPlaceholder')} {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name="name"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>{t('organiser.org.nameLabel')}</FormLabel>
+              <FormControl>
+                <Input {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name="description"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>{t('organiser.org.descriptionLabel')}</FormLabel>
+              <FormControl>
+                <textarea
+                  rows={3}
+                  className="border-input bg-background ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring flex min-h-[60px] w-full rounded-md border px-3 py-2 text-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
+                  {...field}
+                />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <Button type="submit" isLoading={createOrg.isPending}>
+          {t('organiser.org.create')}
+        </Button>
+      </form>
+    </Form>
+  )
+}

--- a/apps/app/src/features/organiser/components/CreateVenueForm.tsx
+++ b/apps/app/src/features/organiser/components/CreateVenueForm.tsx
@@ -1,0 +1,176 @@
+import { zodResolver } from '@hookform/resolvers/zod'
+import { useForm } from 'react-hook-form'
+import { useTranslation } from 'react-i18next'
+import { z } from 'zod'
+
+import { Button } from '@/components/ui/button'
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form'
+import { Input } from '@/components/ui/input'
+
+import type { Venue } from '../api'
+import { useCreateVenue } from '../hooks/useCreateVenue'
+
+const schema = z.object({
+  name: z.string().min(1),
+  address_line: z.string().min(1),
+  city: z.string().min(1),
+  country: z.string().length(2),
+  latitude: z.coerce.number().min(-90).max(90),
+  longitude: z.coerce.number().min(-180).max(180),
+  geofence_radius_m: z.coerce.number().int().min(50).max(5000).optional(),
+  timezone: z.string().min(1),
+  description: z.string().optional(),
+})
+
+type Values = z.infer<typeof schema>
+
+interface Props {
+  onSuccess?: (venue: Venue) => void
+}
+
+export function CreateVenueForm({ onSuccess }: Props) {
+  const { t } = useTranslation()
+
+  const form = useForm<Values>({
+    resolver: zodResolver(schema),
+    defaultValues: {
+      name: '',
+      address_line: '',
+      city: '',
+      country: '',
+      latitude: 0,
+      longitude: 0,
+      geofence_radius_m: 200,
+      timezone: '',
+      description: '',
+    },
+  })
+
+  const createVenue = useCreateVenue((venue: Venue) => {
+    form.reset()
+    onSuccess?.(venue)
+  })
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit((v) => createVenue.mutate(v))} className="space-y-3">
+        <FormField
+          control={form.control}
+          name="name"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Name</FormLabel>
+              <FormControl>
+                <Input {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name="address_line"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Address</FormLabel>
+              <FormControl>
+                <Input {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <div className="grid grid-cols-2 gap-3">
+          <FormField
+            control={form.control}
+            name="city"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>City</FormLabel>
+                <FormControl>
+                  <Input {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name="country"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Country (2-char)</FormLabel>
+                <FormControl>
+                  <Input maxLength={2} {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name="latitude"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Latitude</FormLabel>
+                <FormControl>
+                  <Input type="number" step="any" {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name="longitude"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Longitude</FormLabel>
+                <FormControl>
+                  <Input type="number" step="any" {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        </div>
+        <FormField
+          control={form.control}
+          name="timezone"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Timezone</FormLabel>
+              <FormControl>
+                <Input placeholder="Europe/Madrid" {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name="geofence_radius_m"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Geofence radius (m, optional)</FormLabel>
+              <FormControl>
+                <Input type="number" {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <Button type="submit" isLoading={createVenue.isPending}>
+          {t('organiser.venues.newVenue')}
+        </Button>
+      </form>
+    </Form>
+  )
+}

--- a/apps/app/src/features/organiser/components/EditEventForm.tsx
+++ b/apps/app/src/features/organiser/components/EditEventForm.tsx
@@ -1,0 +1,181 @@
+import { zodResolver } from '@hookform/resolvers/zod'
+import { useForm } from 'react-hook-form'
+import { useTranslation } from 'react-i18next'
+import { z } from 'zod'
+
+import { Button } from '@/components/ui/button'
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form'
+import { Input } from '@/components/ui/input'
+
+import type { OrgEvent } from '../api'
+import { useUpdateEvent } from '../hooks/useUpdateEvent'
+
+const schema = z
+  .object({
+    name: z.string().min(1),
+    description: z.string().optional(),
+    starts_at: z.string().min(1),
+    ends_at: z.string().min(1),
+    sale_starts_at: z.string().min(1),
+    sale_ends_at: z.string().min(1),
+    max_tickets_per_user: z.coerce.number().int().min(1).max(20),
+  })
+  .refine((v) => new Date(v.ends_at) > new Date(v.starts_at), {
+    message: 'End time must be after start time',
+    path: ['ends_at'],
+  })
+  .refine((v) => new Date(v.sale_ends_at) <= new Date(v.starts_at), {
+    message: 'Sale must end before or at event start',
+    path: ['sale_ends_at'],
+  })
+
+type Values = z.infer<typeof schema>
+
+interface Props {
+  event: OrgEvent
+  orgId: string
+}
+
+export function EditEventForm({ event, orgId }: Props) {
+  const { t } = useTranslation()
+
+  const form = useForm<Values>({
+    resolver: zodResolver(schema),
+    defaultValues: {
+      name: event.name,
+      description: event.description ?? '',
+      starts_at: new Date(event.starts_at).toISOString().slice(0, 16),
+      ends_at: new Date(event.ends_at).toISOString().slice(0, 16),
+      sale_starts_at: new Date(event.sale_starts_at).toISOString().slice(0, 16),
+      sale_ends_at: new Date(event.sale_ends_at).toISOString().slice(0, 16),
+      max_tickets_per_user: event.max_tickets_per_user,
+    },
+  })
+
+  const updateEvent = useUpdateEvent(orgId, event.id)
+
+  return (
+    <Form {...form}>
+      <form
+        onSubmit={form.handleSubmit((v) =>
+          updateEvent.mutate({
+            ...v,
+            starts_at: new Date(v.starts_at).toISOString(),
+            ends_at: new Date(v.ends_at).toISOString(),
+            sale_starts_at: new Date(v.sale_starts_at).toISOString(),
+            sale_ends_at: new Date(v.sale_ends_at).toISOString(),
+          }),
+        )}
+        className="space-y-3"
+      >
+        <FormField
+          control={form.control}
+          name="name"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>{t('organiser.events.nameLabel')}</FormLabel>
+              <FormControl>
+                <Input {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name="description"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>{t('organiser.events.descriptionLabel')}</FormLabel>
+              <FormControl>
+                <textarea
+                  rows={3}
+                  className="border-input bg-background ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring flex min-h-[60px] w-full rounded-md border px-3 py-2 text-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
+                  {...field}
+                />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <div className="grid grid-cols-2 gap-3">
+          <FormField
+            control={form.control}
+            name="starts_at"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>{t('organiser.events.startsAtLabel')}</FormLabel>
+                <FormControl>
+                  <Input type="datetime-local" {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name="ends_at"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>{t('organiser.events.endsAtLabel')}</FormLabel>
+                <FormControl>
+                  <Input type="datetime-local" {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name="sale_starts_at"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>{t('organiser.events.saleStartsAtLabel')}</FormLabel>
+                <FormControl>
+                  <Input type="datetime-local" {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name="sale_ends_at"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>{t('organiser.events.saleEndsAtLabel')}</FormLabel>
+                <FormControl>
+                  <Input type="datetime-local" {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        </div>
+        <FormField
+          control={form.control}
+          name="max_tickets_per_user"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>{t('organiser.events.maxTicketsLabel')}</FormLabel>
+              <FormControl>
+                <Input type="number" min={1} max={20} {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <Button type="submit" isLoading={updateEvent.isPending}>
+          {t('common.save')}
+        </Button>
+      </form>
+    </Form>
+  )
+}

--- a/apps/app/src/features/organiser/components/EventActions.tsx
+++ b/apps/app/src/features/organiser/components/EventActions.tsx
@@ -1,0 +1,78 @@
+import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
+
+import { Button } from '@/components/ui/button'
+
+import type { OrgEvent } from '../api'
+import { useCancelEvent } from '../hooks/useCancelEvent'
+import { usePublishEvent } from '../hooks/usePublishEvent'
+
+interface Props {
+  event: OrgEvent
+  orgId: string
+}
+
+export function EventActions({ event, orgId }: Props) {
+  const { t } = useTranslation()
+  const [confirmPublish, setConfirmPublish] = useState(false)
+  const [confirmCancel, setConfirmCancel] = useState(false)
+
+  const publishEvent = usePublishEvent(orgId, event.id)
+  const cancelEvent = useCancelEvent(orgId, event.id)
+
+  return (
+    <div className="flex gap-2">
+      {event.status === 'draft' && (
+        <>
+          {confirmPublish ? (
+            <>
+              <Button
+                size="sm"
+                onClick={() => {
+                  publishEvent.mutate()
+                  setConfirmPublish(false)
+                }}
+                isLoading={publishEvent.isPending}
+              >
+                {t('organiser.events.confirmPublish')}
+              </Button>
+              <Button size="sm" variant="outline" onClick={() => setConfirmPublish(false)}>
+                {t('common.cancel')}
+              </Button>
+            </>
+          ) : (
+            <Button size="sm" variant="outline" onClick={() => setConfirmPublish(true)}>
+              {t('organiser.events.publish')}
+            </Button>
+          )}
+        </>
+      )}
+      {(event.status === 'draft' || event.status === 'published') && (
+        <>
+          {confirmCancel ? (
+            <>
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={() => {
+                  cancelEvent.mutate()
+                  setConfirmCancel(false)
+                }}
+                isLoading={cancelEvent.isPending}
+              >
+                {t('organiser.events.confirmCancel')}
+              </Button>
+              <Button size="sm" variant="outline" onClick={() => setConfirmCancel(false)}>
+                {t('common.cancel')}
+              </Button>
+            </>
+          ) : (
+            <Button size="sm" variant="outline" onClick={() => setConfirmCancel(true)}>
+              {t('organiser.events.cancel')}
+            </Button>
+          )}
+        </>
+      )}
+    </div>
+  )
+}

--- a/apps/app/src/features/organiser/components/InviteMemberForm.tsx
+++ b/apps/app/src/features/organiser/components/InviteMemberForm.tsx
@@ -1,0 +1,87 @@
+import { zodResolver } from '@hookform/resolvers/zod'
+import { useForm } from 'react-hook-form'
+import { useTranslation } from 'react-i18next'
+import { z } from 'zod'
+
+import { Button } from '@/components/ui/button'
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form'
+import { Input } from '@/components/ui/input'
+
+import { useInviteMember } from '../hooks/useInviteMember'
+
+const schema = z.object({
+  email: z.string().email(),
+  role: z.enum(['member', 'manager']),
+})
+
+type Values = z.infer<typeof schema>
+
+interface Props {
+  orgId: string
+}
+
+export function InviteMemberForm({ orgId }: Props) {
+  const { t } = useTranslation()
+
+  const form = useForm<Values>({
+    resolver: zodResolver(schema),
+    defaultValues: { email: '', role: 'member' },
+  })
+
+  const invite = useInviteMember(orgId)
+
+  return (
+    <Form {...form}>
+      <form
+        onSubmit={form.handleSubmit((v) => {
+          invite.mutate(v)
+          form.reset()
+        })}
+        className="space-y-3"
+      >
+        <FormField
+          control={form.control}
+          name="email"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>{t('organiser.members.emailLabel')}</FormLabel>
+              <FormControl>
+                <Input type="email" {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name="role"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>{t('organiser.members.roleLabel')}</FormLabel>
+              <FormControl>
+                <select
+                  className="border-input bg-background ring-offset-background focus-visible:ring-ring flex h-10 w-full rounded-md border px-3 py-2 text-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
+                  {...field}
+                >
+                  <option value="member">Member</option>
+                  <option value="manager">Manager</option>
+                </select>
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <Button type="submit" isLoading={invite.isPending}>
+          {t('organiser.members.inviteButton')}
+        </Button>
+      </form>
+    </Form>
+  )
+}

--- a/apps/app/src/features/organiser/components/OrgCard.tsx
+++ b/apps/app/src/features/organiser/components/OrgCard.tsx
@@ -1,0 +1,22 @@
+import { Link } from '@tanstack/react-router'
+
+import { Card, CardContent } from '@/components/ui/card'
+
+import type { Organisation } from '../api'
+
+interface Props {
+  org: Organisation
+}
+
+export function OrgCard({ org }: Props) {
+  return (
+    <Link to="/organiser/$orgId" params={{ orgId: org.id }}>
+      <Card className="hover:bg-muted/50 cursor-pointer transition-colors">
+        <CardContent className="p-4">
+          <p className="font-medium">{org.name}</p>
+          <p className="text-muted-foreground text-sm">@{org.slug}</p>
+        </CardContent>
+      </Card>
+    </Link>
+  )
+}

--- a/apps/app/src/features/organiser/components/OrgEventList.tsx
+++ b/apps/app/src/features/organiser/components/OrgEventList.tsx
@@ -1,0 +1,69 @@
+import { Link } from '@tanstack/react-router'
+import { useTranslation } from 'react-i18next'
+
+import { Button } from '@/components/ui/button'
+
+import { useOrgEvents } from '../hooks/useOrgEvents'
+
+interface Props {
+  orgId: string
+}
+
+const statusColors: Record<string, string> = {
+  draft: 'bg-gray-100 text-gray-700',
+  published: 'bg-green-100 text-green-700',
+  cancelled: 'bg-red-100 text-red-700',
+}
+
+export function OrgEventList({ orgId }: Props) {
+  const { t } = useTranslation()
+  const { data, isLoading } = useOrgEvents(orgId)
+  const events = data?.items ?? []
+
+  if (isLoading) {
+    return (
+      <div className="flex justify-center py-4">
+        <div className="border-primary h-6 w-6 animate-spin rounded-full border-2 border-t-transparent" />
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-3">
+      <div className="flex justify-end">
+        <Button asChild size="sm">
+          <Link to="/organiser/$orgId/events/new" params={{ orgId }}>
+            {t('organiser.events.create')}
+          </Link>
+        </Button>
+      </div>
+      {events.length === 0 && (
+        <p className="text-muted-foreground py-4 text-center text-sm">
+          {t('organiser.events.empty')}
+        </p>
+      )}
+      <div className="space-y-2">
+        {events.map((event) => (
+          <Link
+            key={event.id}
+            to="/organiser/$orgId/events/$eventId"
+            params={{ orgId, eventId: event.id }}
+            className="hover:bg-muted/50 flex items-center justify-between rounded-md border p-3 transition-colors"
+          >
+            <div>
+              <p className="font-medium">{event.name}</p>
+              <p className="text-muted-foreground text-xs">
+                {new Date(event.starts_at).toLocaleDateString()} · {event.venue_city}
+              </p>
+            </div>
+            <span
+              className={`rounded-full px-2 py-0.5 text-xs font-medium ${statusColors[event.status] ?? ''}`}
+            >
+              {event.status}
+            </span>
+          </Link>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/apps/app/src/features/organiser/components/TicketTypeList.test.tsx
+++ b/apps/app/src/features/organiser/components/TicketTypeList.test.tsx
@@ -1,0 +1,41 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+
+import { TicketTypeList } from './TicketTypeList'
+
+vi.mock('sonner', () => ({
+  toast: { error: vi.fn(), success: vi.fn() },
+  Toaster: () => null,
+}))
+
+function renderList(eventId = 'event-1') {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  })
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <TicketTypeList eventId={eventId} />
+    </QueryClientProvider>,
+  )
+}
+
+describe('TicketTypeList', () => {
+  it('renders ticket type from mock data', async () => {
+    renderList()
+    await waitFor(() => {
+      expect(screen.getByText('General')).toBeInTheDocument()
+    })
+    expect(screen.getByText(/15\.00 EUR/)).toBeInTheDocument()
+  })
+
+  it('shows the create form when "Add ticket type" is clicked', async () => {
+    renderList()
+    await waitFor(() => {
+      expect(screen.getByText('General')).toBeInTheDocument()
+    })
+    await userEvent.click(screen.getByRole('button', { name: /add ticket type/i }))
+    expect(screen.getByLabelText(/name/i)).toBeInTheDocument()
+  })
+})

--- a/apps/app/src/features/organiser/components/TicketTypeList.tsx
+++ b/apps/app/src/features/organiser/components/TicketTypeList.tsx
@@ -1,0 +1,335 @@
+import { zodResolver } from '@hookform/resolvers/zod'
+import { Pencil, Trash2 } from 'lucide-react'
+import { useState } from 'react'
+import { useForm } from 'react-hook-form'
+import { useTranslation } from 'react-i18next'
+import { z } from 'zod'
+
+import { Button } from '@/components/ui/button'
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form'
+import { Input } from '@/components/ui/input'
+
+import { useCreateTicketType } from '../hooks/useCreateTicketType'
+import { useDeleteTicketType } from '../hooks/useDeleteTicketType'
+import { useOrgTicketTypes } from '../hooks/useOrgTicketTypes'
+import { useUpdateTicketType } from '../hooks/useUpdateTicketType'
+
+const createSchema = z.object({
+  name: z.string().min(1).max(32),
+  description: z.string().optional(),
+  capacity: z.coerce.number().int().min(1).max(100000),
+  price_cents: z.coerce.number().int().min(0).max(10000000),
+  currency: z.string().length(3),
+  position: z.coerce.number().int().optional(),
+})
+
+const editSchema = z.object({
+  name: z.string().min(1).max(32),
+  description: z.string().optional(),
+  capacity: z.coerce.number().int().min(1).max(100000),
+  price_cents: z.coerce.number().int().min(0).max(10000000),
+  position: z.coerce.number().int().optional(),
+})
+
+type CreateValues = z.infer<typeof createSchema>
+type EditValues = z.infer<typeof editSchema>
+
+interface EditRowProps {
+  ttId: string
+  eventId: string
+  defaultValues: EditValues
+  onClose: () => void
+}
+
+function EditRow({ ttId, eventId, defaultValues, onClose }: EditRowProps) {
+  const { t } = useTranslation()
+  const updateTt = useUpdateTicketType(eventId)
+  const form = useForm<EditValues>({
+    resolver: zodResolver(editSchema),
+    defaultValues,
+  })
+
+  return (
+    <Form {...form}>
+      <form
+        onSubmit={form.handleSubmit((v) => {
+          updateTt.mutate({ ttId, data: v })
+          onClose()
+        })}
+        className="space-y-2 rounded-md border p-3"
+      >
+        <div className="grid grid-cols-2 gap-2">
+          <FormField
+            control={form.control}
+            name="name"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel className="text-xs">{t('organiser.ticketTypes.nameLabel')}</FormLabel>
+                <FormControl>
+                  <Input className="h-8 text-sm" {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name="capacity"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel className="text-xs">
+                  {t('organiser.ticketTypes.capacityLabel')}
+                </FormLabel>
+                <FormControl>
+                  <Input type="number" className="h-8 text-sm" {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name="price_cents"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel className="text-xs">{t('organiser.ticketTypes.priceLabel')}</FormLabel>
+                <FormControl>
+                  <Input type="number" className="h-8 text-sm" {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name="position"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel className="text-xs">
+                  {t('organiser.ticketTypes.positionLabel')}
+                </FormLabel>
+                <FormControl>
+                  <Input type="number" className="h-8 text-sm" {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        </div>
+        <div className="flex gap-2">
+          <Button type="submit" size="sm" isLoading={updateTt.isPending}>
+            {t('common.save')}
+          </Button>
+          <Button type="button" size="sm" variant="outline" onClick={onClose}>
+            {t('common.cancel')}
+          </Button>
+        </div>
+      </form>
+    </Form>
+  )
+}
+
+interface AddFormProps {
+  eventId: string
+  onClose: () => void
+}
+
+function AddForm({ eventId, onClose }: AddFormProps) {
+  const { t } = useTranslation()
+  const createTt = useCreateTicketType(eventId)
+  const form = useForm<CreateValues>({
+    resolver: zodResolver(createSchema),
+    defaultValues: { name: '', description: '', capacity: 100, price_cents: 0, currency: 'EUR' },
+  })
+
+  return (
+    <Form {...form}>
+      <form
+        onSubmit={form.handleSubmit((v) => {
+          createTt.mutate(v)
+          form.reset()
+          onClose()
+        })}
+        className="space-y-2 rounded-md border p-3"
+      >
+        <div className="grid grid-cols-2 gap-2">
+          <FormField
+            control={form.control}
+            name="name"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel className="text-xs">{t('organiser.ticketTypes.nameLabel')}</FormLabel>
+                <FormControl>
+                  <Input className="h-8 text-sm" {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name="capacity"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel className="text-xs">
+                  {t('organiser.ticketTypes.capacityLabel')}
+                </FormLabel>
+                <FormControl>
+                  <Input type="number" className="h-8 text-sm" {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name="price_cents"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel className="text-xs">{t('organiser.ticketTypes.priceLabel')}</FormLabel>
+                <FormControl>
+                  <Input type="number" className="h-8 text-sm" {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name="currency"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel className="text-xs">
+                  {t('organiser.ticketTypes.currencyLabel')}
+                </FormLabel>
+                <FormControl>
+                  <Input className="h-8 text-sm" maxLength={3} {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        </div>
+        <div className="flex gap-2">
+          <Button type="submit" size="sm" isLoading={createTt.isPending}>
+            {t('common.save')}
+          </Button>
+          <Button type="button" size="sm" variant="outline" onClick={onClose}>
+            {t('common.cancel')}
+          </Button>
+        </div>
+      </form>
+    </Form>
+  )
+}
+
+interface Props {
+  eventId: string
+}
+
+export function TicketTypeList({ eventId }: Props) {
+  const { t } = useTranslation()
+  const { data, isLoading } = useOrgTicketTypes(eventId)
+  const deleteTt = useDeleteTicketType(eventId)
+  const [editingId, setEditingId] = useState<string | null>(null)
+  const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null)
+  const [showAdd, setShowAdd] = useState(false)
+  const ticketTypes = data?.items ?? []
+
+  if (isLoading) {
+    return (
+      <div className="flex justify-center py-4">
+        <div className="border-primary h-6 w-6 animate-spin rounded-full border-2 border-t-transparent" />
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-3">
+      {ticketTypes.map((tt) =>
+        editingId === tt.id ? (
+          <EditRow
+            key={tt.id}
+            ttId={tt.id}
+            eventId={eventId}
+            defaultValues={{
+              name: tt.name,
+              description: tt.description ?? '',
+              capacity: tt.capacity,
+              price_cents: tt.price_cents,
+              position: tt.position,
+            }}
+            onClose={() => setEditingId(null)}
+          />
+        ) : (
+          <div key={tt.id} className="flex items-center justify-between rounded-md border p-3">
+            <div>
+              <p className="font-medium">{tt.name}</p>
+              <p className="text-muted-foreground text-xs">
+                {(tt.price_cents / 100).toFixed(2)} {tt.currency} · {tt.available}/{tt.capacity}{' '}
+                available
+              </p>
+            </div>
+            <div className="flex gap-1">
+              <Button
+                size="icon"
+                variant="ghost"
+                className="h-8 w-8"
+                onClick={() => setEditingId(tt.id)}
+              >
+                <Pencil className="h-3.5 w-3.5" />
+              </Button>
+              {confirmDeleteId === tt.id ? (
+                <>
+                  <Button
+                    size="sm"
+                    variant="destructive"
+                    className="h-8"
+                    onClick={() => {
+                      deleteTt.mutate(tt.id)
+                      setConfirmDeleteId(null)
+                    }}
+                    isLoading={deleteTt.isPending}
+                  >
+                    {t('common.save')}
+                  </Button>
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    className="h-8"
+                    onClick={() => setConfirmDeleteId(null)}
+                  >
+                    {t('common.cancel')}
+                  </Button>
+                </>
+              ) : (
+                <Button
+                  size="icon"
+                  variant="ghost"
+                  className="h-8 w-8"
+                  onClick={() => setConfirmDeleteId(tt.id)}
+                >
+                  <Trash2 className="h-3.5 w-3.5" />
+                </Button>
+              )}
+            </div>
+          </div>
+        ),
+      )}
+      {showAdd ? (
+        <AddForm eventId={eventId} onClose={() => setShowAdd(false)} />
+      ) : (
+        <Button size="sm" variant="outline" onClick={() => setShowAdd(true)}>
+          {t('organiser.ticketTypes.addButton')}
+        </Button>
+      )}
+    </div>
+  )
+}

--- a/apps/app/src/features/organiser/hooks/useCancelEvent.ts
+++ b/apps/app/src/features/organiser/hooks/useCancelEvent.ts
@@ -1,0 +1,29 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import type { AxiosError } from 'axios'
+import { useTranslation } from 'react-i18next'
+import { toast } from 'sonner'
+
+import { type ApiErrorDetail, extractErrorMessage } from '@/features/auth/api'
+
+import { organiserApi } from '../api'
+
+export function useCancelEvent(orgId: string, eventId: string) {
+  const { t } = useTranslation()
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: () => organiserApi.cancelEvent(eventId),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['org-events', orgId] })
+      void queryClient.invalidateQueries({ queryKey: ['event', eventId] })
+      toast.success(t('organiser.events.cancelSuccess'))
+    },
+    onError: (error: AxiosError<{ detail?: ApiErrorDetail }>) => {
+      const message = extractErrorMessage(
+        error.response?.data?.detail,
+        t('organiser.errors.cancelFailed'),
+      )
+      toast.error(message)
+    },
+  })
+}

--- a/apps/app/src/features/organiser/hooks/useCreateEvent.ts
+++ b/apps/app/src/features/organiser/hooks/useCreateEvent.ts
@@ -1,0 +1,29 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import type { AxiosError } from 'axios'
+import { useTranslation } from 'react-i18next'
+import { toast } from 'sonner'
+
+import { type ApiErrorDetail, extractErrorMessage } from '@/features/auth/api'
+
+import { type CreateEventData, organiserApi, type OrgEvent } from '../api'
+
+export function useCreateEvent(orgId: string, onSuccess?: (event: OrgEvent) => void) {
+  const { t } = useTranslation()
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: (data: CreateEventData) => organiserApi.createEvent(orgId, data),
+    onSuccess: (event) => {
+      void queryClient.invalidateQueries({ queryKey: ['org-events', orgId] })
+      toast.success(t('organiser.events.createSuccess'))
+      onSuccess?.(event)
+    },
+    onError: (error: AxiosError<{ detail?: ApiErrorDetail }>) => {
+      const message = extractErrorMessage(
+        error.response?.data?.detail,
+        t('organiser.errors.createEventFailed'),
+      )
+      toast.error(message)
+    },
+  })
+}

--- a/apps/app/src/features/organiser/hooks/useCreateOrganisation.ts
+++ b/apps/app/src/features/organiser/hooks/useCreateOrganisation.ts
@@ -1,0 +1,30 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import type { AxiosError } from 'axios'
+import { useTranslation } from 'react-i18next'
+import { toast } from 'sonner'
+
+import { type ApiErrorDetail, extractErrorMessage } from '@/features/auth/api'
+
+import { type Organisation, organiserApi } from '../api'
+
+export function useCreateOrganisation(onSuccess?: (org: Organisation) => void) {
+  const { t } = useTranslation()
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: (data: { slug: string; name: string; description?: string }) =>
+      organiserApi.createOrg(data),
+    onSuccess: (org) => {
+      void queryClient.invalidateQueries({ queryKey: ['organisations'] })
+      toast.success(t('organiser.org.createSuccess'))
+      onSuccess?.(org)
+    },
+    onError: (error: AxiosError<{ detail?: ApiErrorDetail }>) => {
+      const message = extractErrorMessage(
+        error.response?.data?.detail,
+        t('organiser.errors.createOrgFailed'),
+      )
+      toast.error(message)
+    },
+  })
+}

--- a/apps/app/src/features/organiser/hooks/useCreateTicketType.ts
+++ b/apps/app/src/features/organiser/hooks/useCreateTicketType.ts
@@ -1,0 +1,28 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import type { AxiosError } from 'axios'
+import { useTranslation } from 'react-i18next'
+import { toast } from 'sonner'
+
+import { type ApiErrorDetail, extractErrorMessage } from '@/features/auth/api'
+
+import { type CreateTicketTypeData, organiserApi } from '../api'
+
+export function useCreateTicketType(eventId: string) {
+  const { t } = useTranslation()
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: (data: CreateTicketTypeData) => organiserApi.createTicketType(eventId, data),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['ticket-types', eventId] })
+      toast.success(t('organiser.ticketTypes.createSuccess'))
+    },
+    onError: (error: AxiosError<{ detail?: ApiErrorDetail }>) => {
+      const message = extractErrorMessage(
+        error.response?.data?.detail,
+        t('organiser.errors.createTicketTypeFailed'),
+      )
+      toast.error(message)
+    },
+  })
+}

--- a/apps/app/src/features/organiser/hooks/useCreateVenue.ts
+++ b/apps/app/src/features/organiser/hooks/useCreateVenue.ts
@@ -1,0 +1,29 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import type { AxiosError } from 'axios'
+import { useTranslation } from 'react-i18next'
+import { toast } from 'sonner'
+
+import { type ApiErrorDetail, extractErrorMessage } from '@/features/auth/api'
+
+import { type CreateVenueData, organiserApi, type Venue } from '../api'
+
+export function useCreateVenue(onSuccess?: (venue: Venue) => void) {
+  const { t } = useTranslation()
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: (data: CreateVenueData) => organiserApi.createVenue(data),
+    onSuccess: (venue) => {
+      void queryClient.invalidateQueries({ queryKey: ['venues'] })
+      toast.success(t('organiser.venues.createSuccess'))
+      onSuccess?.(venue)
+    },
+    onError: (error: AxiosError<{ detail?: ApiErrorDetail }>) => {
+      const message = extractErrorMessage(
+        error.response?.data?.detail,
+        t('organiser.errors.createVenueFailed'),
+      )
+      toast.error(message)
+    },
+  })
+}

--- a/apps/app/src/features/organiser/hooks/useDeleteTicketType.ts
+++ b/apps/app/src/features/organiser/hooks/useDeleteTicketType.ts
@@ -1,0 +1,28 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import type { AxiosError } from 'axios'
+import { useTranslation } from 'react-i18next'
+import { toast } from 'sonner'
+
+import { type ApiErrorDetail, extractErrorMessage } from '@/features/auth/api'
+
+import { organiserApi } from '../api'
+
+export function useDeleteTicketType(eventId: string) {
+  const { t } = useTranslation()
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: (ttId: string) => organiserApi.deleteTicketType(eventId, ttId),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['ticket-types', eventId] })
+      toast.success(t('organiser.ticketTypes.deleteSuccess'))
+    },
+    onError: (error: AxiosError<{ detail?: ApiErrorDetail }>) => {
+      const message = extractErrorMessage(
+        error.response?.data?.detail,
+        t('organiser.errors.deleteTicketTypeFailed'),
+      )
+      toast.error(message)
+    },
+  })
+}

--- a/apps/app/src/features/organiser/hooks/useInviteMember.ts
+++ b/apps/app/src/features/organiser/hooks/useInviteMember.ts
@@ -1,0 +1,27 @@
+import { useMutation } from '@tanstack/react-query'
+import type { AxiosError } from 'axios'
+import { useTranslation } from 'react-i18next'
+import { toast } from 'sonner'
+
+import { type ApiErrorDetail, extractErrorMessage } from '@/features/auth/api'
+
+import { organiserApi } from '../api'
+
+export function useInviteMember(orgId: string) {
+  const { t } = useTranslation()
+
+  return useMutation({
+    mutationFn: (data: { email: string; role: 'member' | 'manager' | 'owner' }) =>
+      organiserApi.inviteMember(orgId, data),
+    onSuccess: () => {
+      toast.success(t('organiser.members.inviteSuccess'))
+    },
+    onError: (error: AxiosError<{ detail?: ApiErrorDetail }>) => {
+      const message = extractErrorMessage(
+        error.response?.data?.detail,
+        t('organiser.errors.inviteFailed'),
+      )
+      toast.error(message)
+    },
+  })
+}

--- a/apps/app/src/features/organiser/hooks/useMyOrganisations.ts
+++ b/apps/app/src/features/organiser/hooks/useMyOrganisations.ts
@@ -1,0 +1,10 @@
+import { useQuery } from '@tanstack/react-query'
+
+import { organiserApi } from '../api'
+
+export function useMyOrganisations() {
+  return useQuery({
+    queryKey: ['organisations'],
+    queryFn: organiserApi.listMyOrgs,
+  })
+}

--- a/apps/app/src/features/organiser/hooks/useOrgEvents.ts
+++ b/apps/app/src/features/organiser/hooks/useOrgEvents.ts
@@ -1,0 +1,11 @@
+import { useQuery } from '@tanstack/react-query'
+
+import { organiserApi } from '../api'
+
+export function useOrgEvents(orgId: string) {
+  return useQuery({
+    queryKey: ['org-events', orgId],
+    queryFn: () => organiserApi.listOrgEvents(orgId),
+    enabled: !!orgId,
+  })
+}

--- a/apps/app/src/features/organiser/hooks/useOrgTicketTypes.ts
+++ b/apps/app/src/features/organiser/hooks/useOrgTicketTypes.ts
@@ -1,0 +1,11 @@
+import { useQuery } from '@tanstack/react-query'
+
+import { organiserApi } from '../api'
+
+export function useOrgTicketTypes(eventId: string) {
+  return useQuery({
+    queryKey: ['ticket-types', eventId],
+    queryFn: () => organiserApi.listTicketTypes(eventId),
+    enabled: !!eventId,
+  })
+}

--- a/apps/app/src/features/organiser/hooks/usePublishEvent.ts
+++ b/apps/app/src/features/organiser/hooks/usePublishEvent.ts
@@ -1,0 +1,29 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import type { AxiosError } from 'axios'
+import { useTranslation } from 'react-i18next'
+import { toast } from 'sonner'
+
+import { type ApiErrorDetail, extractErrorMessage } from '@/features/auth/api'
+
+import { organiserApi } from '../api'
+
+export function usePublishEvent(orgId: string, eventId: string) {
+  const { t } = useTranslation()
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: () => organiserApi.publishEvent(eventId),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['org-events', orgId] })
+      void queryClient.invalidateQueries({ queryKey: ['event', eventId] })
+      toast.success(t('organiser.events.publishSuccess'))
+    },
+    onError: (error: AxiosError<{ detail?: ApiErrorDetail }>) => {
+      const message = extractErrorMessage(
+        error.response?.data?.detail,
+        t('organiser.errors.publishFailed'),
+      )
+      toast.error(message)
+    },
+  })
+}

--- a/apps/app/src/features/organiser/hooks/useUpdateEvent.ts
+++ b/apps/app/src/features/organiser/hooks/useUpdateEvent.ts
@@ -1,0 +1,29 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import type { AxiosError } from 'axios'
+import { useTranslation } from 'react-i18next'
+import { toast } from 'sonner'
+
+import { type ApiErrorDetail, extractErrorMessage } from '@/features/auth/api'
+
+import { organiserApi, type UpdateEventData } from '../api'
+
+export function useUpdateEvent(orgId: string, eventId: string) {
+  const { t } = useTranslation()
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: (data: UpdateEventData) => organiserApi.updateEvent(eventId, data),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['org-events', orgId] })
+      void queryClient.invalidateQueries({ queryKey: ['event', eventId] })
+      toast.success(t('organiser.events.updateSuccess'))
+    },
+    onError: (error: AxiosError<{ detail?: ApiErrorDetail }>) => {
+      const message = extractErrorMessage(
+        error.response?.data?.detail,
+        t('organiser.errors.updateEventFailed'),
+      )
+      toast.error(message)
+    },
+  })
+}

--- a/apps/app/src/features/organiser/hooks/useUpdateTicketType.ts
+++ b/apps/app/src/features/organiser/hooks/useUpdateTicketType.ts
@@ -1,0 +1,29 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import type { AxiosError } from 'axios'
+import { useTranslation } from 'react-i18next'
+import { toast } from 'sonner'
+
+import { type ApiErrorDetail, extractErrorMessage } from '@/features/auth/api'
+
+import { organiserApi, type UpdateTicketTypeData } from '../api'
+
+export function useUpdateTicketType(eventId: string) {
+  const { t } = useTranslation()
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: ({ ttId, data }: { ttId: string; data: UpdateTicketTypeData }) =>
+      organiserApi.updateTicketType(eventId, ttId, data),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['ticket-types', eventId] })
+      toast.success(t('organiser.ticketTypes.updateSuccess'))
+    },
+    onError: (error: AxiosError<{ detail?: ApiErrorDetail }>) => {
+      const message = extractErrorMessage(
+        error.response?.data?.detail,
+        t('organiser.errors.updateTicketTypeFailed'),
+      )
+      toast.error(message)
+    },
+  })
+}

--- a/apps/app/src/features/organiser/hooks/useVenues.ts
+++ b/apps/app/src/features/organiser/hooks/useVenues.ts
@@ -1,0 +1,10 @@
+import { useQuery } from '@tanstack/react-query'
+
+import { organiserApi } from '../api'
+
+export function useVenues() {
+  return useQuery({
+    queryKey: ['venues'],
+    queryFn: organiserApi.listVenues,
+  })
+}

--- a/apps/app/src/i18n/locales/en.json
+++ b/apps/app/src/i18n/locales/en.json
@@ -149,6 +149,84 @@
       "renameFailed": "Failed to rename passkey."
     }
   },
+  "organiser": {
+    "title": "My Organisations",
+    "backToOrgs": "Back to organisations",
+    "backToOrg": "Back to organisation",
+    "org": {
+      "create": "New organisation",
+      "createTitle": "Create organisation",
+      "createSuccess": "Organisation created.",
+      "empty": "You have no organisations yet.",
+      "loading": "Loading…",
+      "slugLabel": "Slug",
+      "slugPlaceholder": "my-org",
+      "nameLabel": "Name",
+      "descriptionLabel": "Description (optional)"
+    },
+    "events": {
+      "title": "Events",
+      "create": "Create event",
+      "createSuccess": "Event created.",
+      "updateSuccess": "Event updated.",
+      "publishSuccess": "Event published.",
+      "cancelSuccess": "Event cancelled.",
+      "empty": "No events yet.",
+      "edit": "Edit event",
+      "publish": "Publish",
+      "cancel": "Cancel event",
+      "confirmPublish": "Confirm publish",
+      "confirmCancel": "Confirm cancellation",
+      "nameLabel": "Name",
+      "descriptionLabel": "Description",
+      "venueLabel": "Venue",
+      "venueEmpty": "No venues available — create one first",
+      "startsAtLabel": "Starts at",
+      "endsAtLabel": "Ends at",
+      "saleStartsAtLabel": "Sale starts at",
+      "saleEndsAtLabel": "Sale ends at",
+      "maxTicketsLabel": "Max tickets per person",
+      "saleEndBeforeStart": "Sale must end before event starts"
+    },
+    "ticketTypes": {
+      "title": "Ticket types",
+      "createSuccess": "Ticket type created.",
+      "updateSuccess": "Ticket type updated.",
+      "deleteSuccess": "Ticket type deleted.",
+      "addButton": "Add ticket type",
+      "nameLabel": "Name",
+      "capacityLabel": "Capacity",
+      "priceLabel": "Price (cents)",
+      "currencyLabel": "Currency (3-char ISO)",
+      "positionLabel": "Position"
+    },
+    "members": {
+      "title": "Members",
+      "inviteSuccess": "Invitation sent.",
+      "removeSuccess": "Member removed.",
+      "emailLabel": "Email",
+      "roleLabel": "Role",
+      "inviteButton": "Invite"
+    },
+    "venues": {
+      "createSuccess": "Venue created.",
+      "createTitle": "Create venue",
+      "newVenue": "New venue"
+    },
+    "errors": {
+      "createOrgFailed": "Failed to create organisation.",
+      "createEventFailed": "Failed to create event.",
+      "updateEventFailed": "Failed to update event.",
+      "publishFailed": "Failed to publish event.",
+      "cancelFailed": "Failed to cancel event.",
+      "createTicketTypeFailed": "Failed to create ticket type.",
+      "updateTicketTypeFailed": "Failed to update ticket type.",
+      "deleteTicketTypeFailed": "Failed to delete ticket type.",
+      "inviteFailed": "Failed to invite member.",
+      "removeFailed": "Failed to remove member.",
+      "createVenueFailed": "Failed to create venue."
+    }
+  },
   "onboarding": {
     "title": "Set up your account",
     "subtitle": "Complete these steps to get started",

--- a/apps/app/src/lib/catalogApi.ts
+++ b/apps/app/src/lib/catalogApi.ts
@@ -1,9 +1,19 @@
 import axios from 'axios'
 
 import { env } from '@/config/env'
+import { useAuthStore } from '@/store/auth'
 
 export const catalogClient = axios.create({
   baseURL: env.CATALOG_URL,
   timeout: 10_000,
   headers: { 'Content-Type': 'application/json' },
+})
+
+catalogClient.interceptors.request.use((config) => {
+  const token = useAuthStore.getState().accessToken
+  if (token) config.headers.Authorization = `Bearer ${token}`
+  if (config.method === 'post' || config.method === 'patch') {
+    config.headers['Idempotency-Key'] = crypto.randomUUID()
+  }
+  return config
 })

--- a/apps/app/src/routeTree.gen.ts
+++ b/apps/app/src/routeTree.gen.ts
@@ -18,9 +18,14 @@ import { Route as AuthRegisterRouteImport } from './routes/_auth/register'
 import { Route as AuthLoginRouteImport } from './routes/_auth/login'
 import { Route as AppTicketsIndexRouteImport } from './routes/_app/tickets/index'
 import { Route as AppProfileIndexRouteImport } from './routes/_app/profile/index'
+import { Route as AppOrganiserIndexRouteImport } from './routes/_app/organiser/index'
 import { Route as AppEventsIndexRouteImport } from './routes/_app/events/index'
 import { Route as AppProfilePasskeysRouteImport } from './routes/_app/profile/passkeys'
 import { Route as AppEventsEventIdRouteImport } from './routes/_app/events/$eventId'
+import { Route as AppOrganiserOrgIdIndexRouteImport } from './routes/_app/organiser/$orgId/index'
+import { Route as AppOrganiserOrgIdVenuesNewRouteImport } from './routes/_app/organiser/$orgId/venues/new'
+import { Route as AppOrganiserOrgIdEventsNewRouteImport } from './routes/_app/organiser/$orgId/events/new'
+import { Route as AppOrganiserOrgIdEventsEventIdIndexRouteImport } from './routes/_app/organiser/$orgId/events/$eventId/index'
 
 const ConfirmEmailChangeRoute = ConfirmEmailChangeRouteImport.update({
   id: '/confirm-email-change',
@@ -65,6 +70,11 @@ const AppProfileIndexRoute = AppProfileIndexRouteImport.update({
   path: '/profile/',
   getParentRoute: () => AppRoute,
 } as any)
+const AppOrganiserIndexRoute = AppOrganiserIndexRouteImport.update({
+  id: '/organiser/',
+  path: '/organiser/',
+  getParentRoute: () => AppRoute,
+} as any)
 const AppEventsIndexRoute = AppEventsIndexRouteImport.update({
   id: '/events/',
   path: '/events/',
@@ -80,6 +90,29 @@ const AppEventsEventIdRoute = AppEventsEventIdRouteImport.update({
   path: '/events/$eventId',
   getParentRoute: () => AppRoute,
 } as any)
+const AppOrganiserOrgIdIndexRoute = AppOrganiserOrgIdIndexRouteImport.update({
+  id: '/organiser/$orgId/',
+  path: '/organiser/$orgId/',
+  getParentRoute: () => AppRoute,
+} as any)
+const AppOrganiserOrgIdVenuesNewRoute =
+  AppOrganiserOrgIdVenuesNewRouteImport.update({
+    id: '/organiser/$orgId/venues/new',
+    path: '/organiser/$orgId/venues/new',
+    getParentRoute: () => AppRoute,
+  } as any)
+const AppOrganiserOrgIdEventsNewRoute =
+  AppOrganiserOrgIdEventsNewRouteImport.update({
+    id: '/organiser/$orgId/events/new',
+    path: '/organiser/$orgId/events/new',
+    getParentRoute: () => AppRoute,
+  } as any)
+const AppOrganiserOrgIdEventsEventIdIndexRoute =
+  AppOrganiserOrgIdEventsEventIdIndexRouteImport.update({
+    id: '/organiser/$orgId/events/$eventId/',
+    path: '/organiser/$orgId/events/$eventId/',
+    getParentRoute: () => AppRoute,
+  } as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
@@ -90,8 +123,13 @@ export interface FileRoutesByFullPath {
   '/events/$eventId': typeof AppEventsEventIdRoute
   '/profile/passkeys': typeof AppProfilePasskeysRoute
   '/events/': typeof AppEventsIndexRoute
+  '/organiser/': typeof AppOrganiserIndexRoute
   '/profile/': typeof AppProfileIndexRoute
   '/tickets/': typeof AppTicketsIndexRoute
+  '/organiser/$orgId/': typeof AppOrganiserOrgIdIndexRoute
+  '/organiser/$orgId/events/new': typeof AppOrganiserOrgIdEventsNewRoute
+  '/organiser/$orgId/venues/new': typeof AppOrganiserOrgIdVenuesNewRoute
+  '/organiser/$orgId/events/$eventId/': typeof AppOrganiserOrgIdEventsEventIdIndexRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
@@ -102,8 +140,13 @@ export interface FileRoutesByTo {
   '/events/$eventId': typeof AppEventsEventIdRoute
   '/profile/passkeys': typeof AppProfilePasskeysRoute
   '/events': typeof AppEventsIndexRoute
+  '/organiser': typeof AppOrganiserIndexRoute
   '/profile': typeof AppProfileIndexRoute
   '/tickets': typeof AppTicketsIndexRoute
+  '/organiser/$orgId': typeof AppOrganiserOrgIdIndexRoute
+  '/organiser/$orgId/events/new': typeof AppOrganiserOrgIdEventsNewRoute
+  '/organiser/$orgId/venues/new': typeof AppOrganiserOrgIdVenuesNewRoute
+  '/organiser/$orgId/events/$eventId': typeof AppOrganiserOrgIdEventsEventIdIndexRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
@@ -117,8 +160,13 @@ export interface FileRoutesById {
   '/_app/events/$eventId': typeof AppEventsEventIdRoute
   '/_app/profile/passkeys': typeof AppProfilePasskeysRoute
   '/_app/events/': typeof AppEventsIndexRoute
+  '/_app/organiser/': typeof AppOrganiserIndexRoute
   '/_app/profile/': typeof AppProfileIndexRoute
   '/_app/tickets/': typeof AppTicketsIndexRoute
+  '/_app/organiser/$orgId/': typeof AppOrganiserOrgIdIndexRoute
+  '/_app/organiser/$orgId/events/new': typeof AppOrganiserOrgIdEventsNewRoute
+  '/_app/organiser/$orgId/venues/new': typeof AppOrganiserOrgIdVenuesNewRoute
+  '/_app/organiser/$orgId/events/$eventId/': typeof AppOrganiserOrgIdEventsEventIdIndexRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
@@ -131,8 +179,13 @@ export interface FileRouteTypes {
     | '/events/$eventId'
     | '/profile/passkeys'
     | '/events/'
+    | '/organiser/'
     | '/profile/'
     | '/tickets/'
+    | '/organiser/$orgId/'
+    | '/organiser/$orgId/events/new'
+    | '/organiser/$orgId/venues/new'
+    | '/organiser/$orgId/events/$eventId/'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
@@ -143,8 +196,13 @@ export interface FileRouteTypes {
     | '/events/$eventId'
     | '/profile/passkeys'
     | '/events'
+    | '/organiser'
     | '/profile'
     | '/tickets'
+    | '/organiser/$orgId'
+    | '/organiser/$orgId/events/new'
+    | '/organiser/$orgId/venues/new'
+    | '/organiser/$orgId/events/$eventId'
   id:
     | '__root__'
     | '/'
@@ -157,8 +215,13 @@ export interface FileRouteTypes {
     | '/_app/events/$eventId'
     | '/_app/profile/passkeys'
     | '/_app/events/'
+    | '/_app/organiser/'
     | '/_app/profile/'
     | '/_app/tickets/'
+    | '/_app/organiser/$orgId/'
+    | '/_app/organiser/$orgId/events/new'
+    | '/_app/organiser/$orgId/venues/new'
+    | '/_app/organiser/$orgId/events/$eventId/'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -233,6 +296,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AppProfileIndexRouteImport
       parentRoute: typeof AppRoute
     }
+    '/_app/organiser/': {
+      id: '/_app/organiser/'
+      path: '/organiser'
+      fullPath: '/organiser/'
+      preLoaderRoute: typeof AppOrganiserIndexRouteImport
+      parentRoute: typeof AppRoute
+    }
     '/_app/events/': {
       id: '/_app/events/'
       path: '/events'
@@ -254,6 +324,34 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AppEventsEventIdRouteImport
       parentRoute: typeof AppRoute
     }
+    '/_app/organiser/$orgId/': {
+      id: '/_app/organiser/$orgId/'
+      path: '/organiser/$orgId'
+      fullPath: '/organiser/$orgId/'
+      preLoaderRoute: typeof AppOrganiserOrgIdIndexRouteImport
+      parentRoute: typeof AppRoute
+    }
+    '/_app/organiser/$orgId/venues/new': {
+      id: '/_app/organiser/$orgId/venues/new'
+      path: '/organiser/$orgId/venues/new'
+      fullPath: '/organiser/$orgId/venues/new'
+      preLoaderRoute: typeof AppOrganiserOrgIdVenuesNewRouteImport
+      parentRoute: typeof AppRoute
+    }
+    '/_app/organiser/$orgId/events/new': {
+      id: '/_app/organiser/$orgId/events/new'
+      path: '/organiser/$orgId/events/new'
+      fullPath: '/organiser/$orgId/events/new'
+      preLoaderRoute: typeof AppOrganiserOrgIdEventsNewRouteImport
+      parentRoute: typeof AppRoute
+    }
+    '/_app/organiser/$orgId/events/$eventId/': {
+      id: '/_app/organiser/$orgId/events/$eventId/'
+      path: '/organiser/$orgId/events/$eventId'
+      fullPath: '/organiser/$orgId/events/$eventId/'
+      preLoaderRoute: typeof AppOrganiserOrgIdEventsEventIdIndexRouteImport
+      parentRoute: typeof AppRoute
+    }
   }
 }
 
@@ -261,16 +359,27 @@ interface AppRouteChildren {
   AppEventsEventIdRoute: typeof AppEventsEventIdRoute
   AppProfilePasskeysRoute: typeof AppProfilePasskeysRoute
   AppEventsIndexRoute: typeof AppEventsIndexRoute
+  AppOrganiserIndexRoute: typeof AppOrganiserIndexRoute
   AppProfileIndexRoute: typeof AppProfileIndexRoute
   AppTicketsIndexRoute: typeof AppTicketsIndexRoute
+  AppOrganiserOrgIdIndexRoute: typeof AppOrganiserOrgIdIndexRoute
+  AppOrganiserOrgIdEventsNewRoute: typeof AppOrganiserOrgIdEventsNewRoute
+  AppOrganiserOrgIdVenuesNewRoute: typeof AppOrganiserOrgIdVenuesNewRoute
+  AppOrganiserOrgIdEventsEventIdIndexRoute: typeof AppOrganiserOrgIdEventsEventIdIndexRoute
 }
 
 const AppRouteChildren: AppRouteChildren = {
   AppEventsEventIdRoute: AppEventsEventIdRoute,
   AppProfilePasskeysRoute: AppProfilePasskeysRoute,
   AppEventsIndexRoute: AppEventsIndexRoute,
+  AppOrganiserIndexRoute: AppOrganiserIndexRoute,
   AppProfileIndexRoute: AppProfileIndexRoute,
   AppTicketsIndexRoute: AppTicketsIndexRoute,
+  AppOrganiserOrgIdIndexRoute: AppOrganiserOrgIdIndexRoute,
+  AppOrganiserOrgIdEventsNewRoute: AppOrganiserOrgIdEventsNewRoute,
+  AppOrganiserOrgIdVenuesNewRoute: AppOrganiserOrgIdVenuesNewRoute,
+  AppOrganiserOrgIdEventsEventIdIndexRoute:
+    AppOrganiserOrgIdEventsEventIdIndexRoute,
 }
 
 const AppRouteWithChildren = AppRoute._addFileChildren(AppRouteChildren)

--- a/apps/app/src/routes/_app/organiser/$orgId/events/$eventId/index.tsx
+++ b/apps/app/src/routes/_app/organiser/$orgId/events/$eventId/index.tsx
@@ -1,0 +1,65 @@
+import { createFileRoute, Link } from '@tanstack/react-router'
+import { ArrowLeft } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { EditEventForm } from '@/features/organiser/components/EditEventForm'
+import { EventActions } from '@/features/organiser/components/EventActions'
+import { TicketTypeList } from '@/features/organiser/components/TicketTypeList'
+import { useOrgEvents } from '@/features/organiser/hooks/useOrgEvents'
+
+export const Route = createFileRoute('/_app/organiser/$orgId/events/$eventId/')({
+  component: EventManagePage,
+})
+
+function EventManagePage() {
+  const { t } = useTranslation()
+  const { orgId, eventId } = Route.useParams()
+  const { data } = useOrgEvents(orgId)
+  const event = data?.items.find((e) => e.id === eventId)
+
+  if (!event) {
+    return (
+      <div className="mx-auto max-w-2xl p-6">
+        <div className="flex justify-center py-8">
+          <div className="border-primary h-8 w-8 animate-spin rounded-full border-2 border-t-transparent" />
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="mx-auto max-w-2xl space-y-6 p-6">
+      <Link
+        to="/organiser/$orgId"
+        params={{ orgId }}
+        className="text-muted-foreground hover:text-foreground flex items-center gap-1 text-sm"
+      >
+        <ArrowLeft className="h-4 w-4" />
+        {t('organiser.backToOrg')}
+      </Link>
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-semibold">{event.name}</h1>
+        <EventActions event={event} orgId={orgId} />
+      </div>
+      {event.status === 'draft' && (
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-lg">{t('organiser.events.edit')}</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <EditEventForm event={event} orgId={orgId} />
+          </CardContent>
+        </Card>
+      )}
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-lg">{t('organiser.ticketTypes.title')}</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <TicketTypeList eventId={eventId} />
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/apps/app/src/routes/_app/organiser/$orgId/events/new.tsx
+++ b/apps/app/src/routes/_app/organiser/$orgId/events/new.tsx
@@ -1,0 +1,45 @@
+import { createFileRoute, Link, useNavigate } from '@tanstack/react-router'
+import { ArrowLeft } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { CreateEventForm } from '@/features/organiser/components/CreateEventForm'
+
+export const Route = createFileRoute('/_app/organiser/$orgId/events/new')({
+  component: NewEventPage,
+})
+
+function NewEventPage() {
+  const { t } = useTranslation()
+  const { orgId } = Route.useParams()
+  const navigate = useNavigate()
+
+  return (
+    <div className="mx-auto max-w-2xl space-y-6 p-6">
+      <Link
+        to="/organiser/$orgId"
+        params={{ orgId }}
+        className="text-muted-foreground hover:text-foreground flex items-center gap-1 text-sm"
+      >
+        <ArrowLeft className="h-4 w-4" />
+        {t('organiser.backToOrg')}
+      </Link>
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-lg">{t('organiser.events.create')}</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <CreateEventForm
+            orgId={orgId}
+            onSuccess={(eventId) =>
+              void navigate({
+                to: '/organiser/$orgId/events/$eventId',
+                params: { orgId, eventId },
+              })
+            }
+          />
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/apps/app/src/routes/_app/organiser/$orgId/index.tsx
+++ b/apps/app/src/routes/_app/organiser/$orgId/index.tsx
@@ -1,0 +1,48 @@
+import { createFileRoute, Link } from '@tanstack/react-router'
+import { ArrowLeft } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { InviteMemberForm } from '@/features/organiser/components/InviteMemberForm'
+import { OrgEventList } from '@/features/organiser/components/OrgEventList'
+import { useMyOrganisations } from '@/features/organiser/hooks/useMyOrganisations'
+
+export const Route = createFileRoute('/_app/organiser/$orgId/')({
+  component: OrgDashboardPage,
+})
+
+function OrgDashboardPage() {
+  const { t } = useTranslation()
+  const { orgId } = Route.useParams()
+  const { data } = useMyOrganisations()
+  const org = data?.items.find((o) => o.id === orgId)
+
+  return (
+    <div className="mx-auto max-w-2xl space-y-6 p-6">
+      <Link
+        to="/organiser"
+        className="text-muted-foreground hover:text-foreground flex items-center gap-1 text-sm"
+      >
+        <ArrowLeft className="h-4 w-4" />
+        {t('organiser.backToOrgs')}
+      </Link>
+      <h1 className="text-2xl font-semibold">{org?.name ?? t('organiser.org.loading')}</h1>
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-lg">{t('organiser.events.title')}</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <OrgEventList orgId={orgId} />
+        </CardContent>
+      </Card>
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-lg">{t('organiser.members.title')}</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <InviteMemberForm orgId={orgId} />
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/apps/app/src/routes/_app/organiser/$orgId/venues/new.tsx
+++ b/apps/app/src/routes/_app/organiser/$orgId/venues/new.tsx
@@ -1,0 +1,39 @@
+import { createFileRoute, Link, useNavigate } from '@tanstack/react-router'
+import { ArrowLeft } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { CreateVenueForm } from '@/features/organiser/components/CreateVenueForm'
+
+export const Route = createFileRoute('/_app/organiser/$orgId/venues/new')({
+  component: NewVenuePage,
+})
+
+function NewVenuePage() {
+  const { t } = useTranslation()
+  const { orgId } = Route.useParams()
+  const navigate = useNavigate()
+
+  return (
+    <div className="mx-auto max-w-2xl space-y-6 p-6">
+      <Link
+        to="/organiser/$orgId"
+        params={{ orgId }}
+        className="text-muted-foreground hover:text-foreground flex items-center gap-1 text-sm"
+      >
+        <ArrowLeft className="h-4 w-4" />
+        {t('organiser.backToOrg')}
+      </Link>
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-lg">{t('organiser.venues.createTitle')}</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <CreateVenueForm
+            onSuccess={() => void navigate({ to: '/organiser/$orgId', params: { orgId } })}
+          />
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/apps/app/src/routes/_app/organiser/index.tsx
+++ b/apps/app/src/routes/_app/organiser/index.tsx
@@ -1,0 +1,62 @@
+import { createFileRoute, useNavigate } from '@tanstack/react-router'
+import { Plus } from 'lucide-react'
+import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
+
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { CreateOrganisationForm } from '@/features/organiser/components/CreateOrganisationForm'
+import { OrgCard } from '@/features/organiser/components/OrgCard'
+import { useMyOrganisations } from '@/features/organiser/hooks/useMyOrganisations'
+
+export const Route = createFileRoute('/_app/organiser/')({
+  component: OrganiserPage,
+})
+
+function OrganiserPage() {
+  const { t } = useTranslation()
+  const navigate = useNavigate()
+  const [showCreate, setShowCreate] = useState(false)
+  const { data, isLoading } = useMyOrganisations()
+  const orgs = data?.items ?? []
+
+  return (
+    <div className="mx-auto max-w-2xl space-y-6 p-6">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-semibold">{t('organiser.title')}</h1>
+        <Button onClick={() => setShowCreate((v) => !v)}>
+          <Plus className="mr-2 h-4 w-4" />
+          {t('organiser.org.create')}
+        </Button>
+      </div>
+      {showCreate && (
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-lg">{t('organiser.org.createTitle')}</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <CreateOrganisationForm
+              onSuccess={(id) => {
+                setShowCreate(false)
+                void navigate({ to: '/organiser/$orgId', params: { orgId: id } })
+              }}
+            />
+          </CardContent>
+        </Card>
+      )}
+      {isLoading && (
+        <div className="flex justify-center py-8">
+          <div className="border-primary h-8 w-8 animate-spin rounded-full border-2 border-t-transparent" />
+        </div>
+      )}
+      {!isLoading && orgs.length === 0 && !showCreate && (
+        <p className="text-muted-foreground py-8 text-center text-sm">{t('organiser.org.empty')}</p>
+      )}
+      <div className="grid gap-4">
+        {orgs.map((org) => (
+          <OrgCard key={org.id} org={org} />
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/apps/app/src/test/handlers/catalog.ts
+++ b/apps/app/src/test/handlers/catalog.ts
@@ -27,6 +27,246 @@ export const catalogHandlers = [
     }),
   ),
 
+  http.get(`${CATALOG_URL}/v1/organisations`, () =>
+    HttpResponse.json({
+      items: [
+        {
+          id: 'org-1',
+          slug: 'my-org',
+          name: 'My Org',
+          description: null,
+          created_at: '2026-01-01T00:00:00Z',
+        },
+      ],
+      next_cursor: null,
+    }),
+  ),
+
+  http.post(`${CATALOG_URL}/v1/organisations`, () =>
+    HttpResponse.json(
+      {
+        id: 'org-new',
+        slug: 'new-org',
+        name: 'New Org',
+        description: null,
+        created_at: '2026-07-07T00:00:00Z',
+      },
+      { status: 201 },
+    ),
+  ),
+
+  http.post(`${CATALOG_URL}/v1/organisations/:orgId/members`, () =>
+    HttpResponse.json(
+      {
+        organisation_id: 'org-1',
+        user_id: 'user-2',
+        role: 'member',
+        joined_at: '2026-07-07T00:00:00Z',
+      },
+      { status: 201 },
+    ),
+  ),
+
+  http.delete(
+    `${CATALOG_URL}/v1/organisations/:orgId/members/:userId`,
+    () => new HttpResponse(null, { status: 204 }),
+  ),
+
+  http.get(`${CATALOG_URL}/v1/organisations/:orgId/events`, () =>
+    HttpResponse.json({
+      items: [
+        {
+          id: 'event-1',
+          organisation_id: 'org-1',
+          venue_id: 'venue-1',
+          name: 'Summer Fest',
+          description: null,
+          starts_at: '2026-08-15T20:00:00Z',
+          ends_at: '2026-08-15T23:59:00Z',
+          sale_starts_at: '2026-07-01T00:00:00Z',
+          sale_ends_at: '2026-08-14T23:59:00Z',
+          max_tickets_per_user: 4,
+          status: 'draft',
+          organiser_name: 'My Org',
+          venue_city: 'Barcelona',
+          queue_required: false,
+          created_at: '2026-07-01T00:00:00Z',
+          published_at: null,
+          cancelled_at: null,
+        },
+      ],
+      next_cursor: null,
+    }),
+  ),
+
+  http.post(`${CATALOG_URL}/v1/organisations/:orgId/events`, () =>
+    HttpResponse.json(
+      {
+        id: 'event-new',
+        organisation_id: 'org-1',
+        venue_id: 'venue-1',
+        name: 'New Event',
+        description: null,
+        starts_at: '2026-09-01T20:00:00Z',
+        ends_at: '2026-09-01T23:00:00Z',
+        sale_starts_at: '2026-08-01T00:00:00Z',
+        sale_ends_at: '2026-08-31T23:59:00Z',
+        max_tickets_per_user: 4,
+        status: 'draft',
+        organiser_name: 'My Org',
+        venue_city: 'Barcelona',
+        queue_required: false,
+        created_at: '2026-07-07T00:00:00Z',
+        published_at: null,
+        cancelled_at: null,
+      },
+      { status: 201 },
+    ),
+  ),
+
+  http.patch(`${CATALOG_URL}/v1/events/:eventId`, () =>
+    HttpResponse.json({
+      id: 'event-1',
+      organisation_id: 'org-1',
+      venue_id: 'venue-1',
+      name: 'Updated Event',
+      description: null,
+      starts_at: '2026-08-15T20:00:00Z',
+      ends_at: '2026-08-15T23:59:00Z',
+      sale_starts_at: '2026-07-01T00:00:00Z',
+      sale_ends_at: '2026-08-14T23:59:00Z',
+      max_tickets_per_user: 4,
+      status: 'draft',
+      organiser_name: 'My Org',
+      venue_city: 'Barcelona',
+      queue_required: false,
+      created_at: '2026-07-01T00:00:00Z',
+      published_at: null,
+      cancelled_at: null,
+    }),
+  ),
+
+  http.post(`${CATALOG_URL}/v1/events/:eventId/publish`, () =>
+    HttpResponse.json({
+      id: 'event-1',
+      status: 'published',
+      published_at: '2026-07-07T00:00:00Z',
+      organisation_id: 'org-1',
+      venue_id: 'venue-1',
+      name: 'Summer Fest',
+      description: null,
+      starts_at: '2026-08-15T20:00:00Z',
+      ends_at: '2026-08-15T23:59:00Z',
+      sale_starts_at: '2026-07-01T00:00:00Z',
+      sale_ends_at: '2026-08-14T23:59:00Z',
+      max_tickets_per_user: 4,
+      organiser_name: 'My Org',
+      venue_city: 'Barcelona',
+      queue_required: false,
+      created_at: '2026-07-01T00:00:00Z',
+      cancelled_at: null,
+    }),
+  ),
+
+  http.post(`${CATALOG_URL}/v1/events/:eventId/cancel`, () =>
+    HttpResponse.json({
+      id: 'event-1',
+      status: 'cancelled',
+      cancelled_at: '2026-07-07T00:00:00Z',
+      organisation_id: 'org-1',
+      venue_id: 'venue-1',
+      name: 'Summer Fest',
+      description: null,
+      starts_at: '2026-08-15T20:00:00Z',
+      ends_at: '2026-08-15T23:59:00Z',
+      sale_starts_at: '2026-07-01T00:00:00Z',
+      sale_ends_at: '2026-08-14T23:59:00Z',
+      max_tickets_per_user: 4,
+      organiser_name: 'My Org',
+      venue_city: 'Barcelona',
+      queue_required: false,
+      created_at: '2026-07-01T00:00:00Z',
+      published_at: null,
+    }),
+  ),
+
+  http.get(`${CATALOG_URL}/v1/events/:eventId/ticket-types`, () =>
+    HttpResponse.json({
+      items: [
+        {
+          id: 'tt-1',
+          event_id: 'event-1',
+          name: 'General',
+          description: null,
+          capacity: 100,
+          reserved_count: 20,
+          available: 80,
+          price_cents: 1500,
+          currency: 'EUR',
+          position: 1,
+          created_at: '2026-07-01T00:00:00Z',
+        },
+      ],
+      next_cursor: null,
+    }),
+  ),
+
+  http.post(`${CATALOG_URL}/v1/events/:eventId/ticket-types`, () =>
+    HttpResponse.json(
+      {
+        id: 'tt-new',
+        event_id: 'event-1',
+        name: 'General',
+        description: null,
+        capacity: 100,
+        reserved_count: 0,
+        available: 100,
+        price_cents: 1500,
+        currency: 'EUR',
+        position: 1,
+        created_at: '2026-07-07T00:00:00Z',
+      },
+      { status: 201 },
+    ),
+  ),
+
+  http.patch(`${CATALOG_URL}/v1/events/:eventId/ticket-types/:ttId`, () =>
+    HttpResponse.json({
+      id: 'tt-1',
+      event_id: 'event-1',
+      name: 'General Updated',
+      description: null,
+      capacity: 200,
+      reserved_count: 0,
+      available: 200,
+      price_cents: 2000,
+      currency: 'EUR',
+      position: 1,
+      created_at: '2026-07-07T00:00:00Z',
+    }),
+  ),
+
+  http.delete(
+    `${CATALOG_URL}/v1/events/:eventId/ticket-types/:ttId`,
+    () => new HttpResponse(null, { status: 204 }),
+  ),
+
+  http.post(`${CATALOG_URL}/v1/venues`, () =>
+    HttpResponse.json(
+      {
+        id: 'venue-new',
+        name: 'New Venue',
+        city: 'Madrid',
+        country: 'ES',
+        latitude: 40.416,
+        longitude: -3.703,
+        geofence_radius_m: 200,
+        timezone: 'Europe/Madrid',
+      },
+      { status: 201 },
+    ),
+  ),
+
   http.get(`${CATALOG_URL}/v1/events/:eventId`, ({ params }) => {
     if (params.eventId === 'event-1') {
       return HttpResponse.json({


### PR DESCRIPTION
## Summary

- Implements the organiser dashboard at `/organiser`
- Org dashboard at `/organiser/:orgId`: event list, invite members
- Create/edit/publish/cancel events at `/organiser/:orgId/events/*`
- Manage ticket types (create/inline-edit/delete) per event
- Create venues at `/organiser/:orgId/venues/new`
- Adds auth interceptor + auto-Idempotency-Key (POST/PATCH) to `catalogClient`

## Verification
- `CreateOrganisationForm.test.tsx`
- `TicketTypeList.test.tsx`

## Issue Reference

Closes [QRW-251](https://github.com/cristiangilsanz/qrew/issues/251)

## Checklist
- [x] I confirm that this PR follows the project's established coding standards.