### PR TITLE
fix: organiser bug fixes found during manual testing

### DIFF
--- a/apps/api/services/catalog/migrations/versions/0001_2026_06_14_init_catalog_schema.py
+++ b/apps/api/services/catalog/migrations/versions/0001_2026_06_14_init_catalog_schema.py
@@ -18,6 +18,7 @@ depends_on: Union[str, Sequence[str], None] = None
 
 def upgrade() -> None:
     op.execute("CREATE SCHEMA IF NOT EXISTS catalog")
+    op.execute("CREATE TYPE organisation_role AS ENUM ('member', 'manager', 'owner')")
 
     op.execute("""
         CREATE TABLE IF NOT EXISTS catalog.organisations (
@@ -38,7 +39,7 @@ def upgrade() -> None:
         CREATE TABLE IF NOT EXISTS catalog.organisation_members (
             organisation_id UUID NOT NULL REFERENCES catalog.organisations(id) ON DELETE CASCADE,
             user_id UUID NOT NULL,
-            role VARCHAR(16) NOT NULL DEFAULT 'member',
+            role organisation_role NOT NULL DEFAULT 'member',
             joined_at TIMESTAMPTZ NOT NULL DEFAULT now(),
             PRIMARY KEY (organisation_id, user_id)
         )
@@ -136,4 +137,5 @@ def downgrade() -> None:
     op.execute("DROP TABLE IF EXISTS catalog.venues")
     op.execute("DROP TABLE IF EXISTS catalog.organisation_members")
     op.execute("DROP TABLE IF EXISTS catalog.organisations")
+    op.execute("DROP TYPE IF EXISTS organisation_role")
     op.execute("DROP SCHEMA IF EXISTS catalog CASCADE")

--- a/apps/app/src/features/organiser/components/CreateOrganisationForm.tsx
+++ b/apps/app/src/features/organiser/components/CreateOrganisationForm.tsx
@@ -20,9 +20,10 @@ import { useCreateOrganisation } from '../hooks/useCreateOrganisation'
 const schema = z.object({
   slug: z
     .string()
-    .min(3)
-    .max(64)
-    .regex(/^[a-z0-9-]+$/, 'Only lowercase letters, numbers, and hyphens'),
+    .regex(
+      /^[a-z][a-z0-9_-]{2,63}$/,
+      'Must start with a letter, 3–64 chars, lowercase letters/numbers/hyphens/underscores only',
+    ),
   name: z.string().min(1).max(128),
   description: z.string().optional(),
 })

--- a/apps/app/src/features/organiser/components/OrgEventList.tsx
+++ b/apps/app/src/features/organiser/components/OrgEventList.tsx
@@ -1,8 +1,6 @@
 import { Link } from '@tanstack/react-router'
 import { useTranslation } from 'react-i18next'
 
-import { Button } from '@/components/ui/button'
-
 import { useOrgEvents } from '../hooks/useOrgEvents'
 
 interface Props {
@@ -31,11 +29,13 @@ export function OrgEventList({ orgId }: Props) {
   return (
     <div className="space-y-3">
       <div className="flex justify-end">
-        <Button asChild size="sm">
-          <Link to="/organiser/$orgId/events/new" params={{ orgId }}>
-            {t('organiser.events.create')}
-          </Link>
-        </Button>
+        <Link
+          to="/organiser/$orgId/events/new"
+          params={{ orgId }}
+          className="bg-primary text-primary-foreground hover:bg-primary/90 inline-flex h-8 items-center rounded-md px-3 text-sm font-medium"
+        >
+          {t('organiser.events.create')}
+        </Link>
       </div>
       {events.length === 0 && (
         <p className="text-muted-foreground py-4 text-center text-sm">

--- a/apps/app/src/features/organiser/components/TicketTypeList.tsx
+++ b/apps/app/src/features/organiser/components/TicketTypeList.tsx
@@ -22,16 +22,26 @@ import { useOrgTicketTypes } from '../hooks/useOrgTicketTypes'
 import { useUpdateTicketType } from '../hooks/useUpdateTicketType'
 
 const createSchema = z.object({
-  name: z.string().min(1).max(32),
+  name: z
+    .string()
+    .min(1)
+    .max(32)
+    .transform((v) => v.toLowerCase())
+    .pipe(z.string().regex(/^[a-z][a-z0-9_]{0,31}$/, 'Must start with a letter, no spaces or special chars')),
   description: z.string().optional(),
   capacity: z.coerce.number().int().min(1).max(100000),
   price_cents: z.coerce.number().int().min(0).max(10000000),
-  currency: z.string().length(3),
+  currency: z.enum(['EUR', 'USD', 'GBP']),
   position: z.coerce.number().int().optional(),
 })
 
 const editSchema = z.object({
-  name: z.string().min(1).max(32),
+  name: z
+    .string()
+    .min(1)
+    .max(32)
+    .transform((v) => v.toLowerCase())
+    .pipe(z.string().regex(/^[a-z][a-z0-9_]{0,31}$/, 'Must start with a letter, no spaces or special chars')),
   description: z.string().optional(),
   capacity: z.coerce.number().int().min(1).max(100000),
   price_cents: z.coerce.number().int().min(0).max(10000000),
@@ -271,7 +281,7 @@ export function TicketTypeList({ eventId }: Props) {
         ) : (
           <div key={tt.id} className="flex items-center justify-between rounded-md border p-3">
             <div>
-              <p className="font-medium">{tt.name}</p>
+              <p className="font-medium capitalize">{tt.name}</p>
               <p className="text-muted-foreground text-xs">
                 {(tt.price_cents / 100).toFixed(2)} {tt.currency} · {tt.available}/{tt.capacity}{' '}
                 available


### PR DESCRIPTION
## Summary
Bug fixes found during manual testing of the organiser feature (#251):
- Catalog migration was creating `role` as `VARCHAR(16)` but the SQLAlchemy model expects a native PostgreSQL `organisation_role` enum — caused 500 on every org creation
- Org slug validation regex did not match backend pattern (must start with a letter, `^[a-z][a-z0-9_-]{2,63}$`)
- `OrgEventList` "New event" button used `Button asChild` + TanStack Router `Link` which crashes Radix Slot
- Ticket type name must match `^[a-z][a-z0-9_]{0,31}$` — added auto-lowercase transform and correct regex
- Ticket type currency restricted to `EUR`/`USD`/`GBP` (backend rejects others)
- Ticket type names now display capitalised in the list

## Verification
No new tests — all fixes are form validation and a migration correction verified manually.
- `CreateOrganisationForm.test.tsx` — existing tests still pass
- `TicketTypeList.test.tsx` — existing tests still pass

## Issue Reference

Part of [QRW-251](https://github.com/cristiangilsanz/qrew/issues/251)

## Checklist
- [ ] I confirm that this PR follows the project's established coding standards.